### PR TITLE
feat(domain): model deterministic cancellation rules

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -29,6 +29,8 @@ flowchart TB
 
 The core domain owns customers, contracts, termination terms, cancellation assessments, and cancellation requests. It is the authority for dates, penalties, validation, state changes, and invariants.
 
+The current deterministic rules are documented in [Contract cancellation rules](../domain/cancellation-rules.md).
+
 ### Knowledge
 
 The knowledge module owns document ingestion, versioning, chunking, embeddings, indexing, retrieval, and citations. It never decides whether a contract can be cancelled.

--- a/docs/domain/cancellation-rules.md
+++ b/docs/domain/cancellation-rules.md
@@ -1,0 +1,44 @@
+# Contract cancellation rules
+
+This document describes the deterministic cancellation rules implemented by the Contract Operations domain. These rules are authoritative application behavior; an AI assistant may explain their result but must not recalculate or override it.
+
+## Language
+
+- **Requested on** is the UTC business date on which a cancellation request is submitted.
+- **Earliest termination date** is the first termination date allowed by the notice period.
+- **Minimum commitment end date** is the first date on which early termination no longer has a penalty.
+- **Chargeable monthly period** is a monthly period that starts before the minimum commitment ends. A final partial period counts as one period.
+
+## Assessment rules
+
+Rules are evaluated in this order:
+
+1. The request date cannot be before the contract start date.
+2. A cancelled or expired contract cannot accept another cancellation request.
+3. For an active contract, the earliest termination date is the request date plus the notice period in calendar days.
+4. When the earliest termination date is on or after the minimum commitment end date, the penalty is zero.
+5. Otherwise, the penalty is the configured percentage of the monthly fee for every remaining chargeable monthly period.
+
+The calculation is:
+
+```text
+penalty = monthly fee × penalty rate × chargeable monthly periods
+```
+
+The final amount is rounded to two decimal places with `MidpointRounding.AwayFromZero`. Calculations use `decimal`; the application does not perform currency conversion.
+
+## Boundaries and examples
+
+- A notice period of zero makes the request date the earliest termination date.
+- A request whose earliest termination date equals the commitment end date has no penalty.
+- If only part of the final monthly period remains, that period is still chargeable.
+- Currency codes are normalized to three uppercase ASCII letters, such as `USD` or `BRL`. The MVP validates the format, not the complete ISO 4217 catalog.
+- Cancellation assessments based on current time use the UTC date supplied by `TimeProvider`, which keeps tests and demonstrations repeatable.
+
+The `DateOnly` assessment overload is intentionally pure and can reproduce a historical business date. Application operations that mean "today" must use the `TimeProvider` overload; this prevents the domain from reading the machine clock directly.
+
+For a monthly fee of `USD 100.00`, a penalty rate of `25%`, and two chargeable periods, the penalty is `USD 50.00`.
+
+## Explicitly outside this increment
+
+This first model does not cover business-day calendars, taxes, currency conversion, negotiated waivers, automatic renewals, prorated billing, or cancellation-request persistence. Those behaviors must be introduced only with explicit business rules and tests.

--- a/src/ContractIQ.Domain/Contracts/CancellationAssessment.cs
+++ b/src/ContractIQ.Domain/Contracts/CancellationAssessment.cs
@@ -1,0 +1,41 @@
+namespace ContractIQ.Domain.Contracts;
+
+public sealed record CancellationAssessment
+{
+    internal CancellationAssessment(
+        bool isAllowed,
+        CancellationAssessmentReason reason,
+        DateOnly requestedOn,
+        DateOnly earliestTerminationDate,
+        int chargeableMonthlyPeriods,
+        Money penalty)
+    {
+        IsAllowed = isAllowed;
+        Reason = reason;
+        RequestedOn = requestedOn;
+        EarliestTerminationDate = earliestTerminationDate;
+        ChargeableMonthlyPeriods = chargeableMonthlyPeriods;
+        Penalty = penalty;
+    }
+
+    public bool IsAllowed { get; }
+
+    public CancellationAssessmentReason Reason { get; }
+
+    public DateOnly RequestedOn { get; }
+
+    public DateOnly EarliestTerminationDate { get; }
+
+    public int ChargeableMonthlyPeriods { get; }
+
+    public Money Penalty { get; }
+
+    public bool HasPenalty => Penalty.Amount > 0m;
+}
+
+public enum CancellationAssessmentReason
+{
+    Allowed = 1,
+    ContractAlreadyCancelled = 2,
+    ContractExpired = 3,
+}

--- a/src/ContractIQ.Domain/Contracts/Contract.cs
+++ b/src/ContractIQ.Domain/Contracts/Contract.cs
@@ -1,0 +1,138 @@
+namespace ContractIQ.Domain.Contracts;
+
+public sealed class Contract
+{
+    public Contract(
+        Guid id,
+        Guid customerId,
+        DateOnly startDate,
+        Money monthlyFee,
+        TerminationTerms terminationTerms,
+        ContractStatus status = ContractStatus.Active)
+    {
+        if (id == Guid.Empty)
+        {
+            throw new ArgumentException("A contract identifier is required.", nameof(id));
+        }
+
+        if (customerId == Guid.Empty)
+        {
+            throw new ArgumentException("A customer identifier is required.", nameof(customerId));
+        }
+
+        ArgumentNullException.ThrowIfNull(monthlyFee);
+        ArgumentNullException.ThrowIfNull(terminationTerms);
+
+        if (monthlyFee.Amount < 0m)
+        {
+            throw new ArgumentOutOfRangeException(nameof(monthlyFee), "The monthly fee cannot be negative.");
+        }
+
+        if (terminationTerms.MinimumCommitmentEndDate < startDate)
+        {
+            throw new ArgumentException(
+                "The minimum commitment cannot end before the contract starts.",
+                nameof(terminationTerms));
+        }
+
+        if (!Enum.IsDefined(status))
+        {
+            throw new ArgumentOutOfRangeException(nameof(status));
+        }
+
+        Id = id;
+        CustomerId = customerId;
+        StartDate = startDate;
+        MonthlyFee = monthlyFee;
+        TerminationTerms = terminationTerms;
+        Status = status;
+    }
+
+    public Guid Id { get; }
+
+    public Guid CustomerId { get; }
+
+    public DateOnly StartDate { get; }
+
+    public Money MonthlyFee { get; }
+
+    public TerminationTerms TerminationTerms { get; }
+
+    public ContractStatus Status { get; }
+
+    public CancellationAssessment AssessCancellation(TimeProvider timeProvider)
+    {
+        ArgumentNullException.ThrowIfNull(timeProvider);
+
+        DateOnly requestedOn = DateOnly.FromDateTime(timeProvider.GetUtcNow().UtcDateTime);
+
+        return AssessCancellation(requestedOn);
+    }
+
+    public CancellationAssessment AssessCancellation(DateOnly requestedOn)
+    {
+        if (requestedOn < StartDate)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(requestedOn),
+                "A cancellation cannot be requested before the contract starts.");
+        }
+
+        DateOnly earliestTerminationDate = requestedOn.AddDays(TerminationTerms.NoticePeriodDays);
+
+        if (Status == ContractStatus.Cancelled)
+        {
+            return NotAllowed(
+                CancellationAssessmentReason.ContractAlreadyCancelled,
+                requestedOn,
+                earliestTerminationDate);
+        }
+
+        if (Status == ContractStatus.Expired)
+        {
+            return NotAllowed(
+                CancellationAssessmentReason.ContractExpired,
+                requestedOn,
+                earliestTerminationDate);
+        }
+
+        int chargeableMonthlyPeriods = CountChargeableMonthlyPeriods(earliestTerminationDate);
+        Money penalty = MonthlyFee.Multiply(
+            TerminationTerms.EarlyTerminationPenaltyRate * chargeableMonthlyPeriods);
+
+        return new CancellationAssessment(
+            isAllowed: true,
+            CancellationAssessmentReason.Allowed,
+            requestedOn,
+            earliestTerminationDate,
+            chargeableMonthlyPeriods,
+            penalty);
+    }
+
+    private CancellationAssessment NotAllowed(
+        CancellationAssessmentReason reason,
+        DateOnly requestedOn,
+        DateOnly earliestTerminationDate) =>
+        new(
+            isAllowed: false,
+            reason,
+            requestedOn,
+            earliestTerminationDate,
+            chargeableMonthlyPeriods: 0,
+            Money.Zero(MonthlyFee.Currency));
+
+    private int CountChargeableMonthlyPeriods(DateOnly earliestTerminationDate)
+    {
+        int periods = 0;
+        DateOnly periodStart = earliestTerminationDate;
+
+        // Every monthly period that starts before commitment ends is charged; a final partial period counts.
+        while (periodStart < TerminationTerms.MinimumCommitmentEndDate)
+        {
+            periods++;
+            periodStart = periodStart.AddMonths(1);
+        }
+
+        return periods;
+    }
+}

--- a/src/ContractIQ.Domain/Contracts/ContractStatus.cs
+++ b/src/ContractIQ.Domain/Contracts/ContractStatus.cs
@@ -1,0 +1,8 @@
+namespace ContractIQ.Domain.Contracts;
+
+public enum ContractStatus
+{
+    Active = 1,
+    Cancelled = 2,
+    Expired = 3,
+}

--- a/src/ContractIQ.Domain/Contracts/Money.cs
+++ b/src/ContractIQ.Domain/Contracts/Money.cs
@@ -1,0 +1,34 @@
+namespace ContractIQ.Domain.Contracts;
+
+public sealed record Money
+{
+    public const int DecimalPlaces = 2;
+
+    public Money(decimal amount, string currency)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(currency);
+
+        string normalizedCurrency = currency.Trim().ToUpperInvariant();
+
+        if (normalizedCurrency.Length != 3 || !normalizedCurrency.All(IsAsciiLetter))
+        {
+            throw new ArgumentException(
+                "Currency must contain exactly three ASCII letters, such as USD or BRL.",
+                nameof(currency));
+        }
+
+        Amount = decimal.Round(amount, DecimalPlaces, MidpointRounding.AwayFromZero);
+        Currency = normalizedCurrency;
+    }
+
+    public decimal Amount { get; }
+
+    public string Currency { get; }
+
+    public static Money Zero(string currency) => new(0m, currency);
+
+    public Money Multiply(decimal multiplier) => new(Amount * multiplier, Currency);
+
+    private static bool IsAsciiLetter(char character) =>
+        character is >= 'A' and <= 'Z';
+}

--- a/src/ContractIQ.Domain/Contracts/TerminationTerms.cs
+++ b/src/ContractIQ.Domain/Contracts/TerminationTerms.cs
@@ -1,0 +1,35 @@
+namespace ContractIQ.Domain.Contracts;
+
+public sealed record TerminationTerms
+{
+    public TerminationTerms(
+        int noticePeriodDays,
+        DateOnly minimumCommitmentEndDate,
+        decimal earlyTerminationPenaltyRate)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(noticePeriodDays);
+
+        if (earlyTerminationPenaltyRate is < 0m or > 1m)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(earlyTerminationPenaltyRate),
+                "The early termination penalty rate must be between zero and one.");
+        }
+
+        NoticePeriodDays = noticePeriodDays;
+        MinimumCommitmentEndDate = minimumCommitmentEndDate;
+        EarlyTerminationPenaltyRate = earlyTerminationPenaltyRate;
+    }
+
+    public int NoticePeriodDays { get; }
+
+    /// <summary>
+    /// The first date on which termination no longer incurs an early termination penalty.
+    /// </summary>
+    public DateOnly MinimumCommitmentEndDate { get; }
+
+    /// <summary>
+    /// A decimal rate where 0.25 represents twenty-five percent of each chargeable monthly fee.
+    /// </summary>
+    public decimal EarlyTerminationPenaltyRate { get; }
+}

--- a/tests/ContractIQ.Domain.Tests/Contracts/ContractCancellationScenarioTests.cs
+++ b/tests/ContractIQ.Domain.Tests/Contracts/ContractCancellationScenarioTests.cs
@@ -1,0 +1,60 @@
+using ContractIQ.Domain.Contracts;
+using Xunit;
+
+namespace ContractIQ.Domain.Tests.Contracts;
+
+/// <summary>
+/// Demonstrates the business flow with the same kind of question the assistant will answer later.
+/// The expected outcome still comes entirely from deterministic domain code.
+/// </summary>
+public sealed class ContractCancellationScenarioTests
+{
+    [Fact]
+    public void Acme_can_cancel_now_with_an_early_termination_penalty()
+    {
+        var contract = CreateAcmeContract();
+        var timeProvider = new FixedTimeProvider(
+            new DateTimeOffset(2026, 9, 1, 10, 0, 0, TimeSpan.Zero));
+
+        CancellationAssessment assessment = contract.AssessCancellation(timeProvider);
+
+        Assert.True(assessment.IsAllowed);
+        Assert.Equal(CancellationAssessmentReason.Allowed, assessment.Reason);
+        Assert.Equal(new DateOnly(2026, 9, 1), assessment.RequestedOn);
+        Assert.Equal(new DateOnly(2026, 10, 1), assessment.EarliestTerminationDate);
+        Assert.Equal(3, assessment.ChargeableMonthlyPeriods);
+        Assert.Equal(new Money(750m, "USD"), assessment.Penalty);
+    }
+
+    [Fact]
+    public void Acme_can_cancel_without_a_penalty_when_notice_reaches_commitment_end()
+    {
+        var contract = CreateAcmeContract();
+        var timeProvider = new FixedTimeProvider(
+            new DateTimeOffset(2026, 12, 1, 10, 0, 0, TimeSpan.Zero));
+
+        CancellationAssessment assessment = contract.AssessCancellation(timeProvider);
+
+        Assert.True(assessment.IsAllowed);
+        Assert.Equal(new DateOnly(2026, 12, 31), assessment.EarliestTerminationDate);
+        Assert.Equal(0, assessment.ChargeableMonthlyPeriods);
+        Assert.Equal(Money.Zero("USD"), assessment.Penalty);
+        Assert.False(assessment.HasPenalty);
+    }
+
+    private static Contract CreateAcmeContract() =>
+        new(
+            id: Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+            customerId: Guid.Parse("acacacac-acac-acac-acac-acacacacacac"),
+            startDate: new DateOnly(2026, 1, 1),
+            monthlyFee: new Money(1_000m, "USD"),
+            terminationTerms: new TerminationTerms(
+                noticePeriodDays: 30,
+                minimumCommitmentEndDate: new DateOnly(2026, 12, 31),
+                earlyTerminationPenaltyRate: 0.25m));
+
+    private sealed class FixedTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => utcNow;
+    }
+}

--- a/tests/ContractIQ.Domain.Tests/Contracts/ContractTests.cs
+++ b/tests/ContractIQ.Domain.Tests/Contracts/ContractTests.cs
@@ -1,0 +1,248 @@
+using ContractIQ.Domain.Contracts;
+using Xunit;
+
+namespace ContractIQ.Domain.Tests.Contracts;
+
+public sealed class ContractTests
+{
+    [Fact]
+    public void Constructor_rejects_empty_contract_identifier()
+    {
+        Assert.Throws<ArgumentException>(() => ContractBuilder.Default.WithId(Guid.Empty).Build());
+    }
+
+    [Fact]
+    public void Constructor_rejects_empty_customer_identifier()
+    {
+        Assert.Throws<ArgumentException>(
+            () => ContractBuilder.Default.WithCustomerId(Guid.Empty).Build());
+    }
+
+    [Fact]
+    public void Constructor_rejects_null_monthly_fee()
+    {
+        Assert.Throws<ArgumentNullException>(
+            () => ContractBuilder.Default.WithMonthlyFee(null!).Build());
+    }
+
+    [Fact]
+    public void Constructor_rejects_negative_monthly_fee()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => ContractBuilder.Default.WithMonthlyFee(new Money(-0.01m, "BRL")).Build());
+    }
+
+    [Fact]
+    public void Constructor_rejects_null_termination_terms()
+    {
+        Assert.Throws<ArgumentNullException>(
+            () => ContractBuilder.Default.WithTerminationTerms(null!).Build());
+    }
+
+    [Fact]
+    public void Constructor_rejects_commitment_ending_before_contract_start()
+    {
+        var terms = new TerminationTerms(30, new DateOnly(2025, 12, 31), 0.25m);
+
+        Assert.Throws<ArgumentException>(
+            () => ContractBuilder.Default.WithTerminationTerms(terms).Build());
+    }
+
+    [Fact]
+    public void Constructor_rejects_undefined_status()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => ContractBuilder.Default.WithStatus((ContractStatus)999).Build());
+    }
+
+    [Fact]
+    public void AssessCancellation_rejects_request_before_contract_start()
+    {
+        var contract = ContractBuilder.Default.Build();
+
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => contract.AssessCancellation(new DateOnly(2025, 12, 31)));
+    }
+
+    [Fact]
+    public void AssessCancellation_rejects_null_time_provider()
+    {
+        var contract = ContractBuilder.Default.Build();
+
+        Assert.Throws<ArgumentNullException>(() => contract.AssessCancellation(null!));
+    }
+
+    [Fact]
+    public void Active_contract_before_commitment_end_has_penalty_for_each_monthly_period()
+    {
+        var terms = new TerminationTerms(
+            noticePeriodDays: 0,
+            minimumCommitmentEndDate: new DateOnly(2026, 3, 1),
+            earlyTerminationPenaltyRate: 0.25m);
+        var contract = ContractBuilder.Default
+            .WithMonthlyFee(new Money(1_000m, "BRL"))
+            .WithTerminationTerms(terms)
+            .Build();
+
+        CancellationAssessment assessment = contract.AssessCancellation(new DateOnly(2026, 1, 1));
+
+        Assert.True(assessment.IsAllowed);
+        Assert.Equal(CancellationAssessmentReason.Allowed, assessment.Reason);
+        Assert.Equal(new DateOnly(2026, 1, 1), assessment.RequestedOn);
+        Assert.Equal(new DateOnly(2026, 1, 1), assessment.EarliestTerminationDate);
+        Assert.Equal(2, assessment.ChargeableMonthlyPeriods);
+        Assert.Equal(new Money(500m, "BRL"), assessment.Penalty);
+        Assert.True(assessment.HasPenalty);
+    }
+
+    [Fact]
+    public void Active_contract_at_exact_commitment_boundary_has_no_penalty()
+    {
+        var terms = new TerminationTerms(
+            noticePeriodDays: 30,
+            minimumCommitmentEndDate: new DateOnly(2026, 3, 31),
+            earlyTerminationPenaltyRate: 0.25m);
+        var contract = ContractBuilder.Default.WithTerminationTerms(terms).Build();
+
+        CancellationAssessment assessment = contract.AssessCancellation(new DateOnly(2026, 3, 1));
+
+        Assert.True(assessment.IsAllowed);
+        Assert.Equal(new DateOnly(2026, 3, 31), assessment.EarliestTerminationDate);
+        Assert.Equal(0, assessment.ChargeableMonthlyPeriods);
+        Assert.Equal(Money.Zero("BRL"), assessment.Penalty);
+        Assert.False(assessment.HasPenalty);
+    }
+
+    [Fact]
+    public void Partial_final_month_counts_as_a_full_chargeable_period()
+    {
+        var terms = new TerminationTerms(
+            noticePeriodDays: 0,
+            minimumCommitmentEndDate: new DateOnly(2026, 3, 1),
+            earlyTerminationPenaltyRate: 0.1m);
+        var contract = ContractBuilder.Default
+            .WithMonthlyFee(new Money(100m, "USD"))
+            .WithTerminationTerms(terms)
+            .Build();
+
+        CancellationAssessment assessment = contract.AssessCancellation(new DateOnly(2026, 1, 31));
+
+        Assert.Equal(2, assessment.ChargeableMonthlyPeriods);
+        Assert.Equal(new Money(20m, "USD"), assessment.Penalty);
+    }
+
+    [Fact]
+    public void Zero_penalty_rate_keeps_chargeable_periods_but_produces_no_penalty()
+    {
+        var terms = new TerminationTerms(
+            noticePeriodDays: 0,
+            minimumCommitmentEndDate: new DateOnly(2026, 3, 1),
+            earlyTerminationPenaltyRate: 0m);
+        var contract = ContractBuilder.Default.WithTerminationTerms(terms).Build();
+
+        CancellationAssessment assessment = contract.AssessCancellation(new DateOnly(2026, 1, 1));
+
+        Assert.Equal(new DateOnly(2026, 1, 1), assessment.EarliestTerminationDate);
+        Assert.Equal(2, assessment.ChargeableMonthlyPeriods);
+        Assert.Equal(Money.Zero("BRL"), assessment.Penalty);
+        Assert.False(assessment.HasPenalty);
+    }
+
+    [Theory]
+    [InlineData(ContractStatus.Cancelled, CancellationAssessmentReason.ContractAlreadyCancelled)]
+    [InlineData(ContractStatus.Expired, CancellationAssessmentReason.ContractExpired)]
+    public void Inactive_contract_is_not_allowed_and_has_no_penalty(
+        ContractStatus status,
+        CancellationAssessmentReason expectedReason)
+    {
+        var contract = ContractBuilder.Default.WithStatus(status).Build();
+
+        CancellationAssessment assessment = contract.AssessCancellation(new DateOnly(2026, 2, 1));
+
+        Assert.False(assessment.IsAllowed);
+        Assert.Equal(expectedReason, assessment.Reason);
+        Assert.Equal(0, assessment.ChargeableMonthlyPeriods);
+        Assert.Equal(Money.Zero("BRL"), assessment.Penalty);
+        Assert.False(assessment.HasPenalty);
+    }
+
+    [Fact]
+    public void Notice_period_crosses_month_boundary()
+    {
+        var terms = new TerminationTerms(1, new DateOnly(2027, 1, 1), 0.25m);
+        var contract = ContractBuilder.Default.WithTerminationTerms(terms).Build();
+
+        CancellationAssessment assessment = contract.AssessCancellation(new DateOnly(2026, 1, 31));
+
+        Assert.Equal(new DateOnly(2026, 2, 1), assessment.EarliestTerminationDate);
+    }
+
+    [Fact]
+    public void Notice_period_includes_leap_day()
+    {
+        var terms = new TerminationTerms(1, new DateOnly(2029, 1, 1), 0.25m);
+        var contract = ContractBuilder.Default.WithTerminationTerms(terms).Build();
+
+        CancellationAssessment assessment = contract.AssessCancellation(new DateOnly(2028, 2, 28));
+
+        Assert.Equal(new DateOnly(2028, 2, 29), assessment.EarliestTerminationDate);
+    }
+
+    [Fact]
+    public void TimeProvider_uses_UTC_date_even_when_local_date_is_previous_day()
+    {
+        var terms = new TerminationTerms(1, new DateOnly(2027, 1, 1), 0.25m);
+        var contract = ContractBuilder.Default.WithTerminationTerms(terms).Build();
+        var utcNow = new DateTimeOffset(2026, 3, 1, 0, 30, 0, TimeSpan.Zero);
+        var utcMinusEleven = TimeZoneInfo.CreateCustomTimeZone(
+            "UTC-11-test",
+            TimeSpan.FromHours(-11),
+            "UTC-11 test",
+            "UTC-11 test");
+        var timeProvider = new FrozenTimeProvider(utcNow, utcMinusEleven);
+
+        CancellationAssessment assessment = contract.AssessCancellation(timeProvider);
+
+        Assert.Equal(new DateOnly(2026, 3, 1), assessment.RequestedOn);
+        Assert.Equal(new DateOnly(2026, 3, 2), assessment.EarliestTerminationDate);
+    }
+
+    private sealed class FrozenTimeProvider(
+        DateTimeOffset utcNow,
+        TimeZoneInfo localTimeZone) : TimeProvider
+    {
+        public override TimeZoneInfo LocalTimeZone => localTimeZone;
+
+        public override DateTimeOffset GetUtcNow() => utcNow;
+    }
+
+    private sealed record ContractBuilder(
+        Guid Id,
+        Guid CustomerId,
+        DateOnly StartDate,
+        Money MonthlyFee,
+        TerminationTerms TerminationTerms,
+        ContractStatus Status)
+    {
+        public static ContractBuilder Default => new(
+            Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            Guid.Parse("22222222-2222-2222-2222-222222222222"),
+            new DateOnly(2026, 1, 1),
+            new Money(1_000m, "BRL"),
+            new TerminationTerms(30, new DateOnly(2026, 12, 31), 0.25m),
+            ContractStatus.Active);
+
+        public ContractBuilder WithId(Guid id) => this with { Id = id };
+
+        public ContractBuilder WithCustomerId(Guid customerId) => this with { CustomerId = customerId };
+
+        public ContractBuilder WithMonthlyFee(Money monthlyFee) => this with { MonthlyFee = monthlyFee };
+
+        public ContractBuilder WithTerminationTerms(TerminationTerms terminationTerms) =>
+            this with { TerminationTerms = terminationTerms };
+
+        public ContractBuilder WithStatus(ContractStatus status) => this with { Status = status };
+
+        public Contract Build() => new(Id, CustomerId, StartDate, MonthlyFee, TerminationTerms, Status);
+    }
+}

--- a/tests/ContractIQ.Domain.Tests/Contracts/MoneyTests.cs
+++ b/tests/ContractIQ.Domain.Tests/Contracts/MoneyTests.cs
@@ -1,0 +1,50 @@
+using ContractIQ.Domain.Contracts;
+using Xunit;
+
+namespace ContractIQ.Domain.Tests.Contracts;
+
+public sealed class MoneyTests
+{
+    [Fact]
+    public void Constructor_normalizes_currency()
+    {
+        var money = new Money(42m, " brl ");
+
+        Assert.Equal("BRL", money.Currency);
+        Assert.Equal(42m, money.Amount);
+    }
+
+    [Theory]
+    [InlineData(1.005, 1.01)]
+    [InlineData(-1.005, -1.01)]
+    public void Constructor_rounds_midpoints_away_from_zero(
+        decimal amount,
+        decimal expectedAmount)
+    {
+        var money = new Money(amount, "USD");
+
+        Assert.Equal(expectedAmount, money.Amount);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("US")]
+    [InlineData("USDD")]
+    [InlineData("US1")]
+    [InlineData("BR$")]
+    [InlineData("€UR")]
+    public void Constructor_rejects_invalid_currency(string? currency)
+    {
+        Assert.ThrowsAny<ArgumentException>(() => new Money(10m, currency!));
+    }
+
+    [Fact]
+    public void Multiply_preserves_currency_and_applies_money_rounding()
+    {
+        var result = new Money(10.05m, "brl").Multiply(0.1m);
+
+        Assert.Equal(new Money(1.01m, "BRL"), result);
+    }
+}

--- a/tests/ContractIQ.Domain.Tests/Contracts/TerminationTermsTests.cs
+++ b/tests/ContractIQ.Domain.Tests/Contracts/TerminationTermsTests.cs
@@ -1,0 +1,34 @@
+using ContractIQ.Domain.Contracts;
+using Xunit;
+
+namespace ContractIQ.Domain.Tests.Contracts;
+
+public sealed class TerminationTermsTests
+{
+    [Fact]
+    public void Constructor_accepts_zero_notice_and_boundary_rates()
+    {
+        var noPenalty = new TerminationTerms(0, new DateOnly(2026, 12, 31), 0m);
+        var fullPenalty = new TerminationTerms(0, new DateOnly(2026, 12, 31), 1m);
+
+        Assert.Equal(0, noPenalty.NoticePeriodDays);
+        Assert.Equal(0m, noPenalty.EarlyTerminationPenaltyRate);
+        Assert.Equal(1m, fullPenalty.EarlyTerminationPenaltyRate);
+    }
+
+    [Fact]
+    public void Constructor_rejects_negative_notice_period()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new TerminationTerms(-1, new DateOnly(2026, 12, 31), 0.25m));
+    }
+
+    [Theory]
+    [InlineData(-0.01)]
+    [InlineData(1.01)]
+    public void Constructor_rejects_penalty_rate_outside_zero_to_one(decimal rate)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new TerminationTerms(30, new DateOnly(2026, 12, 31), rate));
+    }
+}


### PR DESCRIPTION
## Summary

- model contract status, termination terms, money, and cancellation assessments in the Domain project
- calculate the earliest termination date from a calendar-day notice period
- calculate early termination penalties from the monthly fee, configured rate, and remaining monthly periods
- make currency normalization and two-decimal `AwayFromZero` rounding explicit
- support deterministic current-date assessments through `TimeProvider` using UTC
- document the business rules and their deliberate MVP boundaries
- demonstrate the ACME flow with narrative tests for cancellation with and without a penalty

## Domain authority

The result is deterministic domain behavior. AI, HTTP, persistence, and application orchestration are not referenced and cannot replace these rules.

The penalty formula is intentionally explicit:

`monthly fee × penalty rate × chargeable monthly periods`

A partial final monthly period counts as a full period. This keeps the fictional policy explainable without adding billing strategies or framework abstractions.

## Verification

- `dotnet format ContractIQ.slnx --verify-no-changes --no-restore`
- `dotnet build ContractIQ.slnx --configuration Release --no-restore -m:1` — 0 warnings, 0 errors
- `dotnet test ContractIQ.slnx --configuration Release --no-build -m:1` — 39 tests passed
- domain suite: 37 tests, including 36 new rule, boundary, and flow cases
- `git diff --check`

## Covered boundaries

- invalid identifiers, terms, status, and dates
- zero notice and zero penalty rate
- exact minimum-commitment boundary
- partial monthly periods
- cancelled and expired contracts
- month and leap-day transitions
- currency format and midpoint rounding
- frozen UTC time independent of local timezone
- ACME cancellation with a USD 750 penalty and at the zero-penalty boundary

Closes #3