### PR TITLE
feat: build bilingual contract operations experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,16 @@ docker compose up -d postgres
 dotnet run --project src/ContractIQ.Api
 ```
 
+In a second terminal, start the React interface:
+
+```powershell
+Set-Location src/ContractIQ.Web
+npm ci
+npm run dev
+```
+
+Open the URL printed by Vite, normally `http://localhost:5173`. The interface supports English and Brazilian Portuguese and proxies its local API requests to the .NET process.
+
 The API applies committed migrations and idempotent fictional seed data during startup. The database port is bound to the local machine only. The committed credentials are fictional and intended exclusively for local development.
 
 See the [local development guide](docs/development.md) for first-time setup, frontend commands, database lifecycle, migrations, and troubleshooting.

--- a/docs/api/contract-operations.md
+++ b/docs/api/contract-operations.md
@@ -20,6 +20,7 @@ The seed operation is idempotent: restarting the API keeps cancellation requests
 | Method | Route | Purpose |
 | --- | --- | --- |
 | `GET` | `/api/v1/customers` | List the fictional customers. |
+| `GET` | `/api/v1/customers/{customerId}/contracts` | List the customer's structured contracts. |
 | `GET` | `/api/v1/contracts/{contractId}` | Read structured contract details. |
 | `GET` | `/api/v1/contracts/{contractId}/cancellation-assessment` | Calculate eligibility, termination date, and penalty using domain rules. |
 | `POST` | `/api/v1/contracts/{contractId}/cancellation-requests` | Recalculate the assessment and create a `PendingReview` request. |

--- a/docs/development.md
+++ b/docs/development.md
@@ -150,12 +150,14 @@ dotnet run --project src/ContractIQ.Api
 
 The API listens on `http://localhost:5186` by default. Use the executable request collection at `src/ContractIQ.Api/ContractIQ.Api.http` or see the [contract operation API guide](api/contract-operations.md) for the seeded demonstration flow.
 
+In a second terminal, start the React application:
+
 ```powershell
 Set-Location src/ContractIQ.Web
 npm run dev
 ```
 
-The Vite development server prints its local URL after startup.
+The Vite development server prints its local URL, normally `http://localhost:5173`. During local development, Vite proxies `/api` requests to the .NET API at `http://localhost:5186`, so both processes must remain running. The browser never needs the PostgreSQL credentials; only the API connects to the database.
 
 ## Formatting
 

--- a/src/ContractIQ.Api/ContractIQ.Api.http
+++ b/src/ContractIQ.Api/ContractIQ.Api.http
@@ -16,6 +16,10 @@ GET {{host}}/health/ready
 GET {{host}}/api/v1/customers
 Accept: application/json
 
+### List ACME's contracts
+GET {{host}}/api/v1/customers/11111111-1111-4111-8111-111111111111/contracts
+Accept: application/json
+
 ### Get ACME's structured contract data
 GET {{host}}/api/v1/contracts/{{acmeContractId}}
 Accept: application/json

--- a/src/ContractIQ.Api/Endpoints/ApiEndpoints.cs
+++ b/src/ContractIQ.Api/Endpoints/ApiEndpoints.cs
@@ -2,6 +2,7 @@ using System.ComponentModel.DataAnnotations;
 using ContractIQ.Application.Cancellations.CreateCancellationRequest;
 using ContractIQ.Application.Contracts.AssessCancellation;
 using ContractIQ.Application.Contracts.GetContractDetails;
+using ContractIQ.Application.Contracts.ListCustomerContracts;
 using ContractIQ.Application.Customers.ListCustomers;
 using Microsoft.AspNetCore.Mvc;
 
@@ -18,6 +19,12 @@ public static class ApiEndpoints
             .WithTags("Customers")
             .WithSummary("Lists customers available to the current user.")
             .Produces<CustomerSummaryDto[]>(StatusCodes.Status200OK);
+
+        api.MapGet("/customers/{customerId:guid}/contracts", ListCustomerContractsAsync)
+            .WithName("ListCustomerContracts")
+            .WithTags("Contracts")
+            .WithSummary("Lists the structured contracts for a customer.")
+            .Produces<ContractSummaryDto[]>(StatusCodes.Status200OK);
 
         api.MapGet("/contracts/{contractId:guid}", GetContractDetailsAsync)
             .WithName("GetContractDetails")
@@ -73,6 +80,18 @@ public static class ApiEndpoints
             cancellationToken);
 
         return Results.Ok(contract);
+    }
+
+    private static async Task<IResult> ListCustomerContractsAsync(
+        Guid customerId,
+        ListCustomerContractsHandler handler,
+        CancellationToken cancellationToken)
+    {
+        var contracts = await handler.HandleAsync(
+            new ListCustomerContractsQuery(customerId),
+            cancellationToken);
+
+        return Results.Ok(contracts);
     }
 
     private static async Task<IResult> AssessCancellationAsync(

--- a/src/ContractIQ.Api/Program.cs
+++ b/src/ContractIQ.Api/Program.cs
@@ -6,6 +6,7 @@ using ContractIQ.Api.Health;
 using ContractIQ.Application.Cancellations.CreateCancellationRequest;
 using ContractIQ.Application.Contracts.AssessCancellation;
 using ContractIQ.Application.Contracts.GetContractDetails;
+using ContractIQ.Application.Contracts.ListCustomerContracts;
 using ContractIQ.Application.Customers.ListCustomers;
 using ContractIQ.Infrastructure;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
@@ -24,6 +25,7 @@ builder.Services.ConfigureHttpJsonOptions(options =>
 builder.Services.AddSingleton(TimeProvider.System);
 builder.Services.AddScoped<ListCustomersHandler>();
 builder.Services.AddScoped<GetContractDetailsHandler>();
+builder.Services.AddScoped<ListCustomerContractsHandler>();
 builder.Services.AddScoped<AssessCancellationHandler>();
 builder.Services.AddScoped<CreateCancellationRequestHandler>();
 builder.Services.AddInfrastructure(builder.Configuration);

--- a/src/ContractIQ.Application/Abstractions/Persistence/IContractRepository.cs
+++ b/src/ContractIQ.Application/Abstractions/Persistence/IContractRepository.cs
@@ -5,4 +5,8 @@ namespace ContractIQ.Application.Abstractions.Persistence;
 public interface IContractRepository
 {
     Task<Contract?> GetByIdAsync(Guid contractId, CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<Contract>> ListByCustomerIdAsync(
+        Guid customerId,
+        CancellationToken cancellationToken);
 }

--- a/src/ContractIQ.Application/Contracts/ListCustomerContracts/ContractSummaryDto.cs
+++ b/src/ContractIQ.Application/Contracts/ListCustomerContracts/ContractSummaryDto.cs
@@ -1,0 +1,11 @@
+using ContractIQ.Application.Common.Models;
+using ContractIQ.Domain.Contracts;
+
+namespace ContractIQ.Application.Contracts.ListCustomerContracts;
+
+public sealed record ContractSummaryDto(
+    Guid Id,
+    Guid CustomerId,
+    DateOnly StartDate,
+    ContractStatus Status,
+    MoneyDto MonthlyFee);

--- a/src/ContractIQ.Application/Contracts/ListCustomerContracts/ListCustomerContractsHandler.cs
+++ b/src/ContractIQ.Application/Contracts/ListCustomerContracts/ListCustomerContractsHandler.cs
@@ -1,0 +1,27 @@
+using ContractIQ.Application.Abstractions.Persistence;
+using ContractIQ.Application.Common.Models;
+
+namespace ContractIQ.Application.Contracts.ListCustomerContracts;
+
+public sealed class ListCustomerContractsHandler(IContractRepository contracts)
+{
+    public async Task<IReadOnlyList<ContractSummaryDto>> HandleAsync(
+        ListCustomerContractsQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var customerContracts = await contracts.ListByCustomerIdAsync(
+            query.CustomerId,
+            cancellationToken);
+
+        return customerContracts
+            .Select(contract => new ContractSummaryDto(
+                contract.Id,
+                contract.CustomerId,
+                contract.StartDate,
+                contract.Status,
+                MoneyDto.FromDomain(contract.MonthlyFee)))
+            .ToArray();
+    }
+}

--- a/src/ContractIQ.Application/Contracts/ListCustomerContracts/ListCustomerContractsQuery.cs
+++ b/src/ContractIQ.Application/Contracts/ListCustomerContracts/ListCustomerContractsQuery.cs
@@ -1,0 +1,3 @@
+namespace ContractIQ.Application.Contracts.ListCustomerContracts;
+
+public sealed record ListCustomerContractsQuery(Guid CustomerId);

--- a/src/ContractIQ.Infrastructure/Persistence/PostgresContractRepository.cs
+++ b/src/ContractIQ.Infrastructure/Persistence/PostgresContractRepository.cs
@@ -19,6 +19,20 @@ internal sealed class PostgresContractRepository(ContractIqDbContext dbContext)
         return record is null ? null : ToDomain(record);
     }
 
+    public async Task<IReadOnlyList<Contract>> ListByCustomerIdAsync(
+        Guid customerId,
+        CancellationToken cancellationToken)
+    {
+        ContractRecord[] records = await dbContext.Contracts
+            .AsNoTracking()
+            .Where(contract => contract.CustomerId == customerId)
+            .OrderByDescending(contract => contract.StartDate)
+            .ThenBy(contract => contract.Id)
+            .ToArrayAsync(cancellationToken);
+
+        return records.Select(ToDomain).ToArray();
+    }
+
     private static Contract ToDomain(ContractRecord record) =>
         new(
             record.Id,

--- a/src/ContractIQ.Web/src/App.test.tsx
+++ b/src/ContractIQ.Web/src/App.test.tsx
@@ -1,31 +1,207 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { App } from './App'
 
+const customer = {
+  id: '11111111-1111-4111-8111-111111111111',
+  name: 'ACME Corporation',
+}
+
+const contract = {
+  id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+  customerId: customer.id,
+  startDate: '2026-01-01',
+  status: 'active',
+  monthlyFee: { amount: 1200, currency: 'USD' },
+}
+
+const contractDetails = {
+  ...contract,
+  noticePeriodDays: 30,
+  minimumCommitmentEndDate: '2028-01-01',
+  earlyTerminationPenaltyRate: 0.25,
+}
+
+const assessment = {
+  contractId: contract.id,
+  isAllowed: true,
+  reason: 'allowed',
+  requestedOn: '2026-08-28',
+  earliestTerminationDate: '2026-09-27',
+  chargeableMonthlyPeriods: 16,
+  penalty: { amount: 4800, currency: 'USD' },
+  hasPenalty: true,
+}
+
+function response(body: unknown, status = 200) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  } as Response)
+}
+
+function createApiMock() {
+  return vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+    const path = String(input)
+
+    if (path === '/api/v1/customers') {
+      return response([customer])
+    }
+
+    if (path === `/api/v1/customers/${customer.id}/contracts`) {
+      return response([contract])
+    }
+
+    if (path === `/api/v1/contracts/${contract.id}/cancellation-assessment`) {
+      return response(assessment)
+    }
+
+    if (path === `/api/v1/contracts/${contract.id}`) {
+      return response(contractDetails)
+    }
+
+    if (
+      path === `/api/v1/contracts/${contract.id}/cancellation-requests` &&
+      init?.method === 'POST'
+    ) {
+      return response(
+        {
+          id: 'dddddddd-dddd-4ddd-8ddd-dddddddddddd',
+          contractId: contract.id,
+          customerId: customer.id,
+          createdAtUtc: '2026-08-28T12:00:00Z',
+          requestedOn: assessment.requestedOn,
+          earliestTerminationDate: assessment.earliestTerminationDate,
+          penalty: assessment.penalty,
+          status: 'pendingReview',
+        },
+        201,
+      )
+    }
+
+    return response({ detail: 'Unexpected request' }, 404)
+  })
+}
+
 describe('App', () => {
-  it('shows the English experience by default', () => {
+  beforeEach(() => {
+    document.documentElement.lang = 'en'
+    vi.stubGlobal('fetch', createApiMock())
+  })
+
+  it('shows the English experience and switches to Brazilian Portuguese without a reload', async () => {
+    const user = userEvent.setup()
     render(<App />)
 
     expect(
       screen.getByRole('heading', {
-        name: 'Understand contracts. Act with confidence.',
+        name: 'Make contract decisions with confidence.',
       }),
     ).toBeInTheDocument()
-  })
-
-  it('switches the interface to Brazilian Portuguese', async () => {
-    const user = userEvent.setup()
-    render(<App />)
+    expect(
+      await screen.findByRole('button', { name: /ACME Corporation/ }),
+    ).toBeInTheDocument()
 
     await user.selectOptions(screen.getByRole('combobox'), 'pt-BR')
 
     expect(
       screen.getByRole('heading', {
-        name: 'Entenda contratos. Decida com confiança.',
+        name: 'Decida sobre contratos com confiança.',
       }),
     ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /ACME Corporation/ }),
+    ).toBeInTheDocument()
     expect(document.documentElement.lang).toBe('pt-BR')
+  })
+
+  it('completes the customer, assessment, confirmation, and success flow', async () => {
+    const user = userEvent.setup()
+    const fetchMock = createApiMock()
+    vi.stubGlobal('fetch', fetchMock)
+    render(<App />)
+
+    await user.click(
+      await screen.findByRole('button', { name: /ACME Corporation/ }),
+    )
+    await user.click(await screen.findByRole('button', { name: /AAAAAAAA/ }))
+
+    expect(
+      await screen.findByRole('heading', { name: 'Cancellation is available' }),
+    ).toBeInTheDocument()
+    expect(screen.getByText('$4,800.00')).toBeInTheDocument()
+
+    await user.click(
+      screen.getByRole('button', { name: 'Create cancellation request' }),
+    )
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Confirm request' }))
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Confirm that you reviewed the assessment',
+    )
+
+    await user.click(screen.getByRole('checkbox'))
+    await user.click(screen.getByRole('button', { name: 'Confirm request' }))
+
+    expect(await screen.findByText('Request created')).toBeInTheDocument()
+    expect(screen.getByText('Pending review')).toBeInTheDocument()
+
+    const postCall = fetchMock.mock.calls.find(
+      ([, init]) => init?.method === 'POST',
+    )
+    expect(postCall?.[1]?.headers).toEqual(
+      expect.objectContaining({ 'Idempotency-Key': expect.any(String) }),
+    )
+  })
+
+  it('shows an empty state when a customer has no contracts', async () => {
+    const user = userEvent.setup()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((input: RequestInfo | URL) =>
+        String(input).endsWith('/contracts')
+          ? response([])
+          : response([customer]),
+      ),
+    )
+    render(<App />)
+
+    await user.click(
+      await screen.findByRole('button', { name: /ACME Corporation/ }),
+    )
+
+    expect(
+      await screen.findByText('This customer has no contracts.'),
+    ).toBeInTheDocument()
+  })
+
+  it('shows a recoverable error when the API is unavailable', async () => {
+    const user = userEvent.setup()
+    let attempt = 0
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => {
+        attempt += 1
+        return attempt === 1
+          ? Promise.reject(new TypeError('Network error'))
+          : response([])
+      }),
+    )
+    render(<App />)
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'The API is unavailable',
+    )
+    await user.click(screen.getByRole('button', { name: 'Try again' }))
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('No customers are available.'),
+      ).toBeInTheDocument(),
+    )
   })
 })

--- a/src/ContractIQ.Web/src/App.tsx
+++ b/src/ContractIQ.Web/src/App.tsx
@@ -1,51 +1,228 @@
-import { useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 
-type Language = 'en' | 'pt-BR'
+import {
+  ApiError,
+  contractIqApi,
+  type CancellationAssessment,
+  type CancellationRequest,
+  type ContractDetails,
+  type ContractSummary,
+  type CustomerSummary,
+  type Money,
+} from './api'
+import { translations, type Language } from './translations'
 
-const content = {
-  en: {
-    languageLabel: 'Language',
-    eyebrow: 'Contract intelligence, grounded in evidence',
-    title: 'Understand contracts. Act with confidence.',
-    description:
-      'ContractIQ brings customer data, contract clauses, and internal policies together to answer questions with clear references.',
-    statusTitle: 'The workspace is being prepared',
-    statusDescription:
-      'Contract search, cancellation assessment, and guided actions will appear here as the project evolves.',
-    principleTitle: 'Built on a simple principle',
-    principleDescription:
-      'AI helps people understand and choose an action. Business rules remain deterministic and auditable.',
-  },
-  'pt-BR': {
-    languageLabel: 'Idioma',
-    eyebrow: 'Inteligência contratual baseada em evidências',
-    title: 'Entenda contratos. Decida com confiança.',
-    description:
-      'O ContractIQ reúne dados de clientes, cláusulas contratuais e políticas internas para responder perguntas com referências claras.',
-    statusTitle: 'O ambiente está sendo preparado',
-    statusDescription:
-      'Busca em contratos, análise de cancelamento e ações guiadas aparecerão aqui conforme o projeto evolui.',
-    principleTitle: 'Construído sobre um princípio simples',
-    principleDescription:
-      'A IA ajuda pessoas a entender e escolher uma ação. As regras de negócio continuam determinísticas e auditáveis.',
-  },
-} satisfies Record<Language, Record<string, string>>
+type Loadable<T> =
+  | { status: 'loading' }
+  | { status: 'error'; error: unknown }
+  | { status: 'ready'; data: T }
+
+type ContractWorkspace = {
+  details: ContractDetails
+  assessment: CancellationAssessment
+}
+
+const initialLoad = { status: 'loading' } as const
+
+function formatDate(value: string, language: Language) {
+  return new Intl.DateTimeFormat(language, {
+    dateStyle: 'medium',
+    timeZone: 'UTC',
+  }).format(new Date(`${value}T00:00:00Z`))
+}
+
+function formatMoney(money: Money, language: Language) {
+  return new Intl.NumberFormat(language, {
+    style: 'currency',
+    currency: money.currency,
+  }).format(money.amount)
+}
+
+function shortId(id: string) {
+  return id.slice(0, 8).toUpperCase()
+}
+
+function errorMessage(error: unknown, language: Language) {
+  const copy = translations[language]
+
+  if (error instanceof ApiError) {
+    if (error.status === 409) {
+      return copy.conflict
+    }
+
+    return error.status === 0 ? copy.apiUnavailable : copy.requestFailed
+  }
+
+  return copy.apiUnavailable
+}
 
 export function App() {
   const [language, setLanguage] = useState<Language>('en')
-  const copy = content[language]
+  const [customers, setCustomers] =
+    useState<Loadable<CustomerSummary[]>>(initialLoad)
+  const [customersReload, setCustomersReload] = useState(0)
+  const [selectedCustomerId, setSelectedCustomerId] = useState<string>()
+  const [contracts, setContracts] = useState<Loadable<
+    ContractSummary[]
+  > | null>(null)
+  const [contractsReload, setContractsReload] = useState(0)
+  const [selectedContractId, setSelectedContractId] = useState<string>()
+  const [workspace, setWorkspace] =
+    useState<Loadable<ContractWorkspace> | null>(null)
+  const [workspaceReload, setWorkspaceReload] = useState(0)
+  const [confirmationOpen, setConfirmationOpen] = useState(false)
+  const [assessmentConfirmed, setAssessmentConfirmed] = useState(false)
+  const [confirmationError, setConfirmationError] = useState<string>()
+  const [submitting, setSubmitting] = useState(false)
+  const [createdRequest, setCreatedRequest] = useState<CancellationRequest>()
+  const [idempotencyKey, setIdempotencyKey] = useState<string>()
+  const copy = translations[language]
+
+  const selectedCustomer = useMemo(
+    () =>
+      customers.status === 'ready'
+        ? customers.data.find((customer) => customer.id === selectedCustomerId)
+        : undefined,
+    [customers, selectedCustomerId],
+  )
+
+  useEffect(() => {
+    const controller = new AbortController()
+
+    contractIqApi
+      .listCustomers(controller.signal)
+      .then((data) => setCustomers({ status: 'ready', data }))
+      .catch((error: unknown) => {
+        if (!controller.signal.aborted) {
+          setCustomers({ status: 'error', error })
+        }
+      })
+
+    return () => controller.abort()
+  }, [customersReload])
+
+  useEffect(() => {
+    if (!selectedCustomerId) {
+      return
+    }
+
+    const controller = new AbortController()
+
+    contractIqApi
+      .listCustomerContracts(selectedCustomerId, controller.signal)
+      .then((data) => setContracts({ status: 'ready', data }))
+      .catch((error: unknown) => {
+        if (!controller.signal.aborted) {
+          setContracts({ status: 'error', error })
+        }
+      })
+
+    return () => controller.abort()
+  }, [selectedCustomerId, contractsReload])
+
+  useEffect(() => {
+    if (!selectedContractId) {
+      return
+    }
+
+    const controller = new AbortController()
+
+    Promise.all([
+      contractIqApi.getContract(selectedContractId, controller.signal),
+      contractIqApi.assessCancellation(selectedContractId, controller.signal),
+    ])
+      .then(([details, assessment]) =>
+        setWorkspace({ status: 'ready', data: { details, assessment } }),
+      )
+      .catch((error: unknown) => {
+        if (!controller.signal.aborted) {
+          setWorkspace({ status: 'error', error })
+        }
+      })
+
+    return () => controller.abort()
+  }, [selectedContractId, workspaceReload])
 
   function changeLanguage(nextLanguage: Language) {
     setLanguage(nextLanguage)
     document.documentElement.lang = nextLanguage
   }
 
+  function selectCustomer(customerId: string) {
+    setSelectedCustomerId(customerId)
+    setContracts(initialLoad)
+    setSelectedContractId(undefined)
+    setWorkspace(null)
+    setCreatedRequest(undefined)
+  }
+
+  function selectContract(contractId: string) {
+    setSelectedContractId(contractId)
+    setWorkspace(initialLoad)
+    setCreatedRequest(undefined)
+  }
+
+  function retryCustomers() {
+    setCustomers(initialLoad)
+    setCustomersReload((value) => value + 1)
+  }
+
+  function retryContracts() {
+    setContracts(initialLoad)
+    setContractsReload((value) => value + 1)
+  }
+
+  function retryWorkspace() {
+    setWorkspace(initialLoad)
+    setWorkspaceReload((value) => value + 1)
+  }
+
+  function openConfirmation() {
+    setAssessmentConfirmed(false)
+    setConfirmationError(undefined)
+    setIdempotencyKey(globalThis.crypto.randomUUID())
+    setConfirmationOpen(true)
+  }
+
+  function closeConfirmation() {
+    if (!submitting) {
+      setConfirmationOpen(false)
+    }
+  }
+
+  async function confirmCancellation() {
+    if (!assessmentConfirmed) {
+      setConfirmationError(copy.confirmationRequired)
+      return
+    }
+
+    if (!selectedContractId || !idempotencyKey) {
+      return
+    }
+
+    setSubmitting(true)
+    setConfirmationError(undefined)
+
+    try {
+      const request = await contractIqApi.createCancellationRequest(
+        selectedContractId,
+        idempotencyKey,
+      )
+      setCreatedRequest(request)
+      setConfirmationOpen(false)
+    } catch (error) {
+      setConfirmationError(errorMessage(error, language))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
   return (
     <div className="app-shell">
       <header className="topbar">
-        <a className="brand" href="#main-content" aria-label="ContractIQ home">
+        <a className="brand" href="#workspace" aria-label="ContractIQ home">
           <span className="brand-mark" aria-hidden="true">
-            CI
+            CQ
           </span>
           <span>ContractIQ</span>
         </a>
@@ -63,38 +240,393 @@ export function App() {
         </label>
       </header>
 
-      <main id="main-content">
-        <section className="hero" aria-labelledby="hero-title">
-          <div className="hero-copy">
-            <p className="eyebrow">{copy.eyebrow}</p>
-            <h1 id="hero-title">{copy.title}</h1>
-            <p className="hero-description">{copy.description}</p>
-          </div>
-
-          <div className="status-card">
-            <span className="status-indicator" aria-hidden="true" />
-            <div>
-              <h2>{copy.statusTitle}</h2>
-              <p>{copy.statusDescription}</p>
-            </div>
-          </div>
+      <main id="workspace">
+        <section className="page-intro" aria-labelledby="page-title">
+          <p className="eyebrow">{copy.productEyebrow}</p>
+          <h1 id="page-title">{copy.title}</h1>
+          <p>{copy.description}</p>
         </section>
 
-        <section className="principle-card" aria-labelledby="principle-title">
-          <p className="principle-number" aria-hidden="true">
-            01
-          </p>
-          <div>
-            <h2 id="principle-title">{copy.principleTitle}</h2>
-            <p>{copy.principleDescription}</p>
+        <section className="operations-layout" aria-label={copy.productEyebrow}>
+          <aside className="customer-panel">
+            <div className="panel-heading">
+              <p className="step-number">01</p>
+              <div>
+                <h2>{copy.customers}</h2>
+                <p>{copy.customersDescription}</p>
+              </div>
+            </div>
+
+            {customers.status === 'loading' && (
+              <p className="state-message" role="status">
+                {copy.loadingCustomers}
+              </p>
+            )}
+
+            {customers.status === 'error' && (
+              <ErrorState
+                message={errorMessage(customers.error, language)}
+                retryLabel={copy.retry}
+                onRetry={retryCustomers}
+              />
+            )}
+
+            {customers.status === 'ready' && customers.data.length === 0 && (
+              <p className="state-message">{copy.noCustomers}</p>
+            )}
+
+            {customers.status === 'ready' && customers.data.length > 0 && (
+              <div className="customer-list">
+                {customers.data.map((customer) => (
+                  <button
+                    className="customer-button"
+                    data-selected={customer.id === selectedCustomerId}
+                    key={customer.id}
+                    onClick={() => selectCustomer(customer.id)}
+                    type="button"
+                  >
+                    <span className="customer-avatar" aria-hidden="true">
+                      {customer.name.slice(0, 2).toUpperCase()}
+                    </span>
+                    <span>
+                      <strong>{customer.name}</strong>
+                      <small>{shortId(customer.id)}</small>
+                    </span>
+                    <span className="chevron" aria-hidden="true">
+                      →
+                    </span>
+                  </button>
+                ))}
+              </div>
+            )}
+          </aside>
+
+          <div className="contract-panel">
+            {!selectedCustomer && (
+              <EmptyState
+                title={copy.chooseCustomer}
+                description={copy.chooseCustomerDescription}
+              />
+            )}
+
+            {selectedCustomer && (
+              <>
+                <div className="contract-panel-header">
+                  <div>
+                    <p className="step-number">02</p>
+                    <h2>{selectedCustomer.name}</h2>
+                  </div>
+                  <span>{copy.contracts}</span>
+                </div>
+
+                {contracts?.status === 'loading' && (
+                  <p className="state-message" role="status">
+                    {copy.loadingContracts}
+                  </p>
+                )}
+
+                {contracts?.status === 'error' && (
+                  <ErrorState
+                    message={errorMessage(contracts.error, language)}
+                    retryLabel={copy.retry}
+                    onRetry={retryContracts}
+                  />
+                )}
+
+                {contracts?.status === 'ready' &&
+                  contracts.data.length === 0 && (
+                    <EmptyState title={copy.noContracts} />
+                  )}
+
+                {contracts?.status === 'ready' && contracts.data.length > 0 && (
+                  <>
+                    <div className="contract-tabs" aria-label={copy.contracts}>
+                      {contracts.data.map((contract) => (
+                        <button
+                          type="button"
+                          key={contract.id}
+                          data-selected={contract.id === selectedContractId}
+                          onClick={() => selectContract(contract.id)}
+                        >
+                          <span>
+                            {copy.contract} {shortId(contract.id)}
+                          </span>
+                          <StatusBadge
+                            label={copy.statusLabels[contract.status]}
+                            status={contract.status}
+                          />
+                        </button>
+                      ))}
+                    </div>
+
+                    {!selectedContractId && (
+                      <EmptyState title={copy.chooseContract} compact />
+                    )}
+                  </>
+                )}
+
+                {workspace?.status === 'loading' && (
+                  <p className="state-message workspace-loading" role="status">
+                    {copy.loadingAssessment}
+                  </p>
+                )}
+
+                {workspace?.status === 'error' && (
+                  <ErrorState
+                    message={errorMessage(workspace.error, language)}
+                    retryLabel={copy.retry}
+                    onRetry={retryWorkspace}
+                  />
+                )}
+
+                {workspace?.status === 'ready' && (
+                  <ContractWorkspaceView
+                    assessment={workspace.data.assessment}
+                    contract={workspace.data.details}
+                    createdRequest={createdRequest}
+                    language={language}
+                    onCreateRequest={openConfirmation}
+                  />
+                )}
+              </>
+            )}
           </div>
         </section>
       </main>
 
       <footer>
         <span>ContractIQ</span>
-        <span>DDD · CQRS · RAG</span>
+        <span>{copy.footerPrinciple}</span>
       </footer>
+
+      {confirmationOpen && workspace?.status === 'ready' && (
+        <div className="dialog-backdrop" onMouseDown={closeConfirmation}>
+          <section
+            aria-labelledby="confirmation-title"
+            aria-modal="true"
+            className="confirmation-dialog"
+            onMouseDown={(event) => event.stopPropagation()}
+            role="dialog"
+          >
+            <p className="step-number">03</p>
+            <h2 id="confirmation-title">{copy.confirmationTitle}</h2>
+            <p>{copy.confirmationDescription}</p>
+
+            <div className="confirmation-summary">
+              <span>{copy.earliestTermination}</span>
+              <strong>
+                {formatDate(
+                  workspace.data.assessment.earliestTerminationDate,
+                  language,
+                )}
+              </strong>
+              <span>{copy.estimatedPenalty}</span>
+              <strong>
+                {formatMoney(workspace.data.assessment.penalty, language)}
+              </strong>
+            </div>
+
+            <label className="confirmation-check">
+              <input
+                checked={assessmentConfirmed}
+                onChange={(event) => {
+                  setAssessmentConfirmed(event.target.checked)
+                  setConfirmationError(undefined)
+                }}
+                type="checkbox"
+              />
+              <span>{copy.confirmationCheck}</span>
+            </label>
+
+            {confirmationError && (
+              <p className="inline-error" role="alert">
+                {confirmationError}
+              </p>
+            )}
+
+            <div className="dialog-actions">
+              <button
+                className="secondary-button"
+                disabled={submitting}
+                onClick={closeConfirmation}
+                type="button"
+              >
+                {copy.cancel}
+              </button>
+              <button
+                className="primary-button"
+                disabled={submitting}
+                onClick={confirmCancellation}
+                type="button"
+              >
+                {submitting ? copy.creating : copy.confirm}
+              </button>
+            </div>
+          </section>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function ContractWorkspaceView({
+  assessment,
+  contract,
+  createdRequest,
+  language,
+  onCreateRequest,
+}: {
+  assessment: CancellationAssessment
+  contract: ContractDetails
+  createdRequest?: CancellationRequest
+  language: Language
+  onCreateRequest: () => void
+}) {
+  const copy = translations[language]
+
+  return (
+    <div className="workspace-grid">
+      <article className="detail-card">
+        <div className="card-heading">
+          <h3>{copy.contractDetails}</h3>
+          <StatusBadge
+            label={copy.statusLabels[contract.status]}
+            status={contract.status}
+          />
+        </div>
+        <dl className="detail-list">
+          <Detail
+            label={copy.monthlyFee}
+            value={formatMoney(contract.monthlyFee, language)}
+          />
+          <Detail
+            label={copy.startDate}
+            value={formatDate(contract.startDate, language)}
+          />
+          <Detail
+            label={copy.commitmentEnd}
+            value={formatDate(contract.minimumCommitmentEndDate, language)}
+          />
+          <Detail
+            label={copy.noticePeriod}
+            value={`${contract.noticePeriodDays} ${copy.days}`}
+          />
+          <Detail
+            label={copy.earlyTerminationRate}
+            value={new Intl.NumberFormat(language, { style: 'percent' }).format(
+              contract.earlyTerminationPenaltyRate,
+            )}
+          />
+        </dl>
+      </article>
+
+      <article className="assessment-card" data-allowed={assessment.isAllowed}>
+        <p className="assessment-label">{copy.assessment}</p>
+        <h3>{assessment.isAllowed ? copy.eligible : copy.notEligible}</h3>
+        <p>{copy.reasonLabels[assessment.reason]}</p>
+
+        <dl className="assessment-values">
+          <Detail
+            label={copy.earliestTermination}
+            value={formatDate(assessment.earliestTerminationDate, language)}
+          />
+          <Detail
+            label={copy.remainingPeriods}
+            value={String(assessment.chargeableMonthlyPeriods)}
+          />
+          <Detail
+            label={copy.estimatedPenalty}
+            value={
+              assessment.hasPenalty
+                ? formatMoney(assessment.penalty, language)
+                : copy.noPenalty
+            }
+          />
+        </dl>
+
+        {assessment.isAllowed && !createdRequest && (
+          <button
+            className="primary-button full-width"
+            onClick={onCreateRequest}
+            type="button"
+          >
+            {copy.createRequest}
+          </button>
+        )}
+
+        {createdRequest && (
+          <div className="success-message" role="status">
+            <span className="success-icon" aria-hidden="true">
+              ✓
+            </span>
+            <div>
+              <strong>{copy.successTitle}</strong>
+              <p>{copy.successDescription}</p>
+              <dl>
+                <Detail
+                  label={copy.requestId}
+                  value={shortId(createdRequest.id)}
+                />
+                <Detail label={copy.status} value={copy.pendingReview} />
+              </dl>
+            </div>
+          </div>
+        )}
+      </article>
+    </div>
+  )
+}
+
+function Detail({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <dt>{label}</dt>
+      <dd>{value}</dd>
+    </div>
+  )
+}
+
+function StatusBadge({ label, status }: { label: string; status: string }) {
+  return (
+    <span className="status-badge" data-status={status}>
+      {label}
+    </span>
+  )
+}
+
+function EmptyState({
+  title,
+  description,
+  compact = false,
+}: {
+  title: string
+  description?: string
+  compact?: boolean
+}) {
+  return (
+    <div className="empty-state" data-compact={compact}>
+      <span aria-hidden="true">⌁</span>
+      <h3>{title}</h3>
+      {description && <p>{description}</p>}
+    </div>
+  )
+}
+
+function ErrorState({
+  message,
+  retryLabel,
+  onRetry,
+}: {
+  message: string
+  retryLabel: string
+  onRetry: () => void
+}) {
+  return (
+    <div className="error-state" role="alert">
+      <strong>{message}</strong>
+      <button className="text-button" onClick={onRetry} type="button">
+        {retryLabel}
+      </button>
     </div>
   )
 }

--- a/src/ContractIQ.Web/src/api.ts
+++ b/src/ContractIQ.Web/src/api.ts
@@ -1,0 +1,143 @@
+export type Money = {
+  amount: number
+  currency: string
+}
+
+export type CustomerSummary = {
+  id: string
+  name: string
+}
+
+export type ContractStatus = 'active' | 'cancelled' | 'expired'
+
+export type ContractSummary = {
+  id: string
+  customerId: string
+  startDate: string
+  status: ContractStatus
+  monthlyFee: Money
+}
+
+export type ContractDetails = ContractSummary & {
+  noticePeriodDays: number
+  minimumCommitmentEndDate: string
+  earlyTerminationPenaltyRate: number
+}
+
+export type AssessmentReason =
+  'allowed' | 'contractAlreadyCancelled' | 'contractExpired'
+
+export type CancellationAssessment = {
+  contractId: string
+  isAllowed: boolean
+  reason: AssessmentReason
+  requestedOn: string
+  earliestTerminationDate: string
+  chargeableMonthlyPeriods: number
+  penalty: Money
+  hasPenalty: boolean
+}
+
+export type CancellationRequest = {
+  id: string
+  contractId: string
+  customerId: string
+  createdAtUtc: string
+  requestedOn: string
+  earliestTerminationDate: string
+  penalty: Money
+  status: 'pendingReview'
+}
+
+type ProblemDetails = {
+  detail?: string
+  code?: string
+  traceId?: string
+}
+
+export class ApiError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly code?: string,
+    public readonly traceId?: string,
+    detail?: string,
+  ) {
+    super(detail || 'The request could not be completed.')
+    this.name = 'ApiError'
+  }
+}
+
+async function request<T>(path: string, init?: RequestInit): Promise<T> {
+  let response: Response
+
+  try {
+    response = await fetch(path, {
+      ...init,
+      headers: {
+        Accept: 'application/json',
+        ...init?.headers,
+      },
+    })
+  } catch {
+    throw new ApiError(0)
+  }
+
+  if (!response.ok) {
+    let problem: ProblemDetails = {}
+
+    try {
+      problem = (await response.json()) as ProblemDetails
+    } catch {
+      // A proxy or network boundary may return a non-JSON response.
+    }
+
+    throw new ApiError(
+      response.status,
+      problem.code,
+      problem.traceId,
+      problem.detail,
+    )
+  }
+
+  return (await response.json()) as T
+}
+
+export const contractIqApi = {
+  listCustomers(signal?: AbortSignal) {
+    return request<CustomerSummary[]>('/api/v1/customers', { signal })
+  },
+
+  listCustomerContracts(customerId: string, signal?: AbortSignal) {
+    return request<ContractSummary[]>(
+      `/api/v1/customers/${customerId}/contracts`,
+      {
+        signal,
+      },
+    )
+  },
+
+  getContract(contractId: string, signal?: AbortSignal) {
+    return request<ContractDetails>(`/api/v1/contracts/${contractId}`, {
+      signal,
+    })
+  },
+
+  assessCancellation(contractId: string, signal?: AbortSignal) {
+    return request<CancellationAssessment>(
+      `/api/v1/contracts/${contractId}/cancellation-assessment`,
+      { signal },
+    )
+  },
+
+  createCancellationRequest(contractId: string, idempotencyKey: string) {
+    return request<CancellationRequest>(
+      `/api/v1/contracts/${contractId}/cancellation-requests`,
+      {
+        method: 'POST',
+        headers: {
+          'Idempotency-Key': idempotencyKey,
+        },
+      },
+    )
+  },
+}

--- a/src/ContractIQ.Web/src/styles.css
+++ b/src/ContractIQ.Web/src/styles.css
@@ -1,9 +1,7 @@
-@import url('https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&family=Manrope:wght@500;600;700&display=swap');
-
 :root {
-  font-family: 'DM Sans', system-ui, sans-serif;
-  color: #17251f;
-  background: #f4f5ef;
+  font-family: Aptos, 'Segoe UI', system-ui, sans-serif;
+  color: #17231e;
+  background: #f2f3ef;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
 }
@@ -19,12 +17,39 @@ body {
 }
 
 button,
-select {
+select,
+input {
   font: inherit;
 }
 
+button,
+select {
+  transition:
+    border-color 160ms ease,
+    background-color 160ms ease,
+    color 160ms ease,
+    transform 160ms ease;
+}
+
+button:focus-visible,
+select:focus-visible,
+input:focus-visible,
+a:focus-visible {
+  outline: 3px solid rgb(31 111 78 / 25%);
+  outline-offset: 3px;
+}
+
+h1,
+h2,
+h3,
+p,
+dl,
+dd {
+  margin-top: 0;
+}
+
 .app-shell {
-  width: min(1180px, calc(100% - 40px));
+  width: min(1240px, calc(100% - 48px));
   min-height: 100vh;
   margin: 0 auto;
   display: flex;
@@ -32,12 +57,12 @@ select {
 }
 
 .topbar {
-  min-height: 88px;
+  min-height: 80px;
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 24px;
-  border-bottom: 1px solid #cad1c7;
+  border-bottom: 1px solid #cfd5ce;
 }
 
 .brand {
@@ -45,9 +70,9 @@ select {
   align-items: center;
   gap: 12px;
   color: inherit;
-  font-family: 'Manrope', sans-serif;
-  font-size: 1.1rem;
-  font-weight: 700;
+  font-size: 1.05rem;
+  font-weight: 750;
+  letter-spacing: -0.02em;
   text-decoration: none;
 }
 
@@ -56,10 +81,10 @@ select {
   height: 38px;
   display: grid;
   place-items: center;
-  color: #eff8f1;
-  background: #174e3a;
-  border-radius: 10px;
-  font-size: 0.77rem;
+  color: #f7fbf8;
+  background: #15523b;
+  border-radius: 11px;
+  font-size: 0.72rem;
   letter-spacing: 0.08em;
 }
 
@@ -67,146 +92,608 @@ select {
   display: flex;
   align-items: center;
   gap: 10px;
-  color: #526159;
-  font-size: 0.85rem;
-  font-weight: 600;
+  color: #5f6d65;
+  font-size: 0.82rem;
+  font-weight: 650;
 }
 
 .language-picker select {
   min-height: 40px;
   padding: 0 34px 0 12px;
-  color: #17251f;
+  color: #17231e;
   background: #fff;
-  border: 1px solid #bdc8bf;
-  border-radius: 8px;
+  border: 1px solid #bdc7bf;
+  border-radius: 9px;
 }
 
 main {
   flex: 1;
-  padding: 88px 0 64px;
+  padding: 64px 0 72px;
 }
 
-.hero {
-  display: grid;
-  grid-template-columns: minmax(0, 1.5fr) minmax(300px, 0.75fr);
-  align-items: end;
-  gap: 80px;
+.page-intro {
+  max-width: 780px;
+  margin-bottom: 48px;
 }
 
-.hero-copy {
-  max-width: 760px;
-}
-
-.eyebrow {
-  margin: 0 0 20px;
-  color: #1a6b4b;
-  font-size: 0.78rem;
-  font-weight: 700;
+.eyebrow,
+.step-number,
+.assessment-label {
+  margin-bottom: 12px;
+  color: #18704d;
+  font-size: 0.72rem;
+  font-weight: 750;
   letter-spacing: 0.12em;
   text-transform: uppercase;
 }
 
-h1,
-h2,
-p {
-  margin-top: 0;
-}
-
-h1,
-h2 {
-  font-family: 'Manrope', sans-serif;
-}
-
-h1 {
-  max-width: 720px;
-  margin-bottom: 28px;
-  font-size: clamp(3rem, 7vw, 6.25rem);
-  line-height: 0.98;
+.page-intro h1 {
+  max-width: 760px;
+  margin-bottom: 18px;
+  font-size: clamp(2.5rem, 5vw, 4.8rem);
+  line-height: 1;
   letter-spacing: -0.055em;
 }
 
-.hero-description {
-  max-width: 650px;
+.page-intro > p:last-child {
+  max-width: 680px;
   margin-bottom: 0;
-  color: #59665f;
-  font-size: clamp(1rem, 1.5vw, 1.2rem);
+  color: #5d6b63;
+  font-size: 1.06rem;
   line-height: 1.65;
 }
 
-.status-card {
-  padding: 28px;
-  display: flex;
-  gap: 16px;
-  background: #e3eadf;
-  border-radius: 16px;
-}
-
-.status-indicator {
-  width: 10px;
-  height: 10px;
-  margin-top: 7px;
-  flex: 0 0 auto;
-  background: #e09f3e;
-  border-radius: 50%;
-  box-shadow: 0 0 0 5px rgb(224 159 62 / 18%);
-}
-
-.status-card h2,
-.principle-card h2 {
-  margin-bottom: 10px;
-  font-size: 1rem;
-}
-
-.status-card p,
-.principle-card p {
-  margin-bottom: 0;
-  color: #526159;
-  font-size: 0.92rem;
-  line-height: 1.6;
-}
-
-.principle-card {
-  margin-top: 96px;
-  padding: 32px 0 0;
+.operations-layout {
   display: grid;
-  grid-template-columns: 72px minmax(0, 560px);
-  gap: 20px;
-  border-top: 1px solid #cad1c7;
+  grid-template-columns: minmax(250px, 0.32fr) minmax(0, 1fr);
+  overflow: hidden;
+  background: #fff;
+  border: 1px solid #d7ddd7;
+  border-radius: 20px;
+  box-shadow: 0 20px 55px rgb(31 48 39 / 7%);
 }
 
-.principle-card .principle-number {
-  color: #1a6b4b;
-  font-family: 'Manrope', sans-serif;
+.customer-panel {
+  min-height: 620px;
+  padding: 28px 20px;
+  background: #f8f9f6;
+  border-right: 1px solid #dfe4df;
+}
+
+.panel-heading {
+  padding: 0 8px 22px;
+  display: grid;
+  grid-template-columns: 30px 1fr;
+  gap: 4px;
+  border-bottom: 1px solid #dfe4df;
+}
+
+.panel-heading h2,
+.contract-panel-header h2 {
+  margin-bottom: 6px;
+  font-size: 1.05rem;
+  letter-spacing: -0.02em;
+}
+
+.panel-heading p:last-child {
+  margin-bottom: 0;
+  color: #66736b;
+  font-size: 0.82rem;
+  line-height: 1.5;
+}
+
+.customer-list {
+  padding-top: 14px;
+  display: grid;
+  gap: 6px;
+}
+
+.customer-button {
+  width: 100%;
+  min-height: 68px;
+  padding: 10px;
+  display: grid;
+  grid-template-columns: 38px 1fr auto;
+  align-items: center;
+  gap: 11px;
+  color: #243129;
+  text-align: left;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 12px;
+  cursor: pointer;
+}
+
+.customer-button:hover {
+  background: #eef2ed;
+}
+
+.customer-button[data-selected='true'] {
+  background: #e2eee7;
+  border-color: #b5d1c0;
+}
+
+.customer-avatar {
+  width: 38px;
+  height: 38px;
+  display: grid;
+  place-items: center;
+  color: #276348;
+  background: #dce9e1;
+  border-radius: 10px;
+  font-size: 0.72rem;
+  font-weight: 750;
+}
+
+.customer-button strong,
+.customer-button small {
+  display: block;
+}
+
+.customer-button strong {
+  margin-bottom: 4px;
+  font-size: 0.88rem;
+}
+
+.customer-button small {
+  color: #78847d;
+  font-size: 0.68rem;
+  letter-spacing: 0.06em;
+}
+
+.chevron {
+  color: #6e7d74;
+}
+
+.contract-panel {
+  min-width: 0;
+  min-height: 620px;
+  padding: 30px;
+}
+
+.contract-panel-header {
+  min-height: 56px;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+}
+
+.contract-panel-header .step-number {
+  margin-bottom: 5px;
+}
+
+.contract-panel-header > span {
+  padding-top: 20px;
+  color: #7a877f;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.contract-tabs {
+  margin: 22px 0 28px;
+  padding-bottom: 12px;
+  display: flex;
+  gap: 10px;
+  overflow-x: auto;
+  border-bottom: 1px solid #e4e8e4;
+}
+
+.contract-tabs button {
+  min-width: 180px;
+  padding: 12px 14px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  color: #526058;
+  white-space: nowrap;
+  background: #f7f8f5;
+  border: 1px solid #dde2dd;
+  border-radius: 10px;
+  cursor: pointer;
   font-size: 0.8rem;
   font-weight: 700;
 }
 
+.contract-tabs button:hover,
+.contract-tabs button[data-selected='true'] {
+  color: #174e39;
+  background: #eaf2ed;
+  border-color: #a9cab6;
+}
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 8px;
+  color: #536158;
+  background: #e8ece8;
+  border-radius: 999px;
+  font-size: 0.66rem;
+  font-weight: 750;
+}
+
+.status-badge[data-status='active'] {
+  color: #17633f;
+  background: #dcefe4;
+}
+
+.status-badge[data-status='cancelled'],
+.status-badge[data-status='expired'] {
+  color: #7b473e;
+  background: #f3e4e0;
+}
+
+.empty-state {
+  min-height: 420px;
+  display: grid;
+  place-content: center;
+  justify-items: center;
+  color: #78847d;
+  text-align: center;
+}
+
+.empty-state[data-compact='true'] {
+  min-height: 300px;
+}
+
+.empty-state > span {
+  width: 52px;
+  height: 52px;
+  margin-bottom: 16px;
+  display: grid;
+  place-items: center;
+  color: #2a6a4d;
+  background: #e5eee8;
+  border-radius: 50%;
+  font-size: 1.5rem;
+}
+
+.empty-state h3 {
+  margin-bottom: 8px;
+  color: #35443b;
+  font-size: 1rem;
+}
+
+.empty-state p {
+  margin-bottom: 0;
+  font-size: 0.86rem;
+}
+
+.state-message {
+  padding: 28px 8px;
+  color: #6b786f;
+  font-size: 0.86rem;
+}
+
+.workspace-loading {
+  min-height: 260px;
+  display: grid;
+  place-items: center;
+}
+
+.workspace-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 0.92fr) minmax(310px, 1.08fr);
+  gap: 18px;
+}
+
+.detail-card,
+.assessment-card {
+  padding: 24px;
+  border: 1px solid #dfe5df;
+  border-radius: 15px;
+}
+
+.detail-card {
+  background: #fbfcfa;
+}
+
+.assessment-card {
+  background: #f8f5ed;
+  border-color: #e5dccb;
+}
+
+.assessment-card[data-allowed='false'] {
+  background: #f8f1ef;
+  border-color: #ead8d2;
+}
+
+.card-heading {
+  margin-bottom: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.card-heading h3,
+.assessment-card h3 {
+  margin-bottom: 0;
+  font-size: 1.08rem;
+  letter-spacing: -0.02em;
+}
+
+.assessment-card h3 {
+  margin-bottom: 10px;
+  font-size: 1.35rem;
+}
+
+.assessment-card > p:not(.assessment-label) {
+  color: #68736c;
+  font-size: 0.88rem;
+  line-height: 1.55;
+}
+
+.detail-list,
+.assessment-values {
+  margin-bottom: 0;
+  display: grid;
+  gap: 17px;
+}
+
+.detail-list > div,
+.assessment-values > div {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 18px;
+  border-bottom: 1px solid #e5e8e4;
+}
+
+.detail-list dt,
+.assessment-values dt {
+  padding-bottom: 11px;
+  color: #6b776f;
+  font-size: 0.78rem;
+}
+
+.detail-list dd,
+.assessment-values dd {
+  margin-bottom: 0;
+  padding-bottom: 11px;
+  color: #26352c;
+  text-align: right;
+  font-size: 0.86rem;
+  font-weight: 700;
+}
+
+.assessment-values {
+  margin: 24px 0;
+}
+
+.primary-button,
+.secondary-button,
+.text-button {
+  min-height: 42px;
+  border-radius: 9px;
+  cursor: pointer;
+  font-weight: 700;
+}
+
+.primary-button {
+  padding: 0 18px;
+  color: #fff;
+  background: #176543;
+  border: 1px solid #176543;
+}
+
+.primary-button:hover:not(:disabled) {
+  background: #104d33;
+  transform: translateY(-1px);
+}
+
+.primary-button:disabled,
+.secondary-button:disabled {
+  cursor: wait;
+  opacity: 0.65;
+}
+
+.full-width {
+  width: 100%;
+}
+
+.secondary-button {
+  padding: 0 18px;
+  color: #334139;
+  background: #fff;
+  border: 1px solid #c7d0c9;
+}
+
+.text-button {
+  min-height: auto;
+  padding: 0;
+  color: #176543;
+  background: transparent;
+  border: 0;
+}
+
+.error-state {
+  margin: 22px 0;
+  padding: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  color: #844a40;
+  background: #faefec;
+  border: 1px solid #efd7d1;
+  border-radius: 11px;
+  font-size: 0.82rem;
+}
+
+.dialog-backdrop {
+  position: fixed;
+  z-index: 10;
+  inset: 0;
+  padding: 24px;
+  display: grid;
+  place-items: center;
+  background: rgb(20 30 25 / 52%);
+  backdrop-filter: blur(4px);
+}
+
+.confirmation-dialog {
+  width: min(520px, 100%);
+  max-height: calc(100vh - 48px);
+  padding: 30px;
+  overflow-y: auto;
+  background: #fff;
+  border-radius: 18px;
+  box-shadow: 0 28px 90px rgb(12 22 17 / 30%);
+}
+
+.confirmation-dialog h2 {
+  margin-bottom: 12px;
+  font-size: 1.55rem;
+  letter-spacing: -0.035em;
+}
+
+.confirmation-dialog > p:not(.step-number, .inline-error) {
+  color: #66736b;
+  line-height: 1.55;
+}
+
+.confirmation-summary {
+  margin: 22px 0;
+  padding: 18px;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 12px 20px;
+  background: #f2f5f1;
+  border-radius: 11px;
+  font-size: 0.84rem;
+}
+
+.confirmation-summary span {
+  color: #68756d;
+}
+
+.confirmation-check {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  color: #3b4940;
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+
+.confirmation-check input {
+  width: 17px;
+  height: 17px;
+  margin-top: 2px;
+  accent-color: #176543;
+}
+
+.inline-error {
+  margin: 12px 0 0;
+  color: #a23e32;
+  font-size: 0.8rem;
+}
+
+.dialog-actions {
+  margin-top: 26px;
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.success-message {
+  margin-top: 20px;
+  padding: 16px;
+  display: grid;
+  grid-template-columns: 30px 1fr;
+  gap: 12px;
+  color: #24543d;
+  background: #e0eee5;
+  border: 1px solid #bcd8c7;
+  border-radius: 11px;
+}
+
+.success-icon {
+  width: 28px;
+  height: 28px;
+  display: grid;
+  place-items: center;
+  color: #fff;
+  background: #25714d;
+  border-radius: 50%;
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.success-message strong {
+  display: block;
+  margin-bottom: 5px;
+}
+
+.success-message p {
+  margin-bottom: 12px;
+  font-size: 0.8rem;
+}
+
+.success-message dl {
+  margin-bottom: 0;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+.success-message dl > div {
+  display: block;
+}
+
+.success-message dt {
+  margin-bottom: 3px;
+  font-size: 0.68rem;
+  opacity: 0.76;
+}
+
+.success-message dd {
+  padding: 0;
+  text-align: left;
+  border: 0;
+  font-size: 0.76rem;
+}
+
 footer {
-  min-height: 72px;
+  min-height: 70px;
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 20px;
-  color: #718078;
-  border-top: 1px solid #cad1c7;
-  font-size: 0.78rem;
-  letter-spacing: 0.04em;
+  color: #78847d;
+  border-top: 1px solid #cfd5ce;
+  font-size: 0.75rem;
 }
 
-@media (max-width: 820px) {
-  .hero {
+@media (max-width: 900px) {
+  .operations-layout {
     grid-template-columns: 1fr;
-    gap: 48px;
   }
 
-  main {
-    padding-top: 64px;
+  .customer-panel {
+    min-height: auto;
+    border-right: 0;
+    border-bottom: 1px solid #dfe4df;
+  }
+
+  .customer-list {
+    grid-template-columns: repeat(3, minmax(180px, 1fr));
+    overflow-x: auto;
+  }
+
+  .workspace-grid {
+    grid-template-columns: 1fr;
   }
 }
 
-@media (max-width: 560px) {
+@media (max-width: 620px) {
   .app-shell {
-    width: min(100% - 24px, 1180px);
+    width: min(100% - 24px, 1240px);
   }
 
   .language-picker > span {
@@ -221,20 +708,62 @@ footer {
   }
 
   main {
-    padding-top: 48px;
+    padding: 44px 0 52px;
   }
 
-  h1 {
-    font-size: clamp(2.75rem, 15vw, 4.25rem);
+  .page-intro {
+    margin-bottom: 32px;
   }
 
-  .status-card {
-    padding: 22px;
+  .page-intro h1 {
+    font-size: clamp(2.4rem, 13vw, 3.7rem);
   }
 
-  .principle-card {
-    margin-top: 64px;
-    grid-template-columns: 1fr;
-    gap: 8px;
+  .customer-list {
+    grid-template-columns: repeat(3, 210px);
+  }
+
+  .contract-panel {
+    min-height: 540px;
+    padding: 22px 16px;
+  }
+
+  .contract-panel-header {
+    display: block;
+  }
+
+  .contract-panel-header > span {
+    display: none;
+  }
+
+  .contract-tabs {
+    margin-top: 16px;
+  }
+
+  .detail-card,
+  .assessment-card,
+  .confirmation-dialog {
+    padding: 20px;
+  }
+
+  .dialog-actions {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+  }
+
+  footer {
+    align-items: flex-start;
+    flex-direction: column;
+    justify-content: center;
+    gap: 5px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
   }
 }

--- a/src/ContractIQ.Web/src/translations.ts
+++ b/src/ContractIQ.Web/src/translations.ts
@@ -1,0 +1,141 @@
+import type { AssessmentReason, ContractStatus } from './api'
+
+export type Language = 'en' | 'pt-BR'
+
+const english = {
+  languageLabel: 'Language',
+  productEyebrow: 'Contract operations workspace',
+  title: 'Make contract decisions with confidence.',
+  description:
+    'Review customer data, understand deterministic cancellation terms, and create an auditable request.',
+  customers: 'Customers',
+  customersDescription: 'Select a customer to review their contracts.',
+  contracts: 'Contracts',
+  contract: 'Contract',
+  chooseCustomer: 'Choose a customer',
+  chooseCustomerDescription: 'Their available contracts will appear here.',
+  chooseContract: 'Choose a contract to review its cancellation terms.',
+  loadingCustomers: 'Loading customers…',
+  loadingContracts: 'Loading contracts…',
+  loadingAssessment: 'Calculating the cancellation assessment…',
+  noCustomers: 'No customers are available.',
+  noContracts: 'This customer has no contracts.',
+  retry: 'Try again',
+  requestFailed: 'We could not load this information. Try again in a moment.',
+  contractDetails: 'Contract details',
+  monthlyFee: 'Monthly fee',
+  startDate: 'Start date',
+  commitmentEnd: 'Minimum commitment ends',
+  noticePeriod: 'Notice period',
+  days: 'days',
+  earlyTerminationRate: 'Early termination rate',
+  assessment: 'Cancellation assessment',
+  eligible: 'Cancellation is available',
+  notEligible: 'Cancellation is not available',
+  earliestTermination: 'Earliest termination',
+  remainingPeriods: 'Chargeable periods',
+  estimatedPenalty: 'Deterministic penalty',
+  noPenalty: 'No penalty',
+  createRequest: 'Create cancellation request',
+  confirmationTitle: 'Confirm cancellation request',
+  confirmationDescription:
+    'ContractIQ will create a request for internal review. The contract is not cancelled immediately.',
+  confirmationCheck: 'I reviewed the date and penalty shown above.',
+  confirmationRequired:
+    'Confirm that you reviewed the assessment before continuing.',
+  cancel: 'Go back',
+  confirm: 'Confirm request',
+  creating: 'Creating request…',
+  successTitle: 'Request created',
+  successDescription: 'The cancellation request is pending internal review.',
+  requestId: 'Request ID',
+  status: 'Status',
+  pendingReview: 'Pending review',
+  apiUnavailable:
+    'The API is unavailable. Confirm that the .NET API and PostgreSQL are running.',
+  conflict: 'A cancellation request is already open for this contract.',
+  footerPrinciple: 'AI assists. Domain rules decide.',
+  statusLabels: {
+    active: 'Active',
+    cancelled: 'Cancelled',
+    expired: 'Expired',
+  } satisfies Record<ContractStatus, string>,
+  reasonLabels: {
+    allowed: 'The active contract can be submitted for cancellation review.',
+    contractAlreadyCancelled: 'This contract has already been cancelled.',
+    contractExpired: 'This contract has expired.',
+  } satisfies Record<AssessmentReason, string>,
+}
+
+const portuguese: typeof english = {
+  languageLabel: 'Idioma',
+  productEyebrow: 'Área de operações contratuais',
+  title: 'Decida sobre contratos com confiança.',
+  description:
+    'Consulte dados do cliente, entenda as condições determinísticas de cancelamento e crie uma solicitação auditável.',
+  customers: 'Clientes',
+  customersDescription: 'Selecione um cliente para consultar seus contratos.',
+  contracts: 'Contratos',
+  contract: 'Contrato',
+  chooseCustomer: 'Selecione um cliente',
+  chooseCustomerDescription: 'Os contratos disponíveis aparecerão aqui.',
+  chooseContract:
+    'Selecione um contrato para consultar suas condições de cancelamento.',
+  loadingCustomers: 'Carregando clientes…',
+  loadingContracts: 'Carregando contratos…',
+  loadingAssessment: 'Calculando a avaliação de cancelamento…',
+  noCustomers: 'Nenhum cliente está disponível.',
+  noContracts: 'Este cliente não possui contratos.',
+  retry: 'Tentar novamente',
+  requestFailed:
+    'Não foi possível carregar estas informações. Tente novamente em instantes.',
+  contractDetails: 'Detalhes do contrato',
+  monthlyFee: 'Mensalidade',
+  startDate: 'Data de início',
+  commitmentEnd: 'Fim da fidelidade mínima',
+  noticePeriod: 'Aviso prévio',
+  days: 'dias',
+  earlyTerminationRate: 'Taxa de cancelamento antecipado',
+  assessment: 'Avaliação de cancelamento',
+  eligible: 'Cancelamento disponível',
+  notEligible: 'Cancelamento indisponível',
+  earliestTermination: 'Primeiro término possível',
+  remainingPeriods: 'Períodos cobrados',
+  estimatedPenalty: 'Multa determinística',
+  noPenalty: 'Sem multa',
+  createRequest: 'Criar solicitação de cancelamento',
+  confirmationTitle: 'Confirmar solicitação de cancelamento',
+  confirmationDescription:
+    'O ContractIQ criará uma solicitação para análise interna. O contrato não será cancelado imediatamente.',
+  confirmationCheck: 'Revisei a data e a multa apresentadas acima.',
+  confirmationRequired:
+    'Confirme que você revisou a avaliação antes de continuar.',
+  cancel: 'Voltar',
+  confirm: 'Confirmar solicitação',
+  creating: 'Criando solicitação…',
+  successTitle: 'Solicitação criada',
+  successDescription: 'A solicitação de cancelamento aguarda análise interna.',
+  requestId: 'ID da solicitação',
+  status: 'Status',
+  pendingReview: 'Aguardando análise',
+  apiUnavailable:
+    'A API está indisponível. Confirme que a API .NET e o PostgreSQL estão em execução.',
+  conflict:
+    'Já existe uma solicitação de cancelamento aberta para este contrato.',
+  footerPrinciple: 'A IA auxilia. As regras de domínio decidem.',
+  statusLabels: {
+    active: 'Ativo',
+    cancelled: 'Cancelado',
+    expired: 'Expirado',
+  },
+  reasonLabels: {
+    allowed: 'O contrato ativo pode ser enviado para análise de cancelamento.',
+    contractAlreadyCancelled: 'Este contrato já foi cancelado.',
+    contractExpired: 'Este contrato está expirado.',
+  },
+}
+
+export const translations = {
+  en: english,
+  'pt-BR': portuguese,
+}

--- a/src/ContractIQ.Web/vite.config.ts
+++ b/src/ContractIQ.Web/vite.config.ts
@@ -3,6 +3,11 @@ import { defineConfig } from 'vite'
 
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:5186',
+    },
+  },
   test: {
     environment: 'jsdom',
     setupFiles: './src/test-setup.ts',

--- a/tests/ContractIQ.Application.Tests/Contracts/ListCustomerContractsHandlerTests.cs
+++ b/tests/ContractIQ.Application.Tests/Contracts/ListCustomerContractsHandlerTests.cs
@@ -1,0 +1,39 @@
+using ContractIQ.Application.Contracts.ListCustomerContracts;
+using Xunit;
+
+namespace ContractIQ.Application.Tests.Contracts;
+
+public sealed class ListCustomerContractsHandlerTests
+{
+    [Fact]
+    public async Task Handle_returns_only_the_customer_contracts()
+    {
+        var acmeContract = ApplicationTestData.CreateContract();
+        var anotherCustomerContract = ApplicationTestData.CreateContract(
+            id: Guid.Parse("33333333-3333-3333-3333-333333333333"),
+            customerId: Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"));
+        var handler = new ListCustomerContractsHandler(
+            new FakeContractRepository(acmeContract, anotherCustomerContract));
+
+        var result = await handler.HandleAsync(
+            new ListCustomerContractsQuery(ApplicationTestData.AcmeCustomerId),
+            CancellationToken.None);
+
+        var contract = Assert.Single(result);
+        Assert.Equal(acmeContract.Id, contract.Id);
+        Assert.Equal(acmeContract.CustomerId, contract.CustomerId);
+        Assert.Equal(acmeContract.MonthlyFee.Amount, contract.MonthlyFee.Amount);
+    }
+
+    [Fact]
+    public async Task Handle_returns_empty_when_customer_has_no_contracts()
+    {
+        var handler = new ListCustomerContractsHandler(new FakeContractRepository());
+
+        var result = await handler.HandleAsync(
+            new ListCustomerContractsQuery(ApplicationTestData.AcmeCustomerId),
+            CancellationToken.None);
+
+        Assert.Empty(result);
+    }
+}

--- a/tests/ContractIQ.Application.Tests/TestDoubles.cs
+++ b/tests/ContractIQ.Application.Tests/TestDoubles.cs
@@ -28,6 +28,19 @@ internal sealed class FakeContractRepository(params Contract[] contracts) : ICon
         _contracts.TryGetValue(contractId, out var contract);
         return Task.FromResult(contract);
     }
+
+    public Task<IReadOnlyList<Contract>> ListByCustomerIdAsync(
+        Guid customerId,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        IReadOnlyList<Contract> matches = _contracts.Values
+            .Where(contract => contract.CustomerId == customerId)
+            .OrderByDescending(contract => contract.StartDate)
+            .ThenBy(contract => contract.Id)
+            .ToArray();
+        return Task.FromResult(matches);
+    }
 }
 
 internal sealed class FakeCancellationRequestStore : ICancellationRequestStore

--- a/tests/ContractIQ.IntegrationTests/ApiEndpointsTests.cs
+++ b/tests/ContractIQ.IntegrationTests/ApiEndpointsTests.cs
@@ -47,6 +47,27 @@ public sealed class ApiEndpointsTests(PostgreSqlFixture postgres) : IAsyncLifeti
     }
 
     [Fact]
+    public async Task Customer_contracts_endpoint_returns_only_that_customers_contracts()
+    {
+        using var factory = CreateFactory();
+        using var client = factory.CreateClient();
+
+        using var response = await client.GetAsync(
+            $"/api/v1/customers/{DemoDataIds.InitechCustomer}/contracts",
+            CancellationToken.None);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        using JsonDocument document = await ReadJsonAsync(response);
+        JsonElement[] contracts = document.RootElement.EnumerateArray().ToArray();
+        Assert.Equal(2, contracts.Length);
+        Assert.All(
+            contracts,
+            contract => Assert.Equal(
+                DemoDataIds.InitechCustomer,
+                contract.GetProperty("customerId").GetGuid()));
+    }
+
+    [Fact]
     public async Task Contract_details_endpoint_returns_the_seeded_contract()
     {
         using var factory = CreateFactory();
@@ -306,7 +327,7 @@ public sealed class ApiEndpointsTests(PostgreSqlFixture postgres) : IAsyncLifeti
     }
 
     [Fact]
-    public async Task OpenApi_describes_the_four_API_paths_and_required_idempotency_header()
+    public async Task OpenApi_describes_the_API_paths_and_required_idempotency_header()
     {
         using var factory = CreateFactory();
         using var client = factory.CreateClient();
@@ -319,6 +340,7 @@ public sealed class ApiEndpointsTests(PostgreSqlFixture postgres) : IAsyncLifeti
         string[] expectedPaths =
         [
             "/api/v1/customers",
+            "/api/v1/customers/{customerId}/contracts",
             "/api/v1/contracts/{contractId}",
             "/api/v1/contracts/{contractId}/cancellation-assessment",
             "/api/v1/contracts/{contractId}/cancellation-requests",


### PR DESCRIPTION
## Summary

- add a CQRS query and PostgreSQL adapter operation for listing contracts by customer
- replace the placeholder React page with the customer, contract, assessment, and cancellation request flow
- provide complete English and Brazilian Portuguese resources without page reloads
- show loading, empty, retryable error, validation, confirmation, and success states
- add responsive desktop and mobile behavior and document local startup

## Architectural decisions

- React consumes typed HTTP contracts and does not embed demo customer-to-contract mappings.
- Cancellation dates and penalties continue to come exclusively from deterministic .NET domain logic.
- The state-changing command requires explicit confirmation and sends an idempotency key.
- Vite proxies local API traffic to ASP.NET Core, so no development-only CORS policy is required.
- No state-management or localization framework was added because this focused MVP flow does not justify one yet.

## Verification

- dotnet format ContractIQ.slnx --verify-no-changes --no-restore
- dotnet build ContractIQ.slnx --configuration Release --no-restore
- dotnet test ContractIQ.slnx --configuration Release --no-build: 81 passed
- npm run format:check
- npm run lint
- npm run test: 4 passed
- npm run build
- manually verified the live English and Portuguese flow against PostgreSQL
- manually verified the confirmation dialog at a 390 px viewport with no horizontal overflow

## Limitations and follow-up

Authentication and AI-assisted question answering remain intentionally outside this issue and will be delivered in later roadmap slices. The current interface demonstrates the deterministic contract operation flow using fictional local data.

Closes #7