### PR TITLE
feat: implement contract operation use cases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 10.0.302
+          dotnet-version: 10.0.400
 
       - name: Restore
         run: dotnet restore ContractIQ.slnx

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,10 @@
 
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.OpenApi" Version="2.12.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.4" />

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The application answers contract questions using structured business data, deter
 
 ## Project status
 
-The project is currently in the foundation stage. Delivery is tracked through GitHub Issues, milestones, short-lived branches, and linked pull requests.
+The foundation and first deterministic contract-cancellation vertical slice are implemented. Delivery is tracked through GitHub Issues, milestones, short-lived branches, and linked pull requests.
 
 ## Planned technology
 
@@ -28,6 +28,7 @@ Cancellation eligibility, dates, penalties, validation, authorization, idempoten
 ## Documentation
 
 - [Architecture overview](docs/architecture/overview.md)
+- [Contract operation API](docs/api/contract-operations.md)
 - [Delivery roadmap](docs/roadmap.md)
 - [Contributing](CONTRIBUTING.md)
 - [Architecture Decision Records](docs/adr)

--- a/docs/api/contract-operations.md
+++ b/docs/api/contract-operations.md
@@ -1,0 +1,52 @@
+# Contract operation API
+
+The first ContractIQ vertical slice exposes structured contract operations through a small CQRS application layer. It deliberately uses an in-memory adapter so that the business workflow can be demonstrated before PostgreSQL is introduced.
+
+## Run locally
+
+Start the API from the repository root:
+
+```powershell
+dotnet run --project src/ContractIQ.Api
+```
+
+The default HTTP address is `http://localhost:5186`. Open `src/ContractIQ.Api/ContractIQ.Api.http` in Visual Studio and run the requests from top to bottom for a complete ACME cancellation scenario.
+
+The in-memory state lasts for the lifetime of the API process. Restarting the API restores the original fictional data and clears cancellation requests.
+
+## Available operations
+
+| Method | Route | Purpose |
+| --- | --- | --- |
+| `GET` | `/api/v1/customers` | List the fictional customers. |
+| `GET` | `/api/v1/contracts/{contractId}` | Read structured contract details. |
+| `GET` | `/api/v1/contracts/{contractId}/cancellation-assessment` | Calculate eligibility, termination date, and penalty using domain rules. |
+| `POST` | `/api/v1/contracts/{contractId}/cancellation-requests` | Recalculate the assessment and create a `PendingReview` request. |
+
+The OpenAPI document is available at `/openapi/v1.json` in the Development environment. Errors use RFC Problem Details and include a stable application error code and trace identifier without exposing exception details.
+
+## Demo records
+
+| Company | Customer ID | Contract ID | Scenario |
+| --- | --- | --- | --- |
+| ACME Corporation | `11111111-1111-4111-8111-111111111111` | `aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa` | Active contract within its minimum commitment; a penalty applies. |
+| Globex Corporation | `22222222-2222-4222-8222-222222222222` | `bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb` | Active contract after its minimum commitment; no penalty applies. |
+| Initech | `33333333-3333-4333-8333-333333333333` | `cccccccc-cccc-4ccc-8ccc-cccccccccccc` | Cancelled contract; creation is rejected. |
+| Initech | `33333333-3333-4333-8333-333333333333` | `dddddddd-dddd-4ddd-8ddd-dddddddddddd` | Expired contract; creation is rejected. |
+
+## Idempotent command behavior
+
+Creating a cancellation request requires an `Idempotency-Key` header. The key is an opaque, non-empty value of at most 128 characters.
+
+- The first valid call creates a request and returns `201 Created`.
+- Repeating the same key for the same contract returns the original request with `200 OK`.
+- Reusing the key for another contract returns `409 Conflict`.
+- A different key cannot create a second open request for the same contract and returns `409 Conflict`.
+
+The client supplies only the contract identifier and idempotency key. Dates, status, eligibility, and penalty are recalculated by deterministic .NET domain logic immediately before the state change; none of those business values are accepted from the caller or an AI model.
+
+## Architecture boundary
+
+The endpoint calls a focused command or query handler. Application ports hide persistence, while the domain owns cancellation calculations and invariants. The current in-memory implementation is an infrastructure adapter and will be replaced by PostgreSQL without changing the domain rules or HTTP contract.
+
+This is also the boundary that a future AI tool will call: the model may choose the cancellation capability, but the same command handler remains the authority for validation and state changes.

--- a/docs/development.md
+++ b/docs/development.md
@@ -56,6 +56,14 @@ dotnet build ContractIQ.slnx
 dotnet test ContractIQ.slnx
 ```
 
+Run the backend API locally:
+
+```powershell
+dotnet run --project src/ContractIQ.Api
+```
+
+The API listens on `http://localhost:5186` by default. Use the executable request collection at `src/ContractIQ.Api/ContractIQ.Api.http` or see the [contract operation API guide](api/contract-operations.md) for the seeded demonstration flow.
+
 ```powershell
 Set-Location src/ContractIQ.Web
 npm run dev

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.302",
+    "version": "10.0.400",
     "rollForward": "latestPatch",
     "allowPrerelease": false
   }

--- a/src/ContractIQ.Api/ContractIQ.Api.csproj
+++ b/src/ContractIQ.Api/ContractIQ.Api.csproj
@@ -3,4 +3,10 @@
     <ProjectReference Include="..\ContractIQ.Application\ContractIQ.Application.csproj" />
     <ProjectReference Include="..\ContractIQ.Infrastructure\ContractIQ.Infrastructure.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+    <!-- Pins the patched 2.x line used transitively by ASP.NET Core OpenAPI. -->
+    <PackageReference Include="Microsoft.OpenApi" />
+  </ItemGroup>
 </Project>

--- a/src/ContractIQ.Api/ContractIQ.Api.http
+++ b/src/ContractIQ.Api/ContractIQ.Api.http
@@ -1,0 +1,43 @@
+@host = http://localhost:5186
+@acmeContractId = aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa
+@cancelledContractId = cccccccc-cccc-4ccc-8ccc-cccccccccccc
+@idempotencyKey = demo-acme-cancellation-001
+
+### Health check
+GET {{host}}/health
+
+### List the fictional customers
+GET {{host}}/api/v1/customers
+Accept: application/json
+
+### Get ACME's structured contract data
+GET {{host}}/api/v1/contracts/{{acmeContractId}}
+Accept: application/json
+
+### Ask the domain model to assess ACME's cancellation
+GET {{host}}/api/v1/contracts/{{acmeContractId}}/cancellation-assessment
+Accept: application/json
+
+### Create ACME's cancellation request in PendingReview
+POST {{host}}/api/v1/contracts/{{acmeContractId}}/cancellation-requests
+Idempotency-Key: {{idempotencyKey}}
+Accept: application/json
+
+### Replay the same operation safely; returns the original request
+POST {{host}}/api/v1/contracts/{{acmeContractId}}/cancellation-requests
+Idempotency-Key: {{idempotencyKey}}
+Accept: application/json
+
+### A different key cannot create a second open request; returns 409
+POST {{host}}/api/v1/contracts/{{acmeContractId}}/cancellation-requests
+Idempotency-Key: demo-acme-cancellation-002
+Accept: application/json
+
+### An inactive contract cannot receive a cancellation request; returns 409
+POST {{host}}/api/v1/contracts/{{cancelledContractId}}/cancellation-requests
+Idempotency-Key: demo-inactive-contract-001
+Accept: application/json
+
+### OpenAPI document, available in Development
+GET {{host}}/openapi/v1.json
+Accept: application/json

--- a/src/ContractIQ.Api/Endpoints/ApiEndpoints.cs
+++ b/src/ContractIQ.Api/Endpoints/ApiEndpoints.cs
@@ -1,0 +1,105 @@
+using System.ComponentModel.DataAnnotations;
+using ContractIQ.Application.Cancellations.CreateCancellationRequest;
+using ContractIQ.Application.Contracts.AssessCancellation;
+using ContractIQ.Application.Contracts.GetContractDetails;
+using ContractIQ.Application.Customers.ListCustomers;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ContractIQ.Api.Endpoints;
+
+public static class ApiEndpoints
+{
+    public static IEndpointRouteBuilder MapApiV1(this IEndpointRouteBuilder endpoints)
+    {
+        var api = endpoints.MapGroup("/api/v1");
+
+        api.MapGet("/customers", ListCustomersAsync)
+            .WithName("ListCustomers")
+            .WithTags("Customers")
+            .WithSummary("Lists customers available to the current user.")
+            .Produces<CustomerSummaryDto[]>(StatusCodes.Status200OK);
+
+        api.MapGet("/contracts/{contractId:guid}", GetContractDetailsAsync)
+            .WithName("GetContractDetails")
+            .WithTags("Contracts")
+            .WithSummary("Gets structured contract details.")
+            .Produces<ContractDetailsDto>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status404NotFound);
+
+        api.MapGet(
+                "/contracts/{contractId:guid}/cancellation-assessment",
+                AssessCancellationAsync)
+            .WithName("AssessContractCancellation")
+            .WithTags("Contracts")
+            .WithSummary("Calculates cancellation eligibility, effective date, and penalty.")
+            .WithDescription("The result is calculated by deterministic domain rules using the server clock.")
+            .Produces<CancellationAssessmentDto>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status400BadRequest);
+
+        api.MapPost(
+                "/contracts/{contractId:guid}/cancellation-requests",
+                CreateCancellationRequestAsync)
+            .WithName("CreateCancellationRequest")
+            .WithTags("Cancellation Requests")
+            .WithSummary("Creates a cancellation request for review.")
+            .WithDescription(
+                "Requires an Idempotency-Key header. Penalty, dates, and status are calculated by the server.")
+            .Produces<CancellationRequestDto>(StatusCodes.Status201Created)
+            .Produces<CancellationRequestDto>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status409Conflict);
+
+        return endpoints;
+    }
+
+    private static async Task<IResult> ListCustomersAsync(
+        ListCustomersHandler handler,
+        CancellationToken cancellationToken)
+    {
+        var customers = await handler.HandleAsync(new ListCustomersQuery(), cancellationToken);
+
+        return Results.Ok(customers);
+    }
+
+    private static async Task<IResult> GetContractDetailsAsync(
+        Guid contractId,
+        GetContractDetailsHandler handler,
+        CancellationToken cancellationToken)
+    {
+        var contract = await handler.HandleAsync(
+            new GetContractDetailsQuery(contractId),
+            cancellationToken);
+
+        return Results.Ok(contract);
+    }
+
+    private static async Task<IResult> AssessCancellationAsync(
+        Guid contractId,
+        AssessCancellationHandler handler,
+        CancellationToken cancellationToken)
+    {
+        var assessment = await handler.HandleAsync(
+            new AssessCancellationQuery(contractId),
+            cancellationToken);
+
+        return Results.Ok(assessment);
+    }
+
+    private static async Task<IResult> CreateCancellationRequestAsync(
+        Guid contractId,
+        [Required]
+        [FromHeader(Name = "Idempotency-Key")] string? idempotencyKey,
+        CreateCancellationRequestHandler handler,
+        CancellationToken cancellationToken)
+    {
+        var result = await handler.HandleAsync(
+            new CreateCancellationRequestCommand(contractId, idempotencyKey ?? string.Empty),
+            cancellationToken);
+
+        return result.IsReplay
+            ? Results.Ok(result.Request)
+            : Results.Json(result.Request, statusCode: StatusCodes.Status201Created);
+    }
+}

--- a/src/ContractIQ.Api/Errors/ApplicationExceptionHandler.cs
+++ b/src/ContractIQ.Api/Errors/ApplicationExceptionHandler.cs
@@ -1,0 +1,83 @@
+using System.Diagnostics;
+using ContractIQ.Application.Common.Exceptions;
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ContractIQ.Api.Errors;
+
+public sealed class ApplicationExceptionHandler(
+    IProblemDetailsService problemDetailsService,
+    ILogger<ApplicationExceptionHandler> logger)
+    : IExceptionHandler
+{
+    public async ValueTask<bool> TryHandleAsync(
+        HttpContext httpContext,
+        Exception exception,
+        CancellationToken cancellationToken)
+    {
+        var mapping = MapException(exception);
+
+        if (mapping.Status == StatusCodes.Status500InternalServerError)
+        {
+            logger.LogError(exception, "An unhandled exception occurred while processing the request.");
+        }
+
+        var problem = new ProblemDetails
+        {
+            Status = mapping.Status,
+            Title = mapping.Title,
+            Detail = mapping.Detail,
+            Type = $"urn:contractiq:error:{mapping.Code}",
+            Instance = httpContext.Request.Path.Value ?? "/",
+        };
+
+        problem.Extensions["code"] = mapping.Code;
+        problem.Extensions["traceId"] = Activity.Current?.Id ?? httpContext.TraceIdentifier;
+
+        if (mapping.Field is not null)
+        {
+            problem.Extensions["field"] = mapping.Field;
+        }
+
+        httpContext.Response.StatusCode = mapping.Status;
+
+        return await problemDetailsService.TryWriteAsync(new ProblemDetailsContext
+        {
+            HttpContext = httpContext,
+            ProblemDetails = problem,
+            Exception = exception,
+        });
+    }
+
+    private static ExceptionMapping MapException(Exception exception) => exception switch
+    {
+        ResourceNotFoundException notFound => new ExceptionMapping(
+            StatusCodes.Status404NotFound,
+            "Resource not found",
+            notFound.Message,
+            "resource_not_found"),
+        ApplicationConflictException conflict => new ExceptionMapping(
+            StatusCodes.Status409Conflict,
+            "Request conflict",
+            conflict.Message,
+            conflict.Code),
+        ApplicationValidationException validation => new ExceptionMapping(
+            StatusCodes.Status400BadRequest,
+            "Validation failed",
+            validation.Message,
+            "validation_error",
+            validation.Field),
+        _ => new ExceptionMapping(
+            StatusCodes.Status500InternalServerError,
+            "Unexpected error",
+            "An unexpected error occurred while processing the request.",
+            "internal_server_error"),
+    };
+
+    private sealed record ExceptionMapping(
+        int Status,
+        string Title,
+        string Detail,
+        string Code,
+        string? Field = null);
+}

--- a/src/ContractIQ.Api/Program.cs
+++ b/src/ContractIQ.Api/Program.cs
@@ -1,10 +1,42 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using ContractIQ.Api.Endpoints;
+using ContractIQ.Api.Errors;
+using ContractIQ.Application.Cancellations.CreateCancellationRequest;
+using ContractIQ.Application.Contracts.AssessCancellation;
+using ContractIQ.Application.Contracts.GetContractDetails;
+using ContractIQ.Application.Customers.ListCustomers;
+using ContractIQ.Infrastructure;
+
 var builder = WebApplication.CreateBuilder(args);
 
+builder.Services.AddProblemDetails();
+builder.Services.AddExceptionHandler<ApplicationExceptionHandler>();
 builder.Services.AddHealthChecks();
+builder.Services.AddOpenApi();
+
+builder.Services.ConfigureHttpJsonOptions(options =>
+    options.SerializerOptions.Converters.Add(
+        new JsonStringEnumConverter(JsonNamingPolicy.CamelCase)));
+
+builder.Services.AddSingleton(TimeProvider.System);
+builder.Services.AddScoped<ListCustomersHandler>();
+builder.Services.AddScoped<GetContractDetailsHandler>();
+builder.Services.AddScoped<AssessCancellationHandler>();
+builder.Services.AddScoped<CreateCancellationRequestHandler>();
+builder.Services.AddInfrastructure();
 
 var app = builder.Build();
 
+app.UseExceptionHandler();
+
+if (app.Environment.IsDevelopment())
+{
+    app.MapOpenApi();
+}
+
 app.MapHealthChecks("/health");
+app.MapApiV1();
 
 app.Run();
 

--- a/src/ContractIQ.Application/Abstractions/Persistence/ICancellationRequestStore.cs
+++ b/src/ContractIQ.Application/Abstractions/Persistence/ICancellationRequestStore.cs
@@ -1,0 +1,29 @@
+using ContractIQ.Domain.Cancellations;
+
+namespace ContractIQ.Application.Abstractions.Persistence;
+
+public interface ICancellationRequestStore
+{
+    Task<CancellationRequest?> FindByIdempotencyKeyAsync(
+        string idempotencyKey,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Atomically enforces unique idempotency keys and at most one open request per contract.
+    /// </summary>
+    Task<CancellationRequestStoreResult> TryCreateAsync(
+        CancellationRequest request,
+        CancellationToken cancellationToken);
+}
+
+public sealed record CancellationRequestStoreResult(
+    CancellationRequestStoreOutcome Outcome,
+    CancellationRequest Request);
+
+public enum CancellationRequestStoreOutcome
+{
+    Created = 1,
+    Replayed = 2,
+    OpenRequestExists = 3,
+    IdempotencyKeyConflict = 4,
+}

--- a/src/ContractIQ.Application/Abstractions/Persistence/IContractRepository.cs
+++ b/src/ContractIQ.Application/Abstractions/Persistence/IContractRepository.cs
@@ -1,0 +1,8 @@
+using ContractIQ.Domain.Contracts;
+
+namespace ContractIQ.Application.Abstractions.Persistence;
+
+public interface IContractRepository
+{
+    Task<Contract?> GetByIdAsync(Guid contractId, CancellationToken cancellationToken);
+}

--- a/src/ContractIQ.Application/Abstractions/Persistence/ICustomerRepository.cs
+++ b/src/ContractIQ.Application/Abstractions/Persistence/ICustomerRepository.cs
@@ -1,0 +1,8 @@
+using ContractIQ.Domain.Customers;
+
+namespace ContractIQ.Application.Abstractions.Persistence;
+
+public interface ICustomerRepository
+{
+    Task<IReadOnlyList<Customer>> ListAsync(CancellationToken cancellationToken);
+}

--- a/src/ContractIQ.Application/Cancellations/CreateCancellationRequest/CancellationRequestDto.cs
+++ b/src/ContractIQ.Application/Cancellations/CreateCancellationRequest/CancellationRequestDto.cs
@@ -1,0 +1,14 @@
+using ContractIQ.Application.Common.Models;
+using ContractIQ.Domain.Cancellations;
+
+namespace ContractIQ.Application.Cancellations.CreateCancellationRequest;
+
+public sealed record CancellationRequestDto(
+    Guid Id,
+    Guid ContractId,
+    Guid CustomerId,
+    DateTimeOffset CreatedAtUtc,
+    DateOnly RequestedOn,
+    DateOnly EarliestTerminationDate,
+    MoneyDto Penalty,
+    CancellationRequestStatus Status);

--- a/src/ContractIQ.Application/Cancellations/CreateCancellationRequest/CreateCancellationRequestCommand.cs
+++ b/src/ContractIQ.Application/Cancellations/CreateCancellationRequest/CreateCancellationRequestCommand.cs
@@ -1,0 +1,3 @@
+namespace ContractIQ.Application.Cancellations.CreateCancellationRequest;
+
+public sealed record CreateCancellationRequestCommand(Guid ContractId, string IdempotencyKey);

--- a/src/ContractIQ.Application/Cancellations/CreateCancellationRequest/CreateCancellationRequestHandler.cs
+++ b/src/ContractIQ.Application/Cancellations/CreateCancellationRequest/CreateCancellationRequestHandler.cs
@@ -1,0 +1,139 @@
+using ContractIQ.Application.Abstractions.Persistence;
+using ContractIQ.Application.Common.Exceptions;
+using ContractIQ.Application.Common.Models;
+using ContractIQ.Domain.Cancellations;
+using CancellationAssessment = ContractIQ.Domain.Contracts.CancellationAssessment;
+using Contract = ContractIQ.Domain.Contracts.Contract;
+
+namespace ContractIQ.Application.Cancellations.CreateCancellationRequest;
+
+public sealed class CreateCancellationRequestHandler(
+    IContractRepository contracts,
+    ICancellationRequestStore cancellationRequests,
+    TimeProvider timeProvider)
+{
+    public async Task<CreateCancellationRequestResult> HandleAsync(
+        CreateCancellationRequestCommand command,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        string idempotencyKey = ValidateIdempotencyKey(command.IdempotencyKey);
+        DateTimeOffset now = timeProvider.GetUtcNow();
+
+        var replay = await cancellationRequests.FindByIdempotencyKeyAsync(
+            idempotencyKey,
+            cancellationToken);
+
+        if (replay is not null)
+        {
+            EnsureReplayMatchesContract(replay, command.ContractId);
+            return ToResult(replay, isReplay: true);
+        }
+
+        var contract = await contracts.GetByIdAsync(command.ContractId, cancellationToken)
+            ?? throw new ResourceNotFoundException("Contract", command.ContractId);
+
+        DateOnly requestedOn = DateOnly.FromDateTime(now.UtcDateTime);
+        var assessment = AssessForCreation(contract, requestedOn);
+
+        var request = CancellationRequest.Create(
+            contract.Id,
+            contract.CustomerId,
+            idempotencyKey,
+            now,
+            assessment);
+
+        var stored = await cancellationRequests.TryCreateAsync(request, cancellationToken);
+
+        return stored.Outcome switch
+        {
+            CancellationRequestStoreOutcome.Created => ToResult(stored.Request, isReplay: false),
+            CancellationRequestStoreOutcome.Replayed => ReplayResult(stored.Request, command.ContractId),
+            CancellationRequestStoreOutcome.OpenRequestExists => throw new ApplicationConflictException(
+                "cancellation_request_already_open",
+                "A different cancellation request is already open for this contract."),
+            CancellationRequestStoreOutcome.IdempotencyKeyConflict => throw new ApplicationConflictException(
+                "idempotency_key_conflict",
+                "The idempotency key has already been used for a different operation."),
+            _ => throw new InvalidOperationException($"Unsupported store outcome '{stored.Outcome}'."),
+        };
+    }
+
+    private static CancellationAssessment AssessForCreation(
+        Contract contract,
+        DateOnly requestedOn)
+    {
+        try
+        {
+            var assessment = contract.AssessCancellation(requestedOn);
+
+            if (!assessment.IsAllowed)
+            {
+                throw new ApplicationConflictException(
+                    "contract_not_cancellable",
+                    $"The contract cannot be cancelled because its assessment is '{assessment.Reason}'.");
+            }
+
+            return assessment;
+        }
+        catch (ArgumentOutOfRangeException exception)
+        {
+            throw new ApplicationValidationException("requestedOn", exception.Message);
+        }
+    }
+
+    private static string ValidateIdempotencyKey(string idempotencyKey)
+    {
+        if (string.IsNullOrWhiteSpace(idempotencyKey))
+        {
+            throw new ApplicationValidationException(
+                "idempotencyKey",
+                "An idempotency key is required.");
+        }
+
+        string normalized = idempotencyKey.Trim();
+
+        if (normalized.Length > 128)
+        {
+            throw new ApplicationValidationException(
+                "idempotencyKey",
+                "The idempotency key cannot exceed 128 characters.");
+        }
+
+        return normalized;
+    }
+
+    private static CreateCancellationRequestResult ReplayResult(
+        CancellationRequest request,
+        Guid contractId)
+    {
+        EnsureReplayMatchesContract(request, contractId);
+        return ToResult(request, isReplay: true);
+    }
+
+    private static void EnsureReplayMatchesContract(CancellationRequest request, Guid contractId)
+    {
+        if (request.ContractId != contractId)
+        {
+            throw new ApplicationConflictException(
+                "idempotency_key_conflict",
+                "The idempotency key has already been used for a different operation.");
+        }
+    }
+
+    private static CreateCancellationRequestResult ToResult(
+        CancellationRequest request,
+        bool isReplay) =>
+        new(
+            new CancellationRequestDto(
+                request.Id,
+                request.ContractId,
+                request.CustomerId,
+                request.CreatedAtUtc,
+                request.RequestedOn,
+                request.EarliestTerminationDate,
+                MoneyDto.FromDomain(request.Penalty),
+                request.Status),
+            isReplay);
+}

--- a/src/ContractIQ.Application/Cancellations/CreateCancellationRequest/CreateCancellationRequestResult.cs
+++ b/src/ContractIQ.Application/Cancellations/CreateCancellationRequest/CreateCancellationRequestResult.cs
@@ -1,0 +1,5 @@
+namespace ContractIQ.Application.Cancellations.CreateCancellationRequest;
+
+public sealed record CreateCancellationRequestResult(
+    CancellationRequestDto Request,
+    bool IsReplay);

--- a/src/ContractIQ.Application/Common/Exceptions/ApplicationConflictException.cs
+++ b/src/ContractIQ.Application/Common/Exceptions/ApplicationConflictException.cs
@@ -1,0 +1,14 @@
+namespace ContractIQ.Application.Common.Exceptions;
+
+public sealed class ApplicationConflictException : Exception
+{
+    public ApplicationConflictException(string code, string message)
+        : base(message)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(code);
+
+        Code = code;
+    }
+
+    public string Code { get; }
+}

--- a/src/ContractIQ.Application/Common/Exceptions/ApplicationValidationException.cs
+++ b/src/ContractIQ.Application/Common/Exceptions/ApplicationValidationException.cs
@@ -1,0 +1,14 @@
+namespace ContractIQ.Application.Common.Exceptions;
+
+public sealed class ApplicationValidationException : Exception
+{
+    public ApplicationValidationException(string field, string message)
+        : base(message)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(field);
+
+        Field = field;
+    }
+
+    public string Field { get; }
+}

--- a/src/ContractIQ.Application/Common/Exceptions/ResourceNotFoundException.cs
+++ b/src/ContractIQ.Application/Common/Exceptions/ResourceNotFoundException.cs
@@ -1,0 +1,15 @@
+namespace ContractIQ.Application.Common.Exceptions;
+
+public sealed class ResourceNotFoundException : Exception
+{
+    public ResourceNotFoundException(string resourceName, object resourceId)
+        : base($"{resourceName} '{resourceId}' was not found.")
+    {
+        ResourceName = resourceName;
+        ResourceId = resourceId;
+    }
+
+    public string ResourceName { get; }
+
+    public object ResourceId { get; }
+}

--- a/src/ContractIQ.Application/Common/Models/MoneyDto.cs
+++ b/src/ContractIQ.Application/Common/Models/MoneyDto.cs
@@ -1,0 +1,8 @@
+using ContractIQ.Domain.Contracts;
+
+namespace ContractIQ.Application.Common.Models;
+
+public sealed record MoneyDto(decimal Amount, string Currency)
+{
+    internal static MoneyDto FromDomain(Money money) => new(money.Amount, money.Currency);
+}

--- a/src/ContractIQ.Application/Contracts/AssessCancellation/AssessCancellationHandler.cs
+++ b/src/ContractIQ.Application/Contracts/AssessCancellation/AssessCancellationHandler.cs
@@ -1,0 +1,32 @@
+using ContractIQ.Application.Abstractions.Persistence;
+using ContractIQ.Application.Common.Exceptions;
+using ContractIQ.Application.Common.Models;
+
+namespace ContractIQ.Application.Contracts.AssessCancellation;
+
+public sealed class AssessCancellationHandler(
+    IContractRepository contracts,
+    TimeProvider timeProvider)
+{
+    public async Task<CancellationAssessmentDto> HandleAsync(
+        AssessCancellationQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var contract = await contracts.GetByIdAsync(query.ContractId, cancellationToken)
+            ?? throw new ResourceNotFoundException("Contract", query.ContractId);
+
+        var assessment = contract.AssessCancellation(timeProvider);
+
+        return new CancellationAssessmentDto(
+            contract.Id,
+            assessment.IsAllowed,
+            assessment.Reason,
+            assessment.RequestedOn,
+            assessment.EarliestTerminationDate,
+            assessment.ChargeableMonthlyPeriods,
+            MoneyDto.FromDomain(assessment.Penalty),
+            assessment.HasPenalty);
+    }
+}

--- a/src/ContractIQ.Application/Contracts/AssessCancellation/AssessCancellationQuery.cs
+++ b/src/ContractIQ.Application/Contracts/AssessCancellation/AssessCancellationQuery.cs
@@ -1,0 +1,3 @@
+namespace ContractIQ.Application.Contracts.AssessCancellation;
+
+public sealed record AssessCancellationQuery(Guid ContractId);

--- a/src/ContractIQ.Application/Contracts/AssessCancellation/CancellationAssessmentDto.cs
+++ b/src/ContractIQ.Application/Contracts/AssessCancellation/CancellationAssessmentDto.cs
@@ -1,0 +1,14 @@
+using ContractIQ.Application.Common.Models;
+using ContractIQ.Domain.Contracts;
+
+namespace ContractIQ.Application.Contracts.AssessCancellation;
+
+public sealed record CancellationAssessmentDto(
+    Guid ContractId,
+    bool IsAllowed,
+    CancellationAssessmentReason Reason,
+    DateOnly RequestedOn,
+    DateOnly EarliestTerminationDate,
+    int ChargeableMonthlyPeriods,
+    MoneyDto Penalty,
+    bool HasPenalty);

--- a/src/ContractIQ.Application/Contracts/GetContractDetails/ContractDetailsDto.cs
+++ b/src/ContractIQ.Application/Contracts/GetContractDetails/ContractDetailsDto.cs
@@ -1,0 +1,14 @@
+using ContractIQ.Application.Common.Models;
+using ContractIQ.Domain.Contracts;
+
+namespace ContractIQ.Application.Contracts.GetContractDetails;
+
+public sealed record ContractDetailsDto(
+    Guid Id,
+    Guid CustomerId,
+    DateOnly StartDate,
+    ContractStatus Status,
+    MoneyDto MonthlyFee,
+    int NoticePeriodDays,
+    DateOnly MinimumCommitmentEndDate,
+    decimal EarlyTerminationPenaltyRate);

--- a/src/ContractIQ.Application/Contracts/GetContractDetails/GetContractDetailsHandler.cs
+++ b/src/ContractIQ.Application/Contracts/GetContractDetails/GetContractDetailsHandler.cs
@@ -1,0 +1,28 @@
+using ContractIQ.Application.Abstractions.Persistence;
+using ContractIQ.Application.Common.Exceptions;
+using ContractIQ.Application.Common.Models;
+
+namespace ContractIQ.Application.Contracts.GetContractDetails;
+
+public sealed class GetContractDetailsHandler(IContractRepository contracts)
+{
+    public async Task<ContractDetailsDto> HandleAsync(
+        GetContractDetailsQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var contract = await contracts.GetByIdAsync(query.ContractId, cancellationToken)
+            ?? throw new ResourceNotFoundException("Contract", query.ContractId);
+
+        return new ContractDetailsDto(
+            contract.Id,
+            contract.CustomerId,
+            contract.StartDate,
+            contract.Status,
+            MoneyDto.FromDomain(contract.MonthlyFee),
+            contract.TerminationTerms.NoticePeriodDays,
+            contract.TerminationTerms.MinimumCommitmentEndDate,
+            contract.TerminationTerms.EarlyTerminationPenaltyRate);
+    }
+}

--- a/src/ContractIQ.Application/Contracts/GetContractDetails/GetContractDetailsQuery.cs
+++ b/src/ContractIQ.Application/Contracts/GetContractDetails/GetContractDetailsQuery.cs
@@ -1,0 +1,3 @@
+namespace ContractIQ.Application.Contracts.GetContractDetails;
+
+public sealed record GetContractDetailsQuery(Guid ContractId);

--- a/src/ContractIQ.Application/Customers/ListCustomers/CustomerSummaryDto.cs
+++ b/src/ContractIQ.Application/Customers/ListCustomers/CustomerSummaryDto.cs
@@ -1,0 +1,3 @@
+namespace ContractIQ.Application.Customers.ListCustomers;
+
+public sealed record CustomerSummaryDto(Guid Id, string Name);

--- a/src/ContractIQ.Application/Customers/ListCustomers/ListCustomersHandler.cs
+++ b/src/ContractIQ.Application/Customers/ListCustomers/ListCustomersHandler.cs
@@ -1,0 +1,19 @@
+using ContractIQ.Application.Abstractions.Persistence;
+
+namespace ContractIQ.Application.Customers.ListCustomers;
+
+public sealed class ListCustomersHandler(ICustomerRepository customers)
+{
+    public async Task<IReadOnlyList<CustomerSummaryDto>> HandleAsync(
+        ListCustomersQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var results = await customers.ListAsync(cancellationToken);
+
+        return results
+            .Select(customer => new CustomerSummaryDto(customer.Id, customer.Name))
+            .ToArray();
+    }
+}

--- a/src/ContractIQ.Application/Customers/ListCustomers/ListCustomersQuery.cs
+++ b/src/ContractIQ.Application/Customers/ListCustomers/ListCustomersQuery.cs
@@ -1,0 +1,3 @@
+namespace ContractIQ.Application.Customers.ListCustomers;
+
+public sealed record ListCustomersQuery;

--- a/src/ContractIQ.Domain/Cancellations/CancellationRequest.cs
+++ b/src/ContractIQ.Domain/Cancellations/CancellationRequest.cs
@@ -1,0 +1,79 @@
+using ContractIQ.Domain.Contracts;
+
+namespace ContractIQ.Domain.Cancellations;
+
+public sealed class CancellationRequest
+{
+    private CancellationRequest(
+        Guid id,
+        Guid contractId,
+        Guid customerId,
+        string idempotencyKey,
+        DateTimeOffset createdAtUtc,
+        CancellationAssessment assessment)
+    {
+        Id = id;
+        ContractId = contractId;
+        CustomerId = customerId;
+        IdempotencyKey = idempotencyKey;
+        CreatedAtUtc = createdAtUtc;
+        RequestedOn = assessment.RequestedOn;
+        EarliestTerminationDate = assessment.EarliestTerminationDate;
+        Penalty = assessment.Penalty;
+        Status = CancellationRequestStatus.PendingReview;
+    }
+
+    public Guid Id { get; }
+
+    public Guid ContractId { get; }
+
+    public Guid CustomerId { get; }
+
+    public string IdempotencyKey { get; }
+
+    public DateTimeOffset CreatedAtUtc { get; }
+
+    public DateOnly RequestedOn { get; }
+
+    public DateOnly EarliestTerminationDate { get; }
+
+    public Money Penalty { get; }
+
+    public CancellationRequestStatus Status { get; }
+
+    public bool IsOpen => Status == CancellationRequestStatus.PendingReview;
+
+    public static CancellationRequest Create(
+        Guid contractId,
+        Guid customerId,
+        string idempotencyKey,
+        DateTimeOffset createdAtUtc,
+        CancellationAssessment assessment)
+    {
+        if (contractId == Guid.Empty)
+        {
+            throw new ArgumentException("A contract identifier is required.", nameof(contractId));
+        }
+
+        if (customerId == Guid.Empty)
+        {
+            throw new ArgumentException("A customer identifier is required.", nameof(customerId));
+        }
+
+        ArgumentException.ThrowIfNullOrWhiteSpace(idempotencyKey);
+        ArgumentNullException.ThrowIfNull(assessment);
+
+        if (!assessment.IsAllowed)
+        {
+            throw new InvalidOperationException("A cancellation request requires an allowed assessment.");
+        }
+
+        return new CancellationRequest(
+            Guid.NewGuid(),
+            contractId,
+            customerId,
+            idempotencyKey.Trim(),
+            createdAtUtc.ToUniversalTime(),
+            assessment);
+    }
+}

--- a/src/ContractIQ.Domain/Cancellations/CancellationRequestStatus.cs
+++ b/src/ContractIQ.Domain/Cancellations/CancellationRequestStatus.cs
@@ -1,0 +1,8 @@
+namespace ContractIQ.Domain.Cancellations;
+
+public enum CancellationRequestStatus
+{
+    PendingReview = 1,
+    Approved = 2,
+    Rejected = 3,
+}

--- a/src/ContractIQ.Domain/Customers/Customer.cs
+++ b/src/ContractIQ.Domain/Customers/Customer.cs
@@ -1,0 +1,21 @@
+namespace ContractIQ.Domain.Customers;
+
+public sealed record Customer
+{
+    public Customer(Guid id, string name)
+    {
+        if (id == Guid.Empty)
+        {
+            throw new ArgumentException("A customer identifier is required.", nameof(id));
+        }
+
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+
+        Id = id;
+        Name = name.Trim();
+    }
+
+    public Guid Id { get; }
+
+    public string Name { get; }
+}

--- a/src/ContractIQ.Infrastructure/ContractIQ.Infrastructure.csproj
+++ b/src/ContractIQ.Infrastructure/ContractIQ.Infrastructure.csproj
@@ -2,4 +2,8 @@
   <ItemGroup>
     <ProjectReference Include="..\ContractIQ.Application\ContractIQ.Application.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+  </ItemGroup>
 </Project>

--- a/src/ContractIQ.Infrastructure/DemoDataIds.cs
+++ b/src/ContractIQ.Infrastructure/DemoDataIds.cs
@@ -1,0 +1,21 @@
+namespace ContractIQ.Infrastructure;
+
+/// <summary>
+/// Stable identifiers for the fictional records used by the local demo experience.
+/// </summary>
+public static class DemoDataIds
+{
+    public static readonly Guid AcmeCustomer = new("11111111-1111-4111-8111-111111111111");
+
+    public static readonly Guid GlobexCustomer = new("22222222-2222-4222-8222-222222222222");
+
+    public static readonly Guid InitechCustomer = new("33333333-3333-4333-8333-333333333333");
+
+    public static readonly Guid AcmeActiveContract = new("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa");
+
+    public static readonly Guid GlobexActiveContract = new("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb");
+
+    public static readonly Guid InitechCancelledContract = new("cccccccc-cccc-4ccc-8ccc-cccccccccccc");
+
+    public static readonly Guid InitechExpiredContract = new("dddddddd-dddd-4ddd-8ddd-dddddddddddd");
+}

--- a/src/ContractIQ.Infrastructure/DependencyInjection.cs
+++ b/src/ContractIQ.Infrastructure/DependencyInjection.cs
@@ -1,0 +1,23 @@
+using ContractIQ.Application.Abstractions.Persistence;
+using ContractIQ.Infrastructure.Persistence;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ContractIQ.Infrastructure;
+
+public static class DependencyInjection
+{
+    public static IServiceCollection AddInfrastructure(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddSingleton<InMemoryDemoStore>();
+        services.AddSingleton<ICustomerRepository>(provider =>
+            provider.GetRequiredService<InMemoryDemoStore>());
+        services.AddSingleton<IContractRepository>(provider =>
+            provider.GetRequiredService<InMemoryDemoStore>());
+        services.AddSingleton<ICancellationRequestStore>(provider =>
+            provider.GetRequiredService<InMemoryDemoStore>());
+
+        return services;
+    }
+}

--- a/src/ContractIQ.Infrastructure/Persistence/InMemoryDemoStore.cs
+++ b/src/ContractIQ.Infrastructure/Persistence/InMemoryDemoStore.cs
@@ -1,0 +1,157 @@
+using ContractIQ.Application.Abstractions.Persistence;
+using ContractIQ.Domain.Cancellations;
+using ContractIQ.Domain.Contracts;
+using ContractIQ.Domain.Customers;
+
+namespace ContractIQ.Infrastructure.Persistence;
+
+internal sealed class InMemoryDemoStore :
+    ICustomerRepository,
+    IContractRepository,
+    ICancellationRequestStore
+{
+    private readonly object _cancellationRequestGate = new();
+    private readonly IReadOnlyList<Customer> _customers;
+    private readonly IReadOnlyDictionary<Guid, Contract> _contracts;
+    private readonly Dictionary<string, CancellationRequest> _cancellationRequestsByIdempotencyKey =
+        new(StringComparer.Ordinal);
+
+    public InMemoryDemoStore()
+    {
+        _customers = Array.AsReadOnly(
+            CreateCustomers()
+                .OrderBy(customer => customer.Name, StringComparer.Ordinal)
+                .ThenBy(customer => customer.Id)
+                .ToArray());
+
+        _contracts = CreateContracts().ToDictionary(contract => contract.Id);
+    }
+
+    public Task<IReadOnlyList<Customer>> ListAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult(_customers);
+    }
+
+    public Task<Contract?> GetByIdAsync(
+        Guid contractId,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        _contracts.TryGetValue(contractId, out Contract? contract);
+
+        return Task.FromResult(contract);
+    }
+
+    public Task<CancellationRequest?> FindByIdempotencyKeyAsync(
+        string idempotencyKey,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ArgumentException.ThrowIfNullOrWhiteSpace(idempotencyKey);
+
+        lock (_cancellationRequestGate)
+        {
+            _cancellationRequestsByIdempotencyKey.TryGetValue(
+                idempotencyKey,
+                out CancellationRequest? request);
+
+            return Task.FromResult(request);
+        }
+    }
+
+    public Task<CancellationRequestStoreResult> TryCreateAsync(
+        CancellationRequest request,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ArgumentNullException.ThrowIfNull(request);
+
+        lock (_cancellationRequestGate)
+        {
+            if (_cancellationRequestsByIdempotencyKey.TryGetValue(
+                    request.IdempotencyKey,
+                    out CancellationRequest? requestWithSameKey))
+            {
+                CancellationRequestStoreOutcome outcome =
+                    requestWithSameKey.ContractId == request.ContractId
+                        ? CancellationRequestStoreOutcome.Replayed
+                        : CancellationRequestStoreOutcome.IdempotencyKeyConflict;
+
+                return Task.FromResult(
+                    new CancellationRequestStoreResult(outcome, requestWithSameKey));
+            }
+
+            CancellationRequest? openRequest = _cancellationRequestsByIdempotencyKey.Values
+                .FirstOrDefault(existing =>
+                    existing.ContractId == request.ContractId && existing.IsOpen);
+
+            if (openRequest is not null)
+            {
+                return Task.FromResult(
+                    new CancellationRequestStoreResult(
+                        CancellationRequestStoreOutcome.OpenRequestExists,
+                        openRequest));
+            }
+
+            _cancellationRequestsByIdempotencyKey.Add(request.IdempotencyKey, request);
+
+            return Task.FromResult(
+                new CancellationRequestStoreResult(
+                    CancellationRequestStoreOutcome.Created,
+                    request));
+        }
+    }
+
+    private static IEnumerable<Customer> CreateCustomers()
+    {
+        yield return new Customer(DemoDataIds.AcmeCustomer, "ACME Corporation");
+        yield return new Customer(DemoDataIds.GlobexCustomer, "Globex Corporation");
+        yield return new Customer(DemoDataIds.InitechCustomer, "Initech");
+    }
+
+    private static IEnumerable<Contract> CreateContracts()
+    {
+        yield return new Contract(
+            DemoDataIds.AcmeActiveContract,
+            DemoDataIds.AcmeCustomer,
+            new DateOnly(2026, 1, 1),
+            new Money(1_200m, "USD"),
+            new TerminationTerms(
+                noticePeriodDays: 30,
+                minimumCommitmentEndDate: new DateOnly(2028, 1, 1),
+                earlyTerminationPenaltyRate: 0.25m));
+
+        yield return new Contract(
+            DemoDataIds.GlobexActiveContract,
+            DemoDataIds.GlobexCustomer,
+            new DateOnly(2024, 1, 1),
+            new Money(850m, "USD"),
+            new TerminationTerms(
+                noticePeriodDays: 15,
+                minimumCommitmentEndDate: new DateOnly(2025, 1, 1),
+                earlyTerminationPenaltyRate: 0.20m));
+
+        yield return new Contract(
+            DemoDataIds.InitechCancelledContract,
+            DemoDataIds.InitechCustomer,
+            new DateOnly(2025, 1, 1),
+            new Money(2_000m, "USD"),
+            new TerminationTerms(
+                noticePeriodDays: 60,
+                minimumCommitmentEndDate: new DateOnly(2027, 1, 1),
+                earlyTerminationPenaltyRate: 0.30m),
+            ContractStatus.Cancelled);
+
+        yield return new Contract(
+            DemoDataIds.InitechExpiredContract,
+            DemoDataIds.InitechCustomer,
+            new DateOnly(2023, 1, 1),
+            new Money(1_500m, "USD"),
+            new TerminationTerms(
+                noticePeriodDays: 30,
+                minimumCommitmentEndDate: new DateOnly(2024, 1, 1),
+                earlyTerminationPenaltyRate: 0.15m),
+            ContractStatus.Expired);
+    }
+}

--- a/tests/ContractIQ.Application.Tests/Cancellations/CreateCancellationRequestHandlerTests.cs
+++ b/tests/ContractIQ.Application.Tests/Cancellations/CreateCancellationRequestHandlerTests.cs
@@ -1,0 +1,201 @@
+using ContractIQ.Application.Cancellations.CreateCancellationRequest;
+using ContractIQ.Application.Common.Exceptions;
+using ContractIQ.Application.Common.Models;
+using ContractIQ.Domain.Cancellations;
+using ContractIQ.Domain.Contracts;
+using Xunit;
+
+namespace ContractIQ.Application.Tests.Cancellations;
+
+public sealed class CreateCancellationRequestHandlerTests
+{
+    private static readonly DateTimeOffset FrozenUtc =
+        DateTimeOffset.Parse("2026-03-01T00:30:00Z");
+
+    [Fact]
+    public async Task HandleAsync_creates_a_pending_review_snapshot()
+    {
+        var contract = ApplicationTestData.CreateContract();
+        var store = new FakeCancellationRequestStore();
+        var handler = CreateHandler(contract, store, new MutableTimeProvider(FrozenUtc));
+
+        CreateCancellationRequestResult result = await handler.HandleAsync(
+            new CreateCancellationRequestCommand(contract.Id, " request-001 "),
+            CancellationToken.None);
+
+        Assert.False(result.IsReplay);
+        Assert.NotEqual(Guid.Empty, result.Request.Id);
+        Assert.Equal(contract.Id, result.Request.ContractId);
+        Assert.Equal(contract.CustomerId, result.Request.CustomerId);
+        Assert.Equal(FrozenUtc, result.Request.CreatedAtUtc);
+        Assert.Equal(new DateOnly(2026, 3, 1), result.Request.RequestedOn);
+        Assert.Equal(new DateOnly(2026, 3, 31), result.Request.EarliestTerminationDate);
+        Assert.Equal(new MoneyDto(2_500m, "BRL"), result.Request.Penalty);
+        Assert.Equal(CancellationRequestStatus.PendingReview, result.Request.Status);
+
+        var stored = Assert.Single(store.Requests);
+        Assert.Equal("request-001", stored.IdempotencyKey);
+        Assert.Equal(result.Request.Id, stored.Id);
+    }
+
+    [Fact]
+    public async Task HandleAsync_replays_the_original_snapshot_after_time_advances()
+    {
+        var contract = ApplicationTestData.CreateContract();
+        var store = new FakeCancellationRequestStore();
+        var timeProvider = new MutableTimeProvider(FrozenUtc);
+        var repository = new FakeContractRepository(contract);
+        var handler = new CreateCancellationRequestHandler(repository, store, timeProvider);
+        var command = new CreateCancellationRequestCommand(contract.Id, "request-001");
+
+        CreateCancellationRequestResult created = await handler.HandleAsync(command, CancellationToken.None);
+        timeProvider.Advance(TimeSpan.FromDays(90));
+        CreateCancellationRequestResult replay = await handler.HandleAsync(command, CancellationToken.None);
+
+        Assert.True(replay.IsReplay);
+        Assert.Equal(created.Request, replay.Request);
+        Assert.Single(store.Requests);
+        Assert.Equal(1, store.TryCreateCallCount);
+        Assert.Equal(1, repository.CallCount);
+    }
+
+    [Fact]
+    public async Task HandleAsync_rejects_same_key_for_a_different_contract()
+    {
+        var acmeContract = ApplicationTestData.CreateContract();
+        var globexContract = ApplicationTestData.CreateContract(
+            id: ApplicationTestData.GlobexContractId,
+            customerId: Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"));
+        var store = new FakeCancellationRequestStore();
+        var repository = new FakeContractRepository(acmeContract, globexContract);
+        var handler = new CreateCancellationRequestHandler(
+            repository,
+            store,
+            new MutableTimeProvider(FrozenUtc));
+
+        await handler.HandleAsync(
+            new CreateCancellationRequestCommand(acmeContract.Id, "shared-key"),
+            CancellationToken.None);
+
+        var exception = await Assert.ThrowsAsync<ApplicationConflictException>(
+            () => handler.HandleAsync(
+                new CreateCancellationRequestCommand(globexContract.Id, "shared-key"),
+                CancellationToken.None));
+
+        Assert.Equal("idempotency_key_conflict", exception.Code);
+        Assert.Single(store.Requests);
+        Assert.Equal(1, store.TryCreateCallCount);
+        Assert.Equal(1, repository.CallCount);
+    }
+
+    [Fact]
+    public async Task HandleAsync_rejects_a_different_key_when_an_open_request_exists()
+    {
+        var contract = ApplicationTestData.CreateContract();
+        var store = new FakeCancellationRequestStore();
+        var handler = CreateHandler(contract, store, new MutableTimeProvider(FrozenUtc));
+
+        await handler.HandleAsync(
+            new CreateCancellationRequestCommand(contract.Id, "request-001"),
+            CancellationToken.None);
+
+        var exception = await Assert.ThrowsAsync<ApplicationConflictException>(
+            () => handler.HandleAsync(
+                new CreateCancellationRequestCommand(contract.Id, "request-002"),
+                CancellationToken.None));
+
+        Assert.Equal("cancellation_request_already_open", exception.Code);
+        Assert.Single(store.Requests);
+        Assert.Equal(2, store.TryCreateCallCount);
+    }
+
+    [Theory]
+    [InlineData(ContractStatus.Cancelled)]
+    [InlineData(ContractStatus.Expired)]
+    public async Task HandleAsync_rejects_inactive_contract(ContractStatus status)
+    {
+        var contract = ApplicationTestData.CreateContract(status: status);
+        var store = new FakeCancellationRequestStore();
+        var handler = CreateHandler(contract, store, new MutableTimeProvider(FrozenUtc));
+
+        var exception = await Assert.ThrowsAsync<ApplicationConflictException>(
+            () => handler.HandleAsync(
+                new CreateCancellationRequestCommand(contract.Id, "request-001"),
+                CancellationToken.None));
+
+        Assert.Equal("contract_not_cancellable", exception.Code);
+        Assert.Empty(store.Requests);
+        Assert.Equal(0, store.TryCreateCallCount);
+    }
+
+    [Fact]
+    public async Task HandleAsync_throws_when_contract_does_not_exist()
+    {
+        var contractId = Guid.Parse("99999999-9999-9999-9999-999999999999");
+        var store = new FakeCancellationRequestStore();
+        var handler = new CreateCancellationRequestHandler(
+            new FakeContractRepository(),
+            store,
+            new MutableTimeProvider(FrozenUtc));
+
+        var exception = await Assert.ThrowsAsync<ResourceNotFoundException>(
+            () => handler.HandleAsync(
+                new CreateCancellationRequestCommand(contractId, "request-001"),
+                CancellationToken.None));
+
+        Assert.Equal(contractId, exception.ResourceId);
+        Assert.Empty(store.Requests);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task HandleAsync_rejects_missing_idempotency_key(string? key)
+    {
+        var contract = ApplicationTestData.CreateContract();
+        var store = new FakeCancellationRequestStore();
+        var repository = new FakeContractRepository(contract);
+        var handler = new CreateCancellationRequestHandler(
+            repository,
+            store,
+            new MutableTimeProvider(FrozenUtc));
+
+        var exception = await Assert.ThrowsAsync<ApplicationValidationException>(
+            () => handler.HandleAsync(
+                new CreateCancellationRequestCommand(contract.Id, key!),
+                CancellationToken.None));
+
+        Assert.Equal("idempotencyKey", exception.Field);
+        Assert.Equal(0, repository.CallCount);
+        Assert.Equal(0, store.FindCallCount);
+        Assert.Equal(0, store.TryCreateCallCount);
+    }
+
+    [Fact]
+    public async Task HandleAsync_rejects_idempotency_key_longer_than_128_characters()
+    {
+        var contract = ApplicationTestData.CreateContract();
+        var store = new FakeCancellationRequestStore();
+        var repository = new FakeContractRepository(contract);
+        var handler = new CreateCancellationRequestHandler(
+            repository,
+            store,
+            new MutableTimeProvider(FrozenUtc));
+
+        var exception = await Assert.ThrowsAsync<ApplicationValidationException>(
+            () => handler.HandleAsync(
+                new CreateCancellationRequestCommand(contract.Id, new string('a', 129)),
+                CancellationToken.None));
+
+        Assert.Equal("idempotencyKey", exception.Field);
+        Assert.Equal(0, repository.CallCount);
+        Assert.Equal(0, store.FindCallCount);
+    }
+
+    private static CreateCancellationRequestHandler CreateHandler(
+        Contract contract,
+        FakeCancellationRequestStore store,
+        TimeProvider timeProvider) =>
+        new(new FakeContractRepository(contract), store, timeProvider);
+}

--- a/tests/ContractIQ.Application.Tests/Contracts/AssessCancellationHandlerTests.cs
+++ b/tests/ContractIQ.Application.Tests/Contracts/AssessCancellationHandlerTests.cs
@@ -1,0 +1,56 @@
+using ContractIQ.Application.Common.Exceptions;
+using ContractIQ.Application.Common.Models;
+using ContractIQ.Application.Contracts.AssessCancellation;
+using ContractIQ.Domain.Contracts;
+using Xunit;
+
+namespace ContractIQ.Application.Tests.Contracts;
+
+public sealed class AssessCancellationHandlerTests
+{
+    [Fact]
+    public async Task HandleAsync_uses_the_deterministic_UTC_date()
+    {
+        var contract = ApplicationTestData.CreateContract();
+        var utcMinusEleven = TimeZoneInfo.CreateCustomTimeZone(
+            "UTC-11-application-test",
+            TimeSpan.FromHours(-11),
+            "UTC-11 application test",
+            "UTC-11 application test");
+        var timeProvider = new MutableTimeProvider(
+            new DateTimeOffset(2026, 3, 1, 0, 30, 0, TimeSpan.Zero),
+            utcMinusEleven);
+        var handler = new AssessCancellationHandler(
+            new FakeContractRepository(contract),
+            timeProvider);
+
+        CancellationAssessmentDto result = await handler.HandleAsync(
+            new AssessCancellationQuery(contract.Id),
+            CancellationToken.None);
+
+        Assert.Equal(contract.Id, result.ContractId);
+        Assert.True(result.IsAllowed);
+        Assert.Equal(CancellationAssessmentReason.Allowed, result.Reason);
+        Assert.Equal(new DateOnly(2026, 3, 1), result.RequestedOn);
+        Assert.Equal(new DateOnly(2026, 3, 31), result.EarliestTerminationDate);
+        Assert.Equal(10, result.ChargeableMonthlyPeriods);
+        Assert.Equal(new MoneyDto(2_500m, "BRL"), result.Penalty);
+        Assert.True(result.HasPenalty);
+    }
+
+    [Fact]
+    public async Task HandleAsync_throws_when_contract_does_not_exist()
+    {
+        var contractId = Guid.Parse("99999999-9999-9999-9999-999999999999");
+        var handler = new AssessCancellationHandler(
+            new FakeContractRepository(),
+            new MutableTimeProvider(DateTimeOffset.Parse("2026-03-01T00:00:00Z")));
+
+        var exception = await Assert.ThrowsAsync<ResourceNotFoundException>(
+            () => handler.HandleAsync(
+                new AssessCancellationQuery(contractId),
+                CancellationToken.None));
+
+        Assert.Equal(contractId, exception.ResourceId);
+    }
+}

--- a/tests/ContractIQ.Application.Tests/Contracts/GetContractDetailsHandlerTests.cs
+++ b/tests/ContractIQ.Application.Tests/Contracts/GetContractDetailsHandlerTests.cs
@@ -1,0 +1,45 @@
+using ContractIQ.Application.Common.Exceptions;
+using ContractIQ.Application.Common.Models;
+using ContractIQ.Application.Contracts.GetContractDetails;
+using ContractIQ.Domain.Contracts;
+using Xunit;
+
+namespace ContractIQ.Application.Tests.Contracts;
+
+public sealed class GetContractDetailsHandlerTests
+{
+    [Fact]
+    public async Task HandleAsync_maps_contract_details()
+    {
+        var contract = ApplicationTestData.CreateContract();
+        var handler = new GetContractDetailsHandler(new FakeContractRepository(contract));
+
+        ContractDetailsDto result = await handler.HandleAsync(
+            new GetContractDetailsQuery(contract.Id),
+            CancellationToken.None);
+
+        Assert.Equal(contract.Id, result.Id);
+        Assert.Equal(contract.CustomerId, result.CustomerId);
+        Assert.Equal(contract.StartDate, result.StartDate);
+        Assert.Equal(ContractStatus.Active, result.Status);
+        Assert.Equal(new MoneyDto(1_000m, "BRL"), result.MonthlyFee);
+        Assert.Equal(30, result.NoticePeriodDays);
+        Assert.Equal(new DateOnly(2026, 12, 31), result.MinimumCommitmentEndDate);
+        Assert.Equal(0.25m, result.EarlyTerminationPenaltyRate);
+    }
+
+    [Fact]
+    public async Task HandleAsync_throws_when_contract_does_not_exist()
+    {
+        var contractId = Guid.Parse("99999999-9999-9999-9999-999999999999");
+        var handler = new GetContractDetailsHandler(new FakeContractRepository());
+
+        var exception = await Assert.ThrowsAsync<ResourceNotFoundException>(
+            () => handler.HandleAsync(
+                new GetContractDetailsQuery(contractId),
+                CancellationToken.None));
+
+        Assert.Equal("Contract", exception.ResourceName);
+        Assert.Equal(contractId, exception.ResourceId);
+    }
+}

--- a/tests/ContractIQ.Application.Tests/Customers/ListCustomersHandlerTests.cs
+++ b/tests/ContractIQ.Application.Tests/Customers/ListCustomersHandlerTests.cs
@@ -1,0 +1,29 @@
+using ContractIQ.Application.Customers.ListCustomers;
+using ContractIQ.Domain.Customers;
+using Xunit;
+
+namespace ContractIQ.Application.Tests.Customers;
+
+public sealed class ListCustomersHandlerTests
+{
+    [Fact]
+    public async Task HandleAsync_returns_customer_summaries_in_repository_order()
+    {
+        var acme = new Customer(ApplicationTestData.AcmeCustomerId, "ACME Corporation");
+        var globex = new Customer(
+            Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
+            "Globex Corporation");
+        var handler = new ListCustomersHandler(new FakeCustomerRepository(acme, globex));
+
+        var results = await handler.HandleAsync(new ListCustomersQuery(), CancellationToken.None);
+
+        Assert.Collection(
+            results,
+            customer => Assert.Equal(
+                new CustomerSummaryDto(acme.Id, acme.Name),
+                customer),
+            customer => Assert.Equal(
+                new CustomerSummaryDto(globex.Id, globex.Name),
+                customer));
+    }
+}

--- a/tests/ContractIQ.Application.Tests/TestDoubles.cs
+++ b/tests/ContractIQ.Application.Tests/TestDoubles.cs
@@ -1,0 +1,125 @@
+using ContractIQ.Application.Abstractions.Persistence;
+using ContractIQ.Domain.Cancellations;
+using ContractIQ.Domain.Contracts;
+using ContractIQ.Domain.Customers;
+
+namespace ContractIQ.Application.Tests;
+
+internal sealed class FakeCustomerRepository(params Customer[] customers) : ICustomerRepository
+{
+    public Task<IReadOnlyList<Customer>> ListAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult<IReadOnlyList<Customer>>(customers);
+    }
+}
+
+internal sealed class FakeContractRepository(params Contract[] contracts) : IContractRepository
+{
+    private readonly IReadOnlyDictionary<Guid, Contract> _contracts =
+        contracts.ToDictionary(contract => contract.Id);
+
+    public int CallCount { get; private set; }
+
+    public Task<Contract?> GetByIdAsync(Guid contractId, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        CallCount++;
+        _contracts.TryGetValue(contractId, out var contract);
+        return Task.FromResult(contract);
+    }
+}
+
+internal sealed class FakeCancellationRequestStore : ICancellationRequestStore
+{
+    private readonly Dictionary<string, CancellationRequest> _requestsByKey =
+        new(StringComparer.Ordinal);
+
+    public IReadOnlyCollection<CancellationRequest> Requests => _requestsByKey.Values;
+
+    public int FindCallCount { get; private set; }
+
+    public int TryCreateCallCount { get; private set; }
+
+    public Task<CancellationRequest?> FindByIdempotencyKeyAsync(
+        string idempotencyKey,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        FindCallCount++;
+        _requestsByKey.TryGetValue(idempotencyKey, out var request);
+        return Task.FromResult(request);
+    }
+
+    public Task<CancellationRequestStoreResult> TryCreateAsync(
+        CancellationRequest request,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        TryCreateCallCount++;
+
+        if (_requestsByKey.TryGetValue(request.IdempotencyKey, out var replay))
+        {
+            var replayOutcome = replay.ContractId == request.ContractId
+                ? CancellationRequestStoreOutcome.Replayed
+                : CancellationRequestStoreOutcome.IdempotencyKeyConflict;
+
+            return Task.FromResult(new CancellationRequestStoreResult(replayOutcome, replay));
+        }
+
+        var openRequest = _requestsByKey.Values.FirstOrDefault(
+            candidate => candidate.ContractId == request.ContractId && candidate.IsOpen);
+
+        if (openRequest is not null)
+        {
+            return Task.FromResult(
+                new CancellationRequestStoreResult(
+                    CancellationRequestStoreOutcome.OpenRequestExists,
+                    openRequest));
+        }
+
+        _requestsByKey.Add(request.IdempotencyKey, request);
+        return Task.FromResult(
+            new CancellationRequestStoreResult(CancellationRequestStoreOutcome.Created, request));
+    }
+}
+
+internal sealed class MutableTimeProvider(
+    DateTimeOffset utcNow,
+    TimeZoneInfo? localTimeZone = null) : TimeProvider
+{
+    private DateTimeOffset _utcNow = utcNow;
+
+    public override TimeZoneInfo LocalTimeZone { get; } = localTimeZone ?? TimeZoneInfo.Utc;
+
+    public override DateTimeOffset GetUtcNow() => _utcNow;
+
+    public void Advance(TimeSpan duration) => _utcNow = _utcNow.Add(duration);
+}
+
+internal static class ApplicationTestData
+{
+    public static readonly Guid AcmeCustomerId =
+        Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+
+    public static readonly Guid AcmeContractId =
+        Guid.Parse("11111111-1111-1111-1111-111111111111");
+
+    public static readonly Guid GlobexContractId =
+        Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    public static Contract CreateContract(
+        Guid? id = null,
+        Guid? customerId = null,
+        ContractStatus status = ContractStatus.Active) =>
+        new(
+            id ?? AcmeContractId,
+            customerId ?? AcmeCustomerId,
+            new DateOnly(2026, 1, 1),
+            new Money(1_000m, "BRL"),
+            new TerminationTerms(
+                noticePeriodDays: 30,
+                minimumCommitmentEndDate: new DateOnly(2026, 12, 31),
+                earlyTerminationPenaltyRate: 0.25m),
+            status);
+}

--- a/tests/ContractIQ.IntegrationTests/ApiEndpointsTests.cs
+++ b/tests/ContractIQ.IntegrationTests/ApiEndpointsTests.cs
@@ -1,0 +1,377 @@
+using System.Net;
+using System.Text.Json;
+using ContractIQ.Infrastructure;
+using Xunit;
+
+namespace ContractIQ.IntegrationTests;
+
+public sealed class ApiEndpointsTests
+{
+    private static readonly DateTimeOffset FrozenUtc =
+        DateTimeOffset.Parse("2026-03-01T00:30:00Z");
+
+    [Fact]
+    public async Task Customers_endpoint_returns_the_ordered_demo_customers()
+    {
+        using var factory = CreateFactory();
+        using var client = factory.CreateClient();
+
+        using var response = await client.GetAsync("/api/v1/customers", CancellationToken.None);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        using JsonDocument document = await ReadJsonAsync(response);
+        JsonElement.ArrayEnumerator customers = document.RootElement.EnumerateArray();
+        Assert.Equal(
+            ["ACME Corporation", "Globex Corporation", "Initech"],
+            customers.Select(customer => customer.GetProperty("name").GetString()!).ToArray());
+    }
+
+    [Fact]
+    public async Task Contract_details_endpoint_returns_the_seeded_contract()
+    {
+        using var factory = CreateFactory();
+        using var client = factory.CreateClient();
+
+        using var response = await client.GetAsync(
+            $"/api/v1/contracts/{DemoDataIds.AcmeActiveContract}",
+            CancellationToken.None);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        using JsonDocument document = await ReadJsonAsync(response);
+        JsonElement contract = document.RootElement;
+        Assert.Equal(DemoDataIds.AcmeActiveContract, contract.GetProperty("id").GetGuid());
+        Assert.Equal(DemoDataIds.AcmeCustomer, contract.GetProperty("customerId").GetGuid());
+        Assert.Equal("active", contract.GetProperty("status").GetString());
+        Assert.Equal(1_200m, contract.GetProperty("monthlyFee").GetProperty("amount").GetDecimal());
+        Assert.Equal("USD", contract.GetProperty("monthlyFee").GetProperty("currency").GetString());
+        Assert.Equal(30, contract.GetProperty("noticePeriodDays").GetInt32());
+    }
+
+    [Fact]
+    public async Task Assessment_uses_the_frozen_UTC_date_and_domain_calculation()
+    {
+        var utcMinusEleven = TimeZoneInfo.CreateCustomTimeZone(
+            "UTC-11-integration-test",
+            TimeSpan.FromHours(-11),
+            "UTC-11 integration test",
+            "UTC-11 integration test");
+        using var factory = new ContractIqApiFactory(FrozenUtc, utcMinusEleven);
+        using var client = factory.CreateClient();
+
+        using var response = await client.GetAsync(
+            $"/api/v1/contracts/{DemoDataIds.AcmeActiveContract}/cancellation-assessment",
+            CancellationToken.None);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        using JsonDocument document = await ReadJsonAsync(response);
+        JsonElement assessment = document.RootElement;
+        Assert.True(assessment.GetProperty("isAllowed").GetBoolean());
+        Assert.Equal("allowed", assessment.GetProperty("reason").GetString());
+        Assert.Equal("2026-03-01", assessment.GetProperty("requestedOn").GetString());
+        Assert.Equal("2026-03-31", assessment.GetProperty("earliestTerminationDate").GetString());
+        Assert.Equal(22, assessment.GetProperty("chargeableMonthlyPeriods").GetInt32());
+        Assert.Equal(6_600m, assessment.GetProperty("penalty").GetProperty("amount").GetDecimal());
+        Assert.Equal("USD", assessment.GetProperty("penalty").GetProperty("currency").GetString());
+    }
+
+    [Theory]
+    [InlineData("cccccccc-cccc-4ccc-8ccc-cccccccccccc", "contractAlreadyCancelled")]
+    [InlineData("dddddddd-dddd-4ddd-8ddd-dddddddddddd", "contractExpired")]
+    public async Task Inactive_contract_assessment_returns_200_with_not_allowed_reason(
+        string contractId,
+        string expectedReason)
+    {
+        using var factory = CreateFactory();
+        using var client = factory.CreateClient();
+
+        using var response = await client.GetAsync(
+            $"/api/v1/contracts/{contractId}/cancellation-assessment",
+            CancellationToken.None);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        using JsonDocument document = await ReadJsonAsync(response);
+        Assert.False(document.RootElement.GetProperty("isAllowed").GetBoolean());
+        Assert.Equal(expectedReason, document.RootElement.GetProperty("reason").GetString());
+        Assert.Equal(0m, document.RootElement.GetProperty("penalty").GetProperty("amount").GetDecimal());
+    }
+
+    [Fact]
+    public async Task Creating_a_request_returns_201_with_a_pending_review_snapshot()
+    {
+        using var factory = CreateFactory();
+        using var client = factory.CreateClient();
+
+        using var response = await PostCancellationAsync(
+            client,
+            DemoDataIds.AcmeActiveContract,
+            "request-001");
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        using JsonDocument document = await ReadJsonAsync(response);
+        JsonElement request = document.RootElement;
+        Assert.NotEqual(Guid.Empty, request.GetProperty("id").GetGuid());
+        Assert.Equal(DemoDataIds.AcmeActiveContract, request.GetProperty("contractId").GetGuid());
+        Assert.Equal("2026-03-01T00:30:00+00:00", request.GetProperty("createdAtUtc").GetString());
+        Assert.Equal("2026-03-01", request.GetProperty("requestedOn").GetString());
+        Assert.Equal("2026-03-31", request.GetProperty("earliestTerminationDate").GetString());
+        Assert.Equal(6_600m, request.GetProperty("penalty").GetProperty("amount").GetDecimal());
+        Assert.Equal("pendingReview", request.GetProperty("status").GetString());
+    }
+
+    [Fact]
+    public async Task Replaying_the_same_key_returns_200_with_the_original_request()
+    {
+        using var factory = CreateFactory();
+        using var client = factory.CreateClient();
+
+        using var createdResponse = await PostCancellationAsync(
+            client,
+            DemoDataIds.AcmeActiveContract,
+            "request-001");
+        using JsonDocument created = await ReadJsonAsync(createdResponse);
+
+        using var replayResponse = await PostCancellationAsync(
+            client,
+            DemoDataIds.AcmeActiveContract,
+            "request-001");
+        using JsonDocument replay = await ReadJsonAsync(replayResponse);
+
+        Assert.Equal(HttpStatusCode.Created, createdResponse.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, replayResponse.StatusCode);
+        Assert.Equal(
+            created.RootElement.GetProperty("id").GetGuid(),
+            replay.RootElement.GetProperty("id").GetGuid());
+        Assert.Equal(created.RootElement.GetRawText(), replay.RootElement.GetRawText());
+    }
+
+    [Fact]
+    public async Task Reusing_a_key_for_another_contract_returns_idempotency_conflict()
+    {
+        using var factory = CreateFactory();
+        using var client = factory.CreateClient();
+
+        using var created = await PostCancellationAsync(
+            client,
+            DemoDataIds.AcmeActiveContract,
+            "shared-key");
+        Assert.Equal(HttpStatusCode.Created, created.StatusCode);
+
+        using var conflict = await PostCancellationAsync(
+            client,
+            DemoDataIds.GlobexActiveContract,
+            "shared-key");
+
+        await AssertProblemDetailsAsync(
+            conflict,
+            HttpStatusCode.Conflict,
+            "idempotency_key_conflict");
+    }
+
+    [Fact]
+    public async Task Different_key_for_an_open_request_returns_conflict()
+    {
+        using var factory = CreateFactory();
+        using var client = factory.CreateClient();
+
+        using var created = await PostCancellationAsync(
+            client,
+            DemoDataIds.AcmeActiveContract,
+            "request-001");
+        Assert.Equal(HttpStatusCode.Created, created.StatusCode);
+
+        using var conflict = await PostCancellationAsync(
+            client,
+            DemoDataIds.AcmeActiveContract,
+            "request-002");
+
+        await AssertProblemDetailsAsync(
+            conflict,
+            HttpStatusCode.Conflict,
+            "cancellation_request_already_open");
+    }
+
+    [Theory]
+    [InlineData("cccccccc-cccc-4ccc-8ccc-cccccccccccc")]
+    [InlineData("dddddddd-dddd-4ddd-8ddd-dddddddddddd")]
+    public async Task Creating_for_an_inactive_contract_returns_conflict(string contractId)
+    {
+        using var factory = CreateFactory();
+        using var client = factory.CreateClient();
+
+        using var response = await PostCancellationAsync(
+            client,
+            Guid.Parse(contractId),
+            "request-001");
+
+        await AssertProblemDetailsAsync(
+            response,
+            HttpStatusCode.Conflict,
+            "contract_not_cancellable");
+    }
+
+    [Theory]
+    [InlineData("details")]
+    [InlineData("assessment")]
+    public async Task Missing_contract_get_endpoints_return_problem_details(string endpoint)
+    {
+        var missingId = Guid.Parse("99999999-9999-4999-8999-999999999999");
+        string path = endpoint == "assessment"
+            ? $"/api/v1/contracts/{missingId}/cancellation-assessment"
+            : $"/api/v1/contracts/{missingId}";
+        using var factory = CreateFactory();
+        using var client = factory.CreateClient();
+
+        using var response = await client.GetAsync(path, CancellationToken.None);
+
+        await AssertProblemDetailsAsync(
+            response,
+            HttpStatusCode.NotFound,
+            "resource_not_found");
+    }
+
+    [Fact]
+    public async Task Creating_for_a_missing_contract_returns_problem_details()
+    {
+        using var factory = CreateFactory();
+        using var client = factory.CreateClient();
+        var missingId = Guid.Parse("99999999-9999-4999-8999-999999999999");
+
+        using var response = await PostCancellationAsync(client, missingId, "request-001");
+
+        await AssertProblemDetailsAsync(
+            response,
+            HttpStatusCode.NotFound,
+            "resource_not_found");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public async Task Missing_idempotency_key_returns_validation_problem_details(string? key)
+    {
+        using var factory = CreateFactory();
+        using var client = factory.CreateClient();
+
+        using var response = await PostCancellationAsync(
+            client,
+            DemoDataIds.AcmeActiveContract,
+            key);
+
+        await AssertProblemDetailsAsync(
+            response,
+            HttpStatusCode.BadRequest,
+            "validation_error",
+            "idempotencyKey");
+    }
+
+    [Fact]
+    public async Task Oversized_idempotency_key_returns_validation_problem_details()
+    {
+        using var factory = CreateFactory();
+        using var client = factory.CreateClient();
+
+        using var response = await PostCancellationAsync(
+            client,
+            DemoDataIds.AcmeActiveContract,
+            new string('a', 129));
+
+        await AssertProblemDetailsAsync(
+            response,
+            HttpStatusCode.BadRequest,
+            "validation_error",
+            "idempotencyKey");
+    }
+
+    [Fact]
+    public async Task OpenApi_describes_the_four_API_paths_and_required_idempotency_header()
+    {
+        using var factory = CreateFactory();
+        using var client = factory.CreateClient();
+
+        using var response = await client.GetAsync("/openapi/v1.json", CancellationToken.None);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        using JsonDocument document = await ReadJsonAsync(response);
+        JsonElement paths = document.RootElement.GetProperty("paths");
+        string[] expectedPaths =
+        [
+            "/api/v1/customers",
+            "/api/v1/contracts/{contractId}",
+            "/api/v1/contracts/{contractId}/cancellation-assessment",
+            "/api/v1/contracts/{contractId}/cancellation-requests",
+        ];
+
+        Assert.Equal(expectedPaths.Length, paths.EnumerateObject().Count());
+        foreach (string path in expectedPaths)
+        {
+            Assert.True(paths.TryGetProperty(path, out _), $"OpenAPI path '{path}' was not found.");
+        }
+
+        JsonElement post = paths
+            .GetProperty("/api/v1/contracts/{contractId}/cancellation-requests")
+            .GetProperty("post");
+        JsonElement idempotencyHeader = post
+            .GetProperty("parameters")
+            .EnumerateArray()
+            .Single(parameter =>
+                parameter.GetProperty("name").GetString() == "Idempotency-Key" &&
+                parameter.GetProperty("in").GetString() == "header");
+
+        Assert.True(
+            idempotencyHeader.TryGetProperty("required", out JsonElement required) &&
+            required.GetBoolean(),
+            "OpenAPI must mark the Idempotency-Key header as required.");
+    }
+
+    private static ContractIqApiFactory CreateFactory() => new(FrozenUtc);
+
+    private static async Task<HttpResponseMessage> PostCancellationAsync(
+        HttpClient client,
+        Guid contractId,
+        string? idempotencyKey)
+    {
+        using var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            $"/api/v1/contracts/{contractId}/cancellation-requests");
+
+        if (idempotencyKey is not null)
+        {
+            request.Headers.TryAddWithoutValidation("Idempotency-Key", idempotencyKey);
+        }
+
+        return await client.SendAsync(request, CancellationToken.None);
+    }
+
+    private static async Task<JsonDocument> ReadJsonAsync(HttpResponseMessage response)
+    {
+        Stream content = await response.Content.ReadAsStreamAsync(CancellationToken.None);
+        return await JsonDocument.ParseAsync(content, cancellationToken: CancellationToken.None);
+    }
+
+    private static async Task AssertProblemDetailsAsync(
+        HttpResponseMessage response,
+        HttpStatusCode expectedStatus,
+        string expectedCode,
+        string? expectedField = null)
+    {
+        Assert.Equal(expectedStatus, response.StatusCode);
+        Assert.Equal("application/problem+json", response.Content.Headers.ContentType?.MediaType);
+
+        using JsonDocument document = await ReadJsonAsync(response);
+        JsonElement problem = document.RootElement;
+        Assert.Equal((int)expectedStatus, problem.GetProperty("status").GetInt32());
+        Assert.False(string.IsNullOrWhiteSpace(problem.GetProperty("title").GetString()));
+        Assert.False(string.IsNullOrWhiteSpace(problem.GetProperty("detail").GetString()));
+        Assert.False(string.IsNullOrWhiteSpace(problem.GetProperty("instance").GetString()));
+        Assert.Equal(expectedCode, problem.GetProperty("code").GetString());
+        Assert.Equal(
+            $"urn:contractiq:error:{expectedCode}",
+            problem.GetProperty("type").GetString());
+        Assert.False(string.IsNullOrWhiteSpace(problem.GetProperty("traceId").GetString()));
+
+        if (expectedField is not null)
+        {
+            Assert.Equal(expectedField, problem.GetProperty("field").GetString());
+        }
+    }
+}

--- a/tests/ContractIQ.IntegrationTests/ContractIqApiFactory.cs
+++ b/tests/ContractIQ.IntegrationTests/ContractIqApiFactory.cs
@@ -1,0 +1,32 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+
+namespace ContractIQ.IntegrationTests;
+
+internal sealed class ContractIqApiFactory(
+    DateTimeOffset utcNow,
+    TimeZoneInfo? localTimeZone = null) : WebApplicationFactory<Program>
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment(Environments.Development);
+        builder.ConfigureServices(services =>
+        {
+            services.RemoveAll<TimeProvider>();
+            services.AddSingleton<TimeProvider>(
+                new FrozenTimeProvider(utcNow, localTimeZone ?? TimeZoneInfo.Utc));
+        });
+    }
+
+    private sealed class FrozenTimeProvider(
+        DateTimeOffset utcNow,
+        TimeZoneInfo localTimeZone) : TimeProvider
+    {
+        public override TimeZoneInfo LocalTimeZone => localTimeZone;
+
+        public override DateTimeOffset GetUtcNow() => utcNow.ToUniversalTime();
+    }
+}


### PR DESCRIPTION
## Summary

- adds focused CQRS queries for customers, contract details, and cancellation assessments
- adds an idempotent cancellation command that recalculates deterministic domain rules and creates a PendingReview request
- exposes versioned minimal API endpoints with RFC Problem Details and OpenAPI
- provides a thread-safe in-memory demo adapter with stable fictional data
- adds an executable ACME request collection and API documentation
- updates the repository and CI to the installed .NET SDK 10.0.400
- pins Microsoft.OpenApi to the patched 2.12.2 release

## Architecture notes

- AI remains outside the domain authority; a future agent tool will call the same command handler
- the API never accepts client-calculated penalty, dates, or status
- persistence is intentionally an adapter and will move to PostgreSQL in issue #6
- no MediatR or generic repository abstractions were introduced

## Validation

- `dotnet format ContractIQ.slnx --verify-no-changes --no-restore`
- `dotnet build ContractIQ.slnx --configuration Release --no-restore` (0 warnings, 0 errors)
- `dotnet test ContractIQ.slnx --configuration Release --no-build` (73 passed)
  - Application: 17
  - Domain: 37
  - Integration: 19

Closes #5