### PR TITLE
feat: add local hybrid knowledge retrieval

### DIFF
--- a/ContractIQ.slnx
+++ b/ContractIQ.slnx
@@ -10,4 +10,7 @@
     <Project Path="tests/ContractIQ.Domain.Tests/ContractIQ.Domain.Tests.csproj" />
     <Project Path="tests/ContractIQ.IntegrationTests/ContractIQ.IntegrationTests.csproj" />
   </Folder>
+  <Folder Name="/tools/">
+    <Project Path="tools/ContractIQ.DocumentIndexer/ContractIQ.DocumentIndexer.csproj" />
+  </Folder>
 </Solution>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,9 +13,12 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.AI" Version="10.9.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.11" />
     <PackageVersion Include="Microsoft.OpenApi" Version="2.12.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.3" />
+    <PackageVersion Include="OllamaSharp" Version="5.4.30" />
     <PackageVersion Include="Pgvector.EntityFrameworkCore" Version="0.3.0" />
     <PackageVersion Include="Respawn" Version="7.0.0" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.14.0" />

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The application answers contract questions using structured business data, deter
 
 ## Project status
 
-The foundation and first deterministic contract-cancellation vertical slice are implemented with PostgreSQL persistence and real integration tests. Delivery is tracked through GitHub Issues, milestones, short-lived branches, and linked pull requests.
+The foundation, bilingual React shell, deterministic cancellation vertical slice, PostgreSQL persistence, and local hybrid knowledge retrieval are implemented with automated tests. Delivery is tracked through GitHub Issues, milestones, short-lived branches, and linked pull requests.
 
 ## Planned technology
 
@@ -29,6 +29,7 @@ Cancellation eligibility, dates, penalties, validation, authorization, idempoten
 
 - [Architecture overview](docs/architecture/overview.md)
 - [Contract operation API](docs/api/contract-operations.md)
+- [Local knowledge retrieval](docs/knowledge/local-retrieval.md)
 - [Delivery roadmap](docs/roadmap.md)
 - [Contributing](CONTRIBUTING.md)
 - [Architecture Decision Records](docs/adr)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,5 +18,20 @@ services:
       retries: 10
       start_period: 10s
 
+  ollama:
+    image: ollama/ollama:0.11.10
+    profiles: ["local-ai"]
+    ports:
+      - "127.0.0.1:${CONTRACTIQ_OLLAMA_PORT:-11434}:11434"
+    volumes:
+      - contractiq-ollama-data:/root/.ollama
+    healthcheck:
+      test: ["CMD", "ollama", "list"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 15s
+
 volumes:
   contractiq-postgres-data:
+  contractiq-ollama-data:

--- a/docs/adr/0003-use-postgresql-for-local-hybrid-retrieval.md
+++ b/docs/adr/0003-use-postgresql-for-local-hybrid-retrieval.md
@@ -1,0 +1,29 @@
+# ADR 0003: Use PostgreSQL for local hybrid retrieval
+
+- Status: Accepted
+- Date: 2026-08-28
+
+## Context
+
+The portfolio MVP needs credible retrieval-augmented generation with document versions, scope filters, citations, lexical relevance, and vector similarity. The default demonstration must remain free of Azure dependencies and reasonably easy for another developer to run.
+
+Azure AI Search is a strong target for an optional hosted profile, but requiring it now would introduce an account, billable resources, additional infrastructure, and a second persistent data service before the retrieval boundaries have been proven.
+
+## Decision
+
+Use the existing local PostgreSQL database for the MVP knowledge index:
+
+- generated `tsvector` columns and `ts_rank_cd` for lexical retrieval;
+- pgvector cosine similarity with an HNSW index for semantic retrieval;
+- Reciprocal Rank Fusion to combine lexical and vector rank positions;
+- customer, contract, and effective-version filters before ranking;
+- Ollama `embeddinggemma` through `Microsoft.Extensions.AI` for local multilingual embeddings;
+- application-owned ports so hosted embedding and search adapters can be added later.
+
+PostgreSQL lexical ranking is described accurately as lexical full-text search. It is not labeled BM25. Azure AI Search remains the planned adapter when demonstrating hosted BM25 and managed hybrid search adds enough value to justify the external resource.
+
+## Consequences
+
+The local profile has no cloud token or search-service cost and reuses the operational skills already required for the structured application database. Integration tests can validate the full query against a real pgvector container without requiring a model download by substituting deterministic embeddings.
+
+The MVP does not demonstrate BM25, semantic ranker, managed search scaling, or Azure search operations. PostgreSQL and the embedding schema are coupled to the selected 768-dimension model in the current migration. Changing embedding dimensions requires a deliberate schema migration and reindex.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -33,7 +33,9 @@ The current deterministic rules are documented in [Contract cancellation rules](
 
 ### Knowledge
 
-The knowledge module owns document ingestion, versioning, chunking, embeddings, indexing, retrieval, and citations. It never decides whether a contract can be cancelled.
+The knowledge module owns document ingestion, versioning, chunking, embeddings, indexing, retrieval, and citations. It never decides whether a contract can be cancelled. Its application ports are provider-neutral; the current local adapters use Ollama for multilingual embeddings and PostgreSQL for lexical and vector retrieval.
+
+Customer, contract, and effective-date filters are applied before ranking. PostgreSQL lexical and cosine-similarity candidate lists are fused with Reciprocal Rank Fusion. See [Local knowledge retrieval](../knowledge/local-retrieval.md) for the concrete flow and trade-offs.
 
 ### Assistant orchestration
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -12,6 +12,8 @@ This guide describes the shared development workflow for ContractIQ. The project
 
 An Azure subscription is not required. PostgreSQL, pgvector, the backend, and the frontend all run locally.
 
+Ollama is optional. It is needed only when indexing sample documents or exercising the knowledge-search endpoint; the deterministic contract operations continue to work without it.
+
 ## Start the local database
 
 The Compose service uses PostgreSQL 18 with pgvector 0.8.6 and persists its data in the named volume `contractiq-postgres-data`. Its port is published only on `127.0.0.1`.
@@ -149,6 +151,27 @@ dotnet run --project src/ContractIQ.Api
 ```
 
 The API listens on `http://localhost:5186` by default. Use the executable request collection at `src/ContractIQ.Api/ContractIQ.Api.http` or see the [contract operation API guide](api/contract-operations.md) for the seeded demonstration flow.
+
+## Run local knowledge retrieval
+
+The `local-ai` Compose profile keeps the model runtime optional. Start it together with PostgreSQL:
+
+```powershell
+docker compose --profile local-ai up -d postgres ollama
+docker compose exec ollama ollama pull embeddinggemma
+```
+
+The first pull downloads the local embedding model to the named volume `contractiq-ollama-data`. It does not create an Azure resource or token charge, but it uses local disk, memory, and CPU.
+
+Index the committed fictional documents:
+
+```powershell
+dotnet run --project tools/ContractIQ.DocumentIndexer
+```
+
+Run the same command again to verify idempotency. Unchanged document versions are skipped by content checksum. Then start the API and execute the knowledge-search request in `src/ContractIQ.Api/ContractIQ.Api.http`.
+
+See [Local knowledge retrieval](knowledge/local-retrieval.md) for the request contract, citation fields, ranking design, and troubleshooting.
 
 In a second terminal, start the React application:
 

--- a/docs/knowledge/local-retrieval.md
+++ b/docs/knowledge/local-retrieval.md
@@ -1,0 +1,90 @@
+# Local knowledge retrieval
+
+This delivery adds a complete retrieval slice without requiring Azure. It ingests fictional Markdown contracts and policies, produces multilingual embeddings through Ollama, stores chunks in PostgreSQL with pgvector, and returns scoped evidence with citation metadata.
+
+It is retrieval, not the final conversational assistant. The later assistant will combine these citations with structured contract data and deterministic cancellation assessments.
+
+## Flow
+
+1. `sample-data/knowledge/manifest.json` supplies document identity, type, version, language, customer and contract scope, effective dates, and source path.
+2. The Markdown chunker recognizes `##` sections and `<!-- page: N -->` markers so every chunk can become a precise citation.
+3. `ContractIQ.DocumentIndexer` computes a SHA-256 document checksum. An unchanged version indexed by the same model is skipped.
+4. Ollama generates 768-dimension `embeddinggemma` vectors through the standard `Microsoft.Extensions.AI` abstraction.
+5. PostgreSQL stores document metadata, generated `tsvector` values, and pgvector embeddings. GIN and HNSW indexes support the two retrieval paths.
+6. Search first selects documents visible to the requested customer and contract and effective on the requested date.
+7. Lexical ranking and cosine vector ranking each produce candidates. Reciprocal Rank Fusion (RRF) combines their positions into the final ranking.
+
+The application returns evidence only. It does not infer a penalty or change contract state. Those responsibilities remain in the domain model and CQRS command/query handlers.
+
+## Local setup
+
+From the repository root:
+
+```powershell
+docker compose --profile local-ai up -d postgres ollama
+docker compose exec ollama ollama pull embeddinggemma
+dotnet run --project tools/ContractIQ.DocumentIndexer
+dotnet run --project src/ContractIQ.Api
+```
+
+The first two commands download a container image and an embedding model. There is no Azure consumption cost, but the files occupy local disk and embedding generation uses local compute.
+
+The ordinary demo remains available with only PostgreSQL:
+
+```powershell
+docker compose up -d postgres
+dotnet run --project src/ContractIQ.Api
+```
+
+In that mode, contract and cancellation endpoints work normally. Knowledge search returns `503 ollama_unavailable` until Ollama and the model are available.
+
+## Search request
+
+`POST /api/v1/knowledge/search`
+
+```json
+{
+  "query": "Can ACME cancel without a penalty?",
+  "customerId": "11111111-1111-4111-8111-111111111111",
+  "contractId": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+  "asOf": "2026-08-28",
+  "limit": 5
+}
+```
+
+`asOf` is optional and defaults to the server's current UTC date. `limit` defaults to 5 and accepts values from 1 through 20.
+
+Each result includes the document key, title, type, version, language, source path, section, page, content, fused score, and available lexical/vector scores. Those fields are the citation contract for the future assistant and React experience.
+
+## PostgreSQL lexical search is not BM25
+
+The local implementation uses PostgreSQL full-text search with the language-neutral `simple` text-search configuration and `ts_rank_cd`. This is lexical relevance ranking, but it is not BM25.
+
+That distinction is intentional and documented rather than hidden behind a misleading generic label. A future Azure profile may implement the same application retrieval port with Azure AI Search, whose text retrieval uses BM25. The MVP keeps PostgreSQL because it is free locally, already owns the structured demo data, and is sufficient to demonstrate hybrid retrieval and RRF without operating another service.
+
+## Why RRF
+
+Lexical and vector scores have different scales and should not be added directly. RRF combines rank positions instead. A chunk that ranks well in both candidate lists receives contributions from both, while a strong result from only one path can still appear.
+
+The current constant is 60 and the candidate pool is at least 20 items or ten times the requested result limit. These values are pragmatic MVP defaults and can later be evaluated against a labeled retrieval dataset.
+
+## Version and scope behavior
+
+- A contract document is visible only when its customer and contract identifiers match the request.
+- A global policy has null scope and is visible to every contract.
+- Only versions effective on `asOf` are candidates.
+- When multiple eligible versions share a document key, only the latest effective version is ranked.
+- Reindexing the same version replaces its chunks atomically only when content or embedding model changes.
+
+Automated integration tests verify scope isolation, effective version selection, hybrid ranking execution, citation metadata, migration behavior, and pgvector availability. They use deterministic test vectors, so CI does not download or depend on Ollama.
+
+## Troubleshooting
+
+Confirm that Ollama is healthy and the model exists:
+
+```powershell
+docker compose --profile local-ai ps
+docker compose exec ollama ollama list
+```
+
+If the indexer reports that Ollama or `embeddinggemma` is unavailable, pull the model and run the indexer again. If search returns no results after resetting the PostgreSQL volume, rerun the indexer because sample document indexing is intentionally separate from application seed data.

--- a/sample-data/knowledge/contracts/acme-managed-services-v1.md
+++ b/sample-data/knowledge/contracts/acme-managed-services-v1.md
@@ -1,0 +1,19 @@
+# ACME Managed Services Agreement
+
+<!-- page: 1 -->
+
+## Parties and term
+
+This Managed Services Agreement is between ContractIQ Services Ltd. and ACME Corporation. Version 1.0 is effective from January 1, 2026 through June 30, 2026.
+
+## Services and fees
+
+ACME receives managed platform support for a monthly fee of USD 1,200.
+
+<!-- page: 2 -->
+
+## Termination for convenience
+
+ACME may terminate the agreement by providing 60 calendar days of written notice.
+
+If termination occurs before January 1, 2028, the early termination charge is 40 percent of the monthly fees remaining until that date.

--- a/sample-data/knowledge/contracts/acme-managed-services-v2.md
+++ b/sample-data/knowledge/contracts/acme-managed-services-v2.md
@@ -1,0 +1,23 @@
+# ACME Managed Services Agreement
+
+<!-- page: 1 -->
+
+## Parties and amendment
+
+This Managed Services Agreement is between ContractIQ Services Ltd. and ACME Corporation. Version 2.0 replaces version 1.0 and is effective from July 1, 2026.
+
+## Services and fees
+
+ACME receives managed platform support for a monthly fee of USD 1,200.
+
+<!-- page: 2 -->
+
+## Termination for convenience
+
+ACME may request termination at any time by providing 30 calendar days of written notice.
+
+If the requested termination occurs before the minimum commitment date of January 1, 2028, an early termination charge of 25 percent of the monthly fees remaining until that date applies. No early termination charge applies on or after the minimum commitment date.
+
+## Termination process
+
+The request must identify the contract and requested date. Submission does not cancel the contract immediately; the request remains pending until reviewed by Contract Operations.

--- a/sample-data/knowledge/contracts/globex-support-v1.md
+++ b/sample-data/knowledge/contracts/globex-support-v1.md
@@ -1,0 +1,13 @@
+# Globex Support Agreement
+
+<!-- page: 1 -->
+
+## Commercial terms
+
+Globex Corporation receives priority support for USD 850 per month under this agreement.
+
+<!-- page: 2 -->
+
+## Termination
+
+Globex may terminate with 15 calendar days of written notice. An early termination charge of 20 percent applied only before January 1, 2025. Requests made after that date have no early termination charge.

--- a/sample-data/knowledge/manifest.json
+++ b/sample-data/knowledge/manifest.json
@@ -1,0 +1,62 @@
+[
+  {
+    "documentKey": "contract-acme-managed-services",
+    "title": "ACME Managed Services Agreement",
+    "documentType": "contract",
+    "version": "1.0",
+    "language": "en",
+    "customerId": "11111111-1111-4111-8111-111111111111",
+    "contractId": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    "effectiveFrom": "2026-01-01",
+    "effectiveTo": "2026-06-30",
+    "file": "contracts/acme-managed-services-v1.md"
+  },
+  {
+    "documentKey": "contract-acme-managed-services",
+    "title": "ACME Managed Services Agreement",
+    "documentType": "contract",
+    "version": "2.0",
+    "language": "en",
+    "customerId": "11111111-1111-4111-8111-111111111111",
+    "contractId": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    "effectiveFrom": "2026-07-01",
+    "effectiveTo": null,
+    "file": "contracts/acme-managed-services-v2.md"
+  },
+  {
+    "documentKey": "contract-globex-support",
+    "title": "Globex Support Agreement",
+    "documentType": "contract",
+    "version": "1.0",
+    "language": "en",
+    "customerId": "22222222-2222-4222-8222-222222222222",
+    "contractId": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+    "effectiveFrom": "2024-01-01",
+    "effectiveTo": null,
+    "file": "contracts/globex-support-v1.md"
+  },
+  {
+    "documentKey": "policy-cancellation-en",
+    "title": "Contract Cancellation Policy",
+    "documentType": "policy",
+    "version": "1.0",
+    "language": "en",
+    "customerId": null,
+    "contractId": null,
+    "effectiveFrom": "2026-01-01",
+    "effectiveTo": null,
+    "file": "policies/cancellation-policy-en-v1.md"
+  },
+  {
+    "documentKey": "policy-cancellation-pt-br",
+    "title": "Política de Cancelamento de Contratos",
+    "documentType": "policy",
+    "version": "1.0",
+    "language": "pt-BR",
+    "customerId": null,
+    "contractId": null,
+    "effectiveFrom": "2026-01-01",
+    "effectiveTo": null,
+    "file": "policies/cancellation-policy-pt-br-v1.md"
+  }
+]

--- a/sample-data/knowledge/policies/cancellation-policy-en-v1.md
+++ b/sample-data/knowledge/policies/cancellation-policy-en-v1.md
@@ -1,0 +1,17 @@
+# Contract Cancellation Policy
+
+<!-- page: 1 -->
+
+## Required review
+
+Every cancellation request must be reviewed by Contract Operations before the contract status changes. The application records a new valid request as Pending Review.
+
+## Source of business rules
+
+Notice dates and penalties are calculated from structured contract terms by the ContractIQ domain model. Document text provides supporting evidence but must not override deterministic contract rules.
+
+<!-- page: 2 -->
+
+## Customer communication
+
+The response to a customer must cite the applicable contract clause and policy section. If evidence conflicts with structured contract data, the request must be escalated for human review.

--- a/sample-data/knowledge/policies/cancellation-policy-pt-br-v1.md
+++ b/sample-data/knowledge/policies/cancellation-policy-pt-br-v1.md
@@ -1,0 +1,17 @@
+# Política de Cancelamento de Contratos
+
+<!-- page: 1 -->
+
+## Revisão obrigatória
+
+Toda solicitação de cancelamento deve ser revisada pela equipe de Operações de Contratos antes da alteração do status do contrato. A aplicação registra uma nova solicitação válida como Pendente de Revisão.
+
+## Origem das regras de negócio
+
+Datas de aviso prévio e multas são calculadas a partir dos termos estruturados do contrato pelo modelo de domínio do ContractIQ. O texto dos documentos fornece evidências, mas não substitui as regras determinísticas do contrato.
+
+<!-- page: 2 -->
+
+## Comunicação ao cliente
+
+A resposta ao cliente deve citar a cláusula contratual e a seção da política aplicáveis. Se a evidência divergir dos dados estruturados, a solicitação deve ser encaminhada para revisão humana.

--- a/src/ContractIQ.Api/ContractIQ.Api.http
+++ b/src/ContractIQ.Api/ContractIQ.Api.http
@@ -3,6 +3,7 @@
 @cancelledContractId = cccccccc-cccc-4ccc-8ccc-cccccccccccc
 @idempotencyKey = demo-acme-cancellation-001
 
+
 ### Health check
 GET {{host}}/health
 
@@ -47,6 +48,18 @@ Accept: application/json
 POST {{host}}/api/v1/contracts/{{cancelledContractId}}/cancellation-requests
 Idempotency-Key: demo-inactive-contract-001
 Accept: application/json
+
+### Retrieve ACME contract and policy evidence (requires indexed documents and Ollama)
+POST {{host}}/api/v1/knowledge/search
+Content-Type: application/json
+Accept: application/json
+
+{
+  "query": "Can ACME cancel without a penalty?",
+  "customerId": "11111111-1111-4111-8111-111111111111",
+  "contractId": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+  "limit": 5
+}
 
 ### OpenAPI document, available in Development
 GET {{host}}/openapi/v1.json

--- a/src/ContractIQ.Api/Endpoints/ApiEndpoints.cs
+++ b/src/ContractIQ.Api/Endpoints/ApiEndpoints.cs
@@ -4,6 +4,8 @@ using ContractIQ.Application.Contracts.AssessCancellation;
 using ContractIQ.Application.Contracts.GetContractDetails;
 using ContractIQ.Application.Contracts.ListCustomerContracts;
 using ContractIQ.Application.Customers.ListCustomers;
+using ContractIQ.Application.Knowledge;
+using ContractIQ.Application.Knowledge.Search;
 using Microsoft.AspNetCore.Mvc;
 
 namespace ContractIQ.Api.Endpoints;
@@ -57,6 +59,16 @@ public static class ApiEndpoints
             .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesProblem(StatusCodes.Status404NotFound)
             .ProducesProblem(StatusCodes.Status409Conflict);
+
+        api.MapPost("/knowledge/search", SearchKnowledgeAsync)
+            .WithName("SearchKnowledge")
+            .WithTags("Knowledge")
+            .WithSummary("Searches contract and policy evidence using local hybrid retrieval.")
+            .WithDescription(
+                "Applies customer and contract scope before fusing PostgreSQL lexical and vector rankings.")
+            .Produces<KnowledgeEvidence[]>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status503ServiceUnavailable);
 
         return endpoints;
     }
@@ -121,4 +133,28 @@ public static class ApiEndpoints
             ? Results.Ok(result.Request)
             : Results.Json(result.Request, statusCode: StatusCodes.Status201Created);
     }
+
+    private static async Task<IResult> SearchKnowledgeAsync(
+        SearchKnowledgeRequest request,
+        SearchKnowledgeHandler handler,
+        CancellationToken cancellationToken)
+    {
+        IReadOnlyList<KnowledgeEvidence> evidence = await handler.HandleAsync(
+            new SearchKnowledgeQuery(
+                request.Query,
+                request.CustomerId,
+                request.ContractId,
+                request.AsOf,
+                request.Limit ?? 5),
+            cancellationToken);
+
+        return Results.Ok(evidence);
+    }
+
+    private sealed record SearchKnowledgeRequest(
+        string Query,
+        Guid CustomerId,
+        Guid ContractId,
+        DateOnly? AsOf,
+        int? Limit);
 }

--- a/src/ContractIQ.Api/Errors/ApplicationExceptionHandler.cs
+++ b/src/ContractIQ.Api/Errors/ApplicationExceptionHandler.cs
@@ -67,6 +67,11 @@ public sealed class ApplicationExceptionHandler(
             validation.Message,
             "validation_error",
             validation.Field),
+        ExternalDependencyUnavailableException unavailable => new ExceptionMapping(
+            StatusCodes.Status503ServiceUnavailable,
+            "External dependency unavailable",
+            unavailable.Message,
+            $"{unavailable.Dependency}_unavailable"),
         _ => new ExceptionMapping(
             StatusCodes.Status500InternalServerError,
             "Unexpected error",

--- a/src/ContractIQ.Api/Program.cs
+++ b/src/ContractIQ.Api/Program.cs
@@ -8,6 +8,8 @@ using ContractIQ.Application.Contracts.AssessCancellation;
 using ContractIQ.Application.Contracts.GetContractDetails;
 using ContractIQ.Application.Contracts.ListCustomerContracts;
 using ContractIQ.Application.Customers.ListCustomers;
+using ContractIQ.Application.Knowledge;
+using ContractIQ.Application.Knowledge.Search;
 using ContractIQ.Infrastructure;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 
@@ -28,6 +30,8 @@ builder.Services.AddScoped<GetContractDetailsHandler>();
 builder.Services.AddScoped<ListCustomerContractsHandler>();
 builder.Services.AddScoped<AssessCancellationHandler>();
 builder.Services.AddScoped<CreateCancellationRequestHandler>();
+builder.Services.AddSingleton<MarkdownKnowledgeChunker>();
+builder.Services.AddScoped<SearchKnowledgeHandler>();
 builder.Services.AddInfrastructure(builder.Configuration);
 
 var app = builder.Build();

--- a/src/ContractIQ.Application/Common/Exceptions/ExternalDependencyUnavailableException.cs
+++ b/src/ContractIQ.Application/Common/Exceptions/ExternalDependencyUnavailableException.cs
@@ -1,0 +1,9 @@
+namespace ContractIQ.Application.Common.Exceptions;
+
+public sealed class ExternalDependencyUnavailableException(
+    string dependency,
+    string message,
+    Exception? innerException = null) : Exception(message, innerException)
+{
+    public string Dependency { get; } = dependency;
+}

--- a/src/ContractIQ.Application/Knowledge/IKnowledgeDocumentCatalog.cs
+++ b/src/ContractIQ.Application/Knowledge/IKnowledgeDocumentCatalog.cs
@@ -1,0 +1,7 @@
+namespace ContractIQ.Application.Knowledge;
+
+public interface IKnowledgeDocumentCatalog
+{
+    Task<IReadOnlyList<KnowledgeDocumentSource>> ReadAllAsync(
+        CancellationToken cancellationToken = default);
+}

--- a/src/ContractIQ.Application/Knowledge/IKnowledgeEmbeddingGenerator.cs
+++ b/src/ContractIQ.Application/Knowledge/IKnowledgeEmbeddingGenerator.cs
@@ -1,0 +1,12 @@
+namespace ContractIQ.Application.Knowledge;
+
+public interface IKnowledgeEmbeddingGenerator
+{
+    string ModelId { get; }
+
+    int Dimensions { get; }
+
+    Task<IReadOnlyList<float[]>> GenerateAsync(
+        IReadOnlyList<string> values,
+        CancellationToken cancellationToken = default);
+}

--- a/src/ContractIQ.Application/Knowledge/IKnowledgeIndex.cs
+++ b/src/ContractIQ.Application/Knowledge/IKnowledgeIndex.cs
@@ -1,0 +1,27 @@
+namespace ContractIQ.Application.Knowledge;
+
+public interface IKnowledgeIndex
+{
+    Task<bool> IsCurrentAsync(
+        string documentKey,
+        string version,
+        string contentChecksum,
+        string embeddingModel,
+        CancellationToken cancellationToken = default);
+
+    Task ReplaceAsync(
+        KnowledgeDocumentSource source,
+        string contentChecksum,
+        string embeddingModel,
+        IReadOnlyList<KnowledgeChunk> chunks,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<KnowledgeEvidence>> SearchAsync(
+        string query,
+        float[] queryEmbedding,
+        Guid customerId,
+        Guid contractId,
+        DateOnly asOf,
+        int limit,
+        CancellationToken cancellationToken = default);
+}

--- a/src/ContractIQ.Application/Knowledge/Indexing/IndexKnowledgeDocumentsHandler.cs
+++ b/src/ContractIQ.Application/Knowledge/Indexing/IndexKnowledgeDocumentsHandler.cs
@@ -1,0 +1,94 @@
+using System.Text;
+
+namespace ContractIQ.Application.Knowledge.Indexing;
+
+public sealed class IndexKnowledgeDocumentsHandler(
+    IKnowledgeDocumentCatalog catalog,
+    IKnowledgeEmbeddingGenerator embeddingGenerator,
+    IKnowledgeIndex knowledgeIndex,
+    MarkdownKnowledgeChunker chunker)
+{
+    public async Task<IndexKnowledgeDocumentsResult> HandleAsync(
+        CancellationToken cancellationToken = default)
+    {
+        IReadOnlyList<KnowledgeDocumentSource> documents =
+            await catalog.ReadAllAsync(cancellationToken);
+
+        int indexedDocuments = 0;
+        int skippedDocuments = 0;
+        int indexedChunks = 0;
+
+        foreach (KnowledgeDocumentSource document in documents)
+        {
+            string checksum = ComputeDocumentChecksum(document);
+            bool isCurrent = await knowledgeIndex.IsCurrentAsync(
+                document.DocumentKey,
+                document.Version,
+                checksum,
+                embeddingGenerator.ModelId,
+                cancellationToken);
+
+            if (isCurrent)
+            {
+                skippedDocuments++;
+                continue;
+            }
+
+            IReadOnlyList<KnowledgeChunkDraft> drafts = chunker.Chunk(document.Content);
+            IReadOnlyList<float[]> embeddings = await embeddingGenerator.GenerateAsync(
+                drafts.Select(chunk => chunk.Content).ToArray(),
+                cancellationToken);
+
+            if (embeddings.Count != drafts.Count ||
+                embeddings.Any(embedding => embedding.Length != embeddingGenerator.Dimensions))
+            {
+                throw new InvalidOperationException(
+                    $"Embedding model '{embeddingGenerator.ModelId}' returned an unexpected shape.");
+            }
+
+            KnowledgeChunk[] chunks = drafts
+                .Select((draft, index) => new KnowledgeChunk(
+                    draft.Index,
+                    draft.Section,
+                    draft.Page,
+                    draft.Content,
+                    draft.Checksum,
+                    embeddings[index]))
+                .ToArray();
+
+            await knowledgeIndex.ReplaceAsync(
+                document,
+                checksum,
+                embeddingGenerator.ModelId,
+                chunks,
+                cancellationToken);
+
+            indexedDocuments++;
+            indexedChunks += chunks.Length;
+        }
+
+        return new IndexKnowledgeDocumentsResult(
+            indexedDocuments,
+            skippedDocuments,
+            indexedChunks);
+    }
+
+    private static string ComputeDocumentChecksum(KnowledgeDocumentSource document)
+    {
+        var value = new StringBuilder()
+            .AppendLine(document.DocumentKey)
+            .AppendLine(document.Version)
+            .AppendLine(document.Language)
+            .AppendLine(document.EffectiveFrom.ToString("O"))
+            .AppendLine(document.EffectiveTo?.ToString("O"))
+            .Append(document.Content)
+            .ToString();
+
+        return MarkdownKnowledgeChunker.ComputeChecksum(value);
+    }
+}
+
+public sealed record IndexKnowledgeDocumentsResult(
+    int IndexedDocuments,
+    int SkippedDocuments,
+    int IndexedChunks);

--- a/src/ContractIQ.Application/Knowledge/KnowledgeChunk.cs
+++ b/src/ContractIQ.Application/Knowledge/KnowledgeChunk.cs
@@ -1,0 +1,9 @@
+namespace ContractIQ.Application.Knowledge;
+
+public sealed record KnowledgeChunk(
+    int Index,
+    string Section,
+    int Page,
+    string Content,
+    string Checksum,
+    float[] Embedding);

--- a/src/ContractIQ.Application/Knowledge/KnowledgeDocumentSource.cs
+++ b/src/ContractIQ.Application/Knowledge/KnowledgeDocumentSource.cs
@@ -1,0 +1,14 @@
+namespace ContractIQ.Application.Knowledge;
+
+public sealed record KnowledgeDocumentSource(
+    string DocumentKey,
+    string Title,
+    KnowledgeDocumentType DocumentType,
+    string Version,
+    string Language,
+    Guid? CustomerId,
+    Guid? ContractId,
+    DateOnly EffectiveFrom,
+    DateOnly? EffectiveTo,
+    string SourcePath,
+    string Content);

--- a/src/ContractIQ.Application/Knowledge/KnowledgeDocumentType.cs
+++ b/src/ContractIQ.Application/Knowledge/KnowledgeDocumentType.cs
@@ -1,0 +1,7 @@
+namespace ContractIQ.Application.Knowledge;
+
+public enum KnowledgeDocumentType
+{
+    Contract,
+    Policy,
+}

--- a/src/ContractIQ.Application/Knowledge/KnowledgeEvidence.cs
+++ b/src/ContractIQ.Application/Knowledge/KnowledgeEvidence.cs
@@ -1,0 +1,19 @@
+namespace ContractIQ.Application.Knowledge;
+
+public sealed record KnowledgeEvidence(
+    Guid ChunkId,
+    string DocumentKey,
+    string Title,
+    KnowledgeDocumentType DocumentType,
+    string Version,
+    string Language,
+    Guid? CustomerId,
+    Guid? ContractId,
+    DateOnly EffectiveFrom,
+    string SourcePath,
+    string Section,
+    int Page,
+    string Content,
+    double Score,
+    double? LexicalScore,
+    double? VectorScore);

--- a/src/ContractIQ.Application/Knowledge/MarkdownKnowledgeChunker.cs
+++ b/src/ContractIQ.Application/Knowledge/MarkdownKnowledgeChunker.cs
@@ -1,0 +1,97 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace ContractIQ.Application.Knowledge;
+
+public sealed partial class MarkdownKnowledgeChunker(int maximumCharacters = 1_200)
+{
+    private readonly int _maximumCharacters = maximumCharacters > 100
+        ? maximumCharacters
+        : throw new ArgumentOutOfRangeException(nameof(maximumCharacters));
+
+    public IReadOnlyList<KnowledgeChunkDraft> Chunk(string markdown)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(markdown);
+
+        var chunks = new List<KnowledgeChunkDraft>();
+        var buffer = new StringBuilder();
+        string section = "Document";
+        int page = 1;
+
+        void Flush()
+        {
+            string content = buffer.ToString().Trim();
+            buffer.Clear();
+
+            if (content.Length == 0)
+            {
+                return;
+            }
+
+            chunks.Add(new KnowledgeChunkDraft(
+                chunks.Count,
+                section,
+                page,
+                content,
+                ComputeChecksum(content)));
+        }
+
+        foreach (string rawLine in markdown.ReplaceLineEndings("\n").Split('\n'))
+        {
+            string line = rawLine.Trim();
+            Match pageMatch = PageMarkerRegex().Match(line);
+
+            if (pageMatch.Success)
+            {
+                Flush();
+                page = int.Parse(pageMatch.Groups[1].Value);
+                continue;
+            }
+
+            if (line.StartsWith("## ", StringComparison.Ordinal))
+            {
+                Flush();
+                section = line[3..].Trim();
+                continue;
+            }
+
+            if (line.Length == 0)
+            {
+                Flush();
+                continue;
+            }
+
+            if (buffer.Length > 0 && buffer.Length + line.Length + 1 > _maximumCharacters)
+            {
+                Flush();
+            }
+
+            if (buffer.Length > 0)
+            {
+                buffer.Append(' ');
+            }
+
+            buffer.Append(line);
+        }
+
+        Flush();
+        return chunks;
+    }
+
+    public static string ComputeChecksum(string value)
+    {
+        byte[] hash = SHA256.HashData(Encoding.UTF8.GetBytes(value));
+        return Convert.ToHexString(hash).ToLowerInvariant();
+    }
+
+    [GeneratedRegex("^<!--\\s*page:\\s*(\\d+)\\s*-->$", RegexOptions.IgnoreCase)]
+    private static partial Regex PageMarkerRegex();
+}
+
+public sealed record KnowledgeChunkDraft(
+    int Index,
+    string Section,
+    int Page,
+    string Content,
+    string Checksum);

--- a/src/ContractIQ.Application/Knowledge/Search/SearchKnowledgeHandler.cs
+++ b/src/ContractIQ.Application/Knowledge/Search/SearchKnowledgeHandler.cs
@@ -1,0 +1,66 @@
+using ContractIQ.Application.Common.Exceptions;
+
+namespace ContractIQ.Application.Knowledge.Search;
+
+public sealed class SearchKnowledgeHandler(
+    IKnowledgeEmbeddingGenerator embeddingGenerator,
+    IKnowledgeIndex knowledgeIndex,
+    TimeProvider timeProvider)
+{
+    public async Task<IReadOnlyList<KnowledgeEvidence>> HandleAsync(
+        SearchKnowledgeQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        if (string.IsNullOrWhiteSpace(query.Query) || query.Query.Trim().Length < 3)
+        {
+            throw new ApplicationValidationException(
+                nameof(query.Query),
+                "Query must contain at least 3 characters.");
+        }
+
+        if (query.CustomerId == Guid.Empty)
+        {
+            throw new ApplicationValidationException(
+                nameof(query.CustomerId),
+                "Customer id is required.");
+        }
+
+        if (query.ContractId == Guid.Empty)
+        {
+            throw new ApplicationValidationException(
+                nameof(query.ContractId),
+                "Contract id is required.");
+        }
+
+        if (query.Limit is < 1 or > 20)
+        {
+            throw new ApplicationValidationException(
+                nameof(query.Limit),
+                "Limit must be between 1 and 20.");
+        }
+
+        IReadOnlyList<float[]> embeddings = await embeddingGenerator.GenerateAsync(
+            [query.Query.Trim()],
+            cancellationToken);
+
+        if (embeddings.Count != 1 || embeddings[0].Length != embeddingGenerator.Dimensions)
+        {
+            throw new InvalidOperationException(
+                $"Embedding model '{embeddingGenerator.ModelId}' returned an unexpected shape.");
+        }
+
+        DateOnly asOf = query.AsOf ?? DateOnly.FromDateTime(
+            timeProvider.GetUtcNow().UtcDateTime);
+
+        return await knowledgeIndex.SearchAsync(
+            query.Query.Trim(),
+            embeddings[0],
+            query.CustomerId,
+            query.ContractId,
+            asOf,
+            query.Limit,
+            cancellationToken);
+    }
+}

--- a/src/ContractIQ.Application/Knowledge/Search/SearchKnowledgeQuery.cs
+++ b/src/ContractIQ.Application/Knowledge/Search/SearchKnowledgeQuery.cs
@@ -1,0 +1,8 @@
+namespace ContractIQ.Application.Knowledge.Search;
+
+public sealed record SearchKnowledgeQuery(
+    string Query,
+    Guid CustomerId,
+    Guid ContractId,
+    DateOnly? AsOf = null,
+    int Limit = 5);

--- a/src/ContractIQ.Infrastructure/ContractIQ.Infrastructure.csproj
+++ b/src/ContractIQ.Infrastructure/ContractIQ.Infrastructure.csproj
@@ -13,7 +13,9 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" />
+    <PackageReference Include="Microsoft.Extensions.AI" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
+    <PackageReference Include="OllamaSharp" />
     <PackageReference Include="Pgvector.EntityFrameworkCore" />
   </ItemGroup>
 </Project>

--- a/src/ContractIQ.Infrastructure/DependencyInjection.cs
+++ b/src/ContractIQ.Infrastructure/DependencyInjection.cs
@@ -1,4 +1,6 @@
 using ContractIQ.Application.Abstractions.Persistence;
+using ContractIQ.Application.Knowledge;
+using ContractIQ.Infrastructure.Knowledge;
 using ContractIQ.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
@@ -21,12 +23,27 @@ public static class DependencyInjection
             ?? throw new InvalidOperationException(
                 $"Connection string '{ConnectionStringName}' is not configured.");
 
-        return services.AddInfrastructure(connectionString);
+        KnowledgeOptions knowledgeOptions = KnowledgeOptions.FromConfiguration(configuration);
+        return services.AddInfrastructure(connectionString, knowledgeOptions);
     }
 
     public static IServiceCollection AddInfrastructure(
         this IServiceCollection services,
         string connectionString)
+    {
+        return services.AddInfrastructure(
+            connectionString,
+            new KnowledgeOptions(
+                "sample-data/knowledge",
+                new Uri("http://localhost:11434"),
+                "embeddinggemma",
+                768));
+    }
+
+    public static IServiceCollection AddInfrastructure(
+        this IServiceCollection services,
+        string connectionString,
+        KnowledgeOptions knowledgeOptions)
     {
         ArgumentNullException.ThrowIfNull(services);
         ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
@@ -48,6 +65,10 @@ public static class DependencyInjection
         services.AddScoped<ICustomerRepository, PostgresCustomerRepository>();
         services.AddScoped<IContractRepository, PostgresContractRepository>();
         services.AddScoped<ICancellationRequestStore, PostgresCancellationRequestStore>();
+        services.AddScoped<IKnowledgeIndex, PostgresKnowledgeIndex>();
+        services.AddSingleton(knowledgeOptions);
+        services.AddSingleton<IKnowledgeDocumentCatalog, FileSystemKnowledgeDocumentCatalog>();
+        services.AddSingleton<IKnowledgeEmbeddingGenerator, OllamaKnowledgeEmbeddingGenerator>();
 
         return services;
     }

--- a/src/ContractIQ.Infrastructure/Knowledge/FileSystemKnowledgeDocumentCatalog.cs
+++ b/src/ContractIQ.Infrastructure/Knowledge/FileSystemKnowledgeDocumentCatalog.cs
@@ -1,0 +1,98 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using ContractIQ.Application.Knowledge;
+
+namespace ContractIQ.Infrastructure.Knowledge;
+
+internal sealed class FileSystemKnowledgeDocumentCatalog(KnowledgeOptions options)
+    : IKnowledgeDocumentCatalog
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new(JsonSerializerDefaults.Web)
+    {
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    public async Task<IReadOnlyList<KnowledgeDocumentSource>> ReadAllAsync(
+        CancellationToken cancellationToken = default)
+    {
+        string contentRoot = ResolveContentRoot(options.ContentRoot);
+        string manifestPath = Path.Combine(contentRoot, "manifest.json");
+
+        await using FileStream manifest = File.OpenRead(manifestPath);
+        KnowledgeManifestEntry[] entries = await JsonSerializer.DeserializeAsync<KnowledgeManifestEntry[]>(
+            manifest,
+            SerializerOptions,
+            cancellationToken) ?? [];
+
+        var documents = new List<KnowledgeDocumentSource>(entries.Length);
+
+        foreach (KnowledgeManifestEntry entry in entries)
+        {
+            string sourcePath = Path.GetFullPath(Path.Combine(contentRoot, entry.File));
+            EnsureInsideContentRoot(contentRoot, sourcePath);
+            string content = await File.ReadAllTextAsync(sourcePath, cancellationToken);
+
+            documents.Add(new KnowledgeDocumentSource(
+                entry.DocumentKey,
+                entry.Title,
+                entry.DocumentType,
+                entry.Version,
+                entry.Language,
+                entry.CustomerId,
+                entry.ContractId,
+                entry.EffectiveFrom,
+                entry.EffectiveTo,
+                Path.GetRelativePath(contentRoot, sourcePath).Replace('\\', '/'),
+                content));
+        }
+
+        return documents;
+    }
+
+    private static string ResolveContentRoot(string configuredPath)
+    {
+        if (Path.IsPathRooted(configuredPath))
+        {
+            return Path.GetFullPath(configuredPath);
+        }
+
+        DirectoryInfo? directory = new(AppContext.BaseDirectory);
+
+        while (directory is not null)
+        {
+            string candidate = Path.Combine(directory.FullName, configuredPath);
+
+            if (Directory.Exists(candidate))
+            {
+                return Path.GetFullPath(candidate);
+            }
+
+            directory = directory.Parent;
+        }
+
+        return Path.GetFullPath(configuredPath);
+    }
+
+    private static void EnsureInsideContentRoot(string contentRoot, string sourcePath)
+    {
+        string root = Path.GetFullPath(contentRoot)
+            .TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+
+        if (!sourcePath.StartsWith(root, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidDataException("Knowledge manifest references a file outside its content root.");
+        }
+    }
+
+    private sealed record KnowledgeManifestEntry(
+        string DocumentKey,
+        string Title,
+        KnowledgeDocumentType DocumentType,
+        string Version,
+        string Language,
+        Guid? CustomerId,
+        Guid? ContractId,
+        DateOnly EffectiveFrom,
+        DateOnly? EffectiveTo,
+        string File);
+}

--- a/src/ContractIQ.Infrastructure/Knowledge/KnowledgeOptions.cs
+++ b/src/ContractIQ.Infrastructure/Knowledge/KnowledgeOptions.cs
@@ -1,0 +1,38 @@
+namespace ContractIQ.Infrastructure.Knowledge;
+
+public sealed record KnowledgeOptions(
+    string ContentRoot,
+    Uri OllamaEndpoint,
+    string EmbeddingModel,
+    int EmbeddingDimensions)
+{
+    public const int StoredEmbeddingDimensions = 768;
+
+    public static KnowledgeOptions FromConfiguration(
+        Microsoft.Extensions.Configuration.IConfiguration configuration)
+    {
+        string contentRoot = configuration["Knowledge:ContentRoot"]
+            ?? "sample-data/knowledge";
+        string endpoint = configuration["Knowledge:Ollama:Endpoint"]
+            ?? "http://localhost:11434";
+        string model = configuration["Knowledge:Ollama:EmbeddingModel"]
+            ?? "embeddinggemma";
+        int dimensions = int.TryParse(
+            configuration["Knowledge:Ollama:Dimensions"],
+            out int configuredDimensions)
+            ? configuredDimensions
+            : StoredEmbeddingDimensions;
+
+        if (dimensions != StoredEmbeddingDimensions)
+        {
+            throw new InvalidOperationException(
+                $"The current pgvector schema requires {StoredEmbeddingDimensions}-dimension embeddings.");
+        }
+
+        return new KnowledgeOptions(
+            contentRoot,
+            new Uri(endpoint, UriKind.Absolute),
+            model,
+            dimensions);
+    }
+}

--- a/src/ContractIQ.Infrastructure/Knowledge/OllamaKnowledgeEmbeddingGenerator.cs
+++ b/src/ContractIQ.Infrastructure/Knowledge/OllamaKnowledgeEmbeddingGenerator.cs
@@ -1,0 +1,51 @@
+using ContractIQ.Application.Knowledge;
+using Microsoft.Extensions.AI;
+using OllamaSharp;
+using OllamaSharp.Models.Exceptions;
+
+namespace ContractIQ.Infrastructure.Knowledge;
+
+internal sealed class OllamaKnowledgeEmbeddingGenerator : IKnowledgeEmbeddingGenerator
+{
+    private readonly IEmbeddingGenerator<string, Embedding<float>> _generator;
+
+    public OllamaKnowledgeEmbeddingGenerator(KnowledgeOptions options)
+    {
+        ModelId = options.EmbeddingModel;
+        Dimensions = options.EmbeddingDimensions;
+        _generator = new OllamaApiClient(options.OllamaEndpoint, ModelId);
+    }
+
+    public string ModelId { get; }
+
+    public int Dimensions { get; }
+
+    public async Task<IReadOnlyList<float[]>> GenerateAsync(
+        IReadOnlyList<string> values,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            GeneratedEmbeddings<Embedding<float>> embeddings = await _generator.GenerateAsync(
+                values,
+                new EmbeddingGenerationOptions
+                {
+                    ModelId = ModelId,
+                    Dimensions = Dimensions,
+                },
+                cancellationToken);
+
+            return embeddings
+                .Select(embedding => embedding.Vector.ToArray())
+                .ToArray();
+        }
+        catch (Exception exception) when (
+            exception is HttpRequestException or OllamaException)
+        {
+            throw new ContractIQ.Application.Common.Exceptions.ExternalDependencyUnavailableException(
+                "ollama",
+                $"Ollama is unavailable or embedding model '{ModelId}' is not installed.",
+                exception);
+        }
+    }
+}

--- a/src/ContractIQ.Infrastructure/Persistence/Configurations/KnowledgeChunkRecordConfiguration.cs
+++ b/src/ContractIQ.Infrastructure/Persistence/Configurations/KnowledgeChunkRecordConfiguration.cs
@@ -1,0 +1,40 @@
+using ContractIQ.Infrastructure.Persistence.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace ContractIQ.Infrastructure.Persistence.Configurations;
+
+internal sealed class KnowledgeChunkRecordConfiguration
+    : IEntityTypeConfiguration<KnowledgeChunkRecord>
+{
+    public void Configure(EntityTypeBuilder<KnowledgeChunkRecord> builder)
+    {
+        builder.ToTable("knowledge_chunks");
+        builder.HasKey(chunk => chunk.Id).HasName("pk_knowledge_chunks");
+
+        builder.Property(chunk => chunk.Id).HasColumnName("id").ValueGeneratedNever();
+        builder.Property(chunk => chunk.DocumentId).HasColumnName("document_id");
+        builder.Property(chunk => chunk.ChunkIndex).HasColumnName("chunk_index");
+        builder.Property(chunk => chunk.Section).HasColumnName("section").HasMaxLength(300);
+        builder.Property(chunk => chunk.Page).HasColumnName("page");
+        builder.Property(chunk => chunk.Content).HasColumnName("content");
+        builder.Property(chunk => chunk.ContentChecksum).HasColumnName("content_checksum").HasMaxLength(64);
+        builder.Property(chunk => chunk.Embedding).HasColumnName("embedding").HasColumnType("vector(768)");
+        builder.Property(chunk => chunk.SearchVector)
+            .HasColumnName("search_vector")
+            .HasColumnType("tsvector")
+            .HasComputedColumnSql(
+                "to_tsvector('simple', coalesce(section, '') || ' ' || coalesce(content, ''))",
+                stored: true);
+
+        builder.HasIndex(chunk => new { chunk.DocumentId, chunk.ChunkIndex })
+            .HasDatabaseName("ux_knowledge_chunks_document_index")
+            .IsUnique();
+
+        builder.HasOne(chunk => chunk.Document)
+            .WithMany(document => document.Chunks)
+            .HasForeignKey(chunk => chunk.DocumentId)
+            .HasConstraintName("fk_knowledge_chunks_documents_document_id")
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/src/ContractIQ.Infrastructure/Persistence/Configurations/KnowledgeDocumentRecordConfiguration.cs
+++ b/src/ContractIQ.Infrastructure/Persistence/Configurations/KnowledgeDocumentRecordConfiguration.cs
@@ -1,0 +1,40 @@
+using ContractIQ.Infrastructure.Persistence.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace ContractIQ.Infrastructure.Persistence.Configurations;
+
+internal sealed class KnowledgeDocumentRecordConfiguration
+    : IEntityTypeConfiguration<KnowledgeDocumentRecord>
+{
+    public void Configure(EntityTypeBuilder<KnowledgeDocumentRecord> builder)
+    {
+        builder.ToTable("knowledge_documents");
+        builder.HasKey(document => document.Id).HasName("pk_knowledge_documents");
+
+        builder.Property(document => document.Id).HasColumnName("id").ValueGeneratedNever();
+        builder.Property(document => document.DocumentKey).HasColumnName("document_key").HasMaxLength(200);
+        builder.Property(document => document.Title).HasColumnName("title").HasMaxLength(300);
+        builder.Property(document => document.DocumentType).HasColumnName("document_type").HasConversion<string>().HasMaxLength(30);
+        builder.Property(document => document.Version).HasColumnName("version").HasMaxLength(50);
+        builder.Property(document => document.Language).HasColumnName("language").HasMaxLength(10);
+        builder.Property(document => document.CustomerId).HasColumnName("customer_id");
+        builder.Property(document => document.ContractId).HasColumnName("contract_id");
+        builder.Property(document => document.EffectiveFrom).HasColumnName("effective_from");
+        builder.Property(document => document.EffectiveTo).HasColumnName("effective_to");
+        builder.Property(document => document.SourcePath).HasColumnName("source_path").HasMaxLength(500);
+        builder.Property(document => document.ContentChecksum).HasColumnName("content_checksum").HasMaxLength(64);
+        builder.Property(document => document.EmbeddingModel).HasColumnName("embedding_model").HasMaxLength(200);
+        builder.Property(document => document.IndexedAtUtc).HasColumnName("indexed_at_utc");
+
+        builder.HasIndex(document => new { document.DocumentKey, document.Version })
+            .HasDatabaseName("ux_knowledge_documents_key_version")
+            .IsUnique();
+        builder.HasIndex(document => new
+        {
+            document.CustomerId,
+            document.ContractId,
+            document.EffectiveFrom,
+        }).HasDatabaseName("ix_knowledge_documents_scope_effective_from");
+    }
+}

--- a/src/ContractIQ.Infrastructure/Persistence/ContractIqDbContext.cs
+++ b/src/ContractIQ.Infrastructure/Persistence/ContractIqDbContext.cs
@@ -13,6 +13,12 @@ public sealed class ContractIqDbContext(DbContextOptions<ContractIqDbContext> op
     internal DbSet<CancellationRequestRecord> CancellationRequests =>
         Set<CancellationRequestRecord>();
 
+    internal DbSet<KnowledgeDocumentRecord> KnowledgeDocuments =>
+        Set<KnowledgeDocumentRecord>();
+
+    internal DbSet<KnowledgeChunkRecord> KnowledgeChunks =>
+        Set<KnowledgeChunkRecord>();
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);

--- a/src/ContractIQ.Infrastructure/Persistence/Migrations/20260828204150_AddKnowledgeRetrieval.Designer.cs
+++ b/src/ContractIQ.Infrastructure/Persistence/Migrations/20260828204150_AddKnowledgeRetrieval.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using ContractIQ.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace ContractIQ.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(ContractIqDbContext))]
-    partial class ContractIqDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260828204150_AddKnowledgeRetrieval")]
+    partial class AddKnowledgeRetrieval
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/ContractIQ.Infrastructure/Persistence/Migrations/20260828204150_AddKnowledgeRetrieval.cs
+++ b/src/ContractIQ.Infrastructure/Persistence/Migrations/20260828204150_AddKnowledgeRetrieval.cs
@@ -1,0 +1,101 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NpgsqlTypes;
+using Pgvector;
+
+#nullable disable
+
+namespace ContractIQ.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddKnowledgeRetrieval : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "knowledge_documents",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    document_key = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    title = table.Column<string>(type: "character varying(300)", maxLength: 300, nullable: false),
+                    document_type = table.Column<string>(type: "character varying(30)", maxLength: 30, nullable: false),
+                    version = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    language = table.Column<string>(type: "character varying(10)", maxLength: 10, nullable: false),
+                    customer_id = table.Column<Guid>(type: "uuid", nullable: true),
+                    contract_id = table.Column<Guid>(type: "uuid", nullable: true),
+                    effective_from = table.Column<DateOnly>(type: "date", nullable: false),
+                    effective_to = table.Column<DateOnly>(type: "date", nullable: true),
+                    source_path = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: false),
+                    content_checksum = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    embedding_model = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    indexed_at_utc = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_knowledge_documents", x => x.id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "knowledge_chunks",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    document_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    chunk_index = table.Column<int>(type: "integer", nullable: false),
+                    section = table.Column<string>(type: "character varying(300)", maxLength: 300, nullable: false),
+                    page = table.Column<int>(type: "integer", nullable: false),
+                    content = table.Column<string>(type: "text", nullable: false),
+                    content_checksum = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    embedding = table.Column<Vector>(type: "vector(768)", nullable: false),
+                    search_vector = table.Column<NpgsqlTsVector>(type: "tsvector", nullable: false, computedColumnSql: "to_tsvector('simple', coalesce(section, '') || ' ' || coalesce(content, ''))", stored: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_knowledge_chunks", x => x.id);
+                    table.ForeignKey(
+                        name: "fk_knowledge_chunks_documents_document_id",
+                        column: x => x.document_id,
+                        principalTable: "knowledge_documents",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ux_knowledge_chunks_document_index",
+                table: "knowledge_chunks",
+                columns: new[] { "document_id", "chunk_index" },
+                unique: true);
+
+            migrationBuilder.Sql(
+                "CREATE INDEX ix_knowledge_chunks_search_vector " +
+                "ON knowledge_chunks USING GIN (search_vector);");
+
+            migrationBuilder.Sql(
+                "CREATE INDEX ix_knowledge_chunks_embedding_hnsw " +
+                "ON knowledge_chunks USING hnsw (embedding vector_cosine_ops);");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_knowledge_documents_scope_effective_from",
+                table: "knowledge_documents",
+                columns: new[] { "customer_id", "contract_id", "effective_from" });
+
+            migrationBuilder.CreateIndex(
+                name: "ux_knowledge_documents_key_version",
+                table: "knowledge_documents",
+                columns: new[] { "document_key", "version" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "knowledge_chunks");
+
+            migrationBuilder.DropTable(
+                name: "knowledge_documents");
+        }
+    }
+}

--- a/src/ContractIQ.Infrastructure/Persistence/Models/KnowledgeChunkRecord.cs
+++ b/src/ContractIQ.Infrastructure/Persistence/Models/KnowledgeChunkRecord.cs
@@ -1,0 +1,27 @@
+using NpgsqlTypes;
+using Pgvector;
+
+namespace ContractIQ.Infrastructure.Persistence.Models;
+
+internal sealed class KnowledgeChunkRecord
+{
+    public Guid Id { get; set; }
+
+    public Guid DocumentId { get; set; }
+
+    public int ChunkIndex { get; set; }
+
+    public required string Section { get; set; }
+
+    public int Page { get; set; }
+
+    public required string Content { get; set; }
+
+    public required string ContentChecksum { get; set; }
+
+    public required Vector Embedding { get; set; }
+
+    public NpgsqlTsVector SearchVector { get; set; } = null!;
+
+    public KnowledgeDocumentRecord Document { get; set; } = null!;
+}

--- a/src/ContractIQ.Infrastructure/Persistence/Models/KnowledgeDocumentRecord.cs
+++ b/src/ContractIQ.Infrastructure/Persistence/Models/KnowledgeDocumentRecord.cs
@@ -1,0 +1,36 @@
+using ContractIQ.Application.Knowledge;
+
+namespace ContractIQ.Infrastructure.Persistence.Models;
+
+internal sealed class KnowledgeDocumentRecord
+{
+    public Guid Id { get; set; }
+
+    public required string DocumentKey { get; set; }
+
+    public required string Title { get; set; }
+
+    public KnowledgeDocumentType DocumentType { get; set; }
+
+    public required string Version { get; set; }
+
+    public required string Language { get; set; }
+
+    public Guid? CustomerId { get; set; }
+
+    public Guid? ContractId { get; set; }
+
+    public DateOnly EffectiveFrom { get; set; }
+
+    public DateOnly? EffectiveTo { get; set; }
+
+    public required string SourcePath { get; set; }
+
+    public required string ContentChecksum { get; set; }
+
+    public required string EmbeddingModel { get; set; }
+
+    public DateTimeOffset IndexedAtUtc { get; set; }
+
+    public List<KnowledgeChunkRecord> Chunks { get; set; } = [];
+}

--- a/src/ContractIQ.Infrastructure/Persistence/PostgresKnowledgeIndex.cs
+++ b/src/ContractIQ.Infrastructure/Persistence/PostgresKnowledgeIndex.cs
@@ -1,0 +1,211 @@
+using System.Data;
+using ContractIQ.Application.Knowledge;
+using ContractIQ.Infrastructure.Persistence.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Npgsql;
+using Pgvector;
+
+namespace ContractIQ.Infrastructure.Persistence;
+
+internal sealed class PostgresKnowledgeIndex(
+    ContractIqDbContext dbContext,
+    TimeProvider timeProvider) : IKnowledgeIndex
+{
+    private const int ReciprocalRankConstant = 60;
+
+    public Task<bool> IsCurrentAsync(
+        string documentKey,
+        string version,
+        string contentChecksum,
+        string embeddingModel,
+        CancellationToken cancellationToken = default)
+    {
+        return dbContext.KnowledgeDocuments.AnyAsync(
+            document =>
+                document.DocumentKey == documentKey &&
+                document.Version == version &&
+                document.ContentChecksum == contentChecksum &&
+                document.EmbeddingModel == embeddingModel,
+            cancellationToken);
+    }
+
+    public async Task ReplaceAsync(
+        KnowledgeDocumentSource source,
+        string contentChecksum,
+        string embeddingModel,
+        IReadOnlyList<KnowledgeChunk> chunks,
+        CancellationToken cancellationToken = default)
+    {
+        await using IDbContextTransaction transaction =
+            await dbContext.Database.BeginTransactionAsync(cancellationToken);
+
+        KnowledgeDocumentRecord? existing = await dbContext.KnowledgeDocuments
+            .Include(document => document.Chunks)
+            .SingleOrDefaultAsync(
+                document => document.DocumentKey == source.DocumentKey &&
+                    document.Version == source.Version,
+                cancellationToken);
+
+        if (existing is not null)
+        {
+            dbContext.KnowledgeDocuments.Remove(existing);
+            await dbContext.SaveChangesAsync(cancellationToken);
+        }
+
+        var document = new KnowledgeDocumentRecord
+        {
+            Id = Guid.NewGuid(),
+            DocumentKey = source.DocumentKey,
+            Title = source.Title,
+            DocumentType = source.DocumentType,
+            Version = source.Version,
+            Language = source.Language,
+            CustomerId = source.CustomerId,
+            ContractId = source.ContractId,
+            EffectiveFrom = source.EffectiveFrom,
+            EffectiveTo = source.EffectiveTo,
+            SourcePath = source.SourcePath,
+            ContentChecksum = contentChecksum,
+            EmbeddingModel = embeddingModel,
+            IndexedAtUtc = timeProvider.GetUtcNow(),
+        };
+
+        document.Chunks.AddRange(chunks.Select(chunk => new KnowledgeChunkRecord
+        {
+            Id = Guid.NewGuid(),
+            DocumentId = document.Id,
+            ChunkIndex = chunk.Index,
+            Section = chunk.Section,
+            Page = chunk.Page,
+            Content = chunk.Content,
+            ContentChecksum = chunk.Checksum,
+            Embedding = new Vector(chunk.Embedding),
+        }));
+
+        dbContext.KnowledgeDocuments.Add(document);
+        await dbContext.SaveChangesAsync(cancellationToken);
+        await transaction.CommitAsync(cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<KnowledgeEvidence>> SearchAsync(
+        string query,
+        float[] queryEmbedding,
+        Guid customerId,
+        Guid contractId,
+        DateOnly asOf,
+        int limit,
+        CancellationToken cancellationToken = default)
+    {
+        const string sql = """
+            WITH versioned_documents AS (
+                SELECT d.*,
+                       ROW_NUMBER() OVER (
+                           PARTITION BY d.document_key
+                           ORDER BY d.effective_from DESC, d.version DESC) AS version_rank
+                FROM knowledge_documents d
+                WHERE d.effective_from <= @as_of
+                  AND (d.effective_to IS NULL OR d.effective_to >= @as_of)
+                  AND (d.customer_id IS NULL OR d.customer_id = @customer_id)
+                  AND (d.contract_id IS NULL OR d.contract_id = @contract_id)
+            ),
+            eligible_chunks AS (
+                SELECT c.*, d.document_key, d.title, d.document_type, d.version,
+                       d.language, d.customer_id, d.contract_id, d.effective_from,
+                       d.source_path
+                FROM knowledge_chunks c
+                INNER JOIN versioned_documents d ON d.id = c.document_id
+                WHERE d.version_rank = 1
+            ),
+            lexical AS (
+                SELECT id,
+                       ts_rank_cd(search_vector, websearch_to_tsquery('simple', @query))::double precision AS score,
+                       ROW_NUMBER() OVER (
+                           ORDER BY ts_rank_cd(search_vector, websearch_to_tsquery('simple', @query)) DESC) AS rank
+                FROM eligible_chunks
+                WHERE search_vector @@ websearch_to_tsquery('simple', @query)
+                ORDER BY score DESC
+                LIMIT @candidate_count
+            ),
+            semantic AS (
+                SELECT id,
+                       (1 - (embedding <=> @embedding))::double precision AS score,
+                       ROW_NUMBER() OVER (ORDER BY embedding <=> @embedding) AS rank
+                FROM eligible_chunks
+                ORDER BY embedding <=> @embedding
+                LIMIT @candidate_count
+            ),
+            fused AS (
+                SELECT COALESCE(lexical.id, semantic.id) AS id,
+                       COALESCE(1.0::double precision / (@rrf_constant + lexical.rank), 0.0) +
+                       COALESCE(1.0::double precision / (@rrf_constant + semantic.rank), 0.0) AS score,
+                       lexical.score AS lexical_score,
+                       semantic.score AS vector_score
+                FROM lexical
+                FULL OUTER JOIN semantic ON semantic.id = lexical.id
+            )
+            SELECT c.id, c.document_key, c.title, c.document_type, c.version,
+                   c.language, c.customer_id, c.contract_id, c.effective_from,
+                   c.source_path, c.section, c.page, c.content, f.score,
+                   f.lexical_score, f.vector_score
+            FROM fused f
+            INNER JOIN eligible_chunks c ON c.id = f.id
+            ORDER BY f.score DESC, c.document_key, c.chunk_index
+            LIMIT @limit;
+            """;
+
+        var connection = (NpgsqlConnection)dbContext.Database.GetDbConnection();
+        bool closeConnection = connection.State != ConnectionState.Open;
+
+        if (closeConnection)
+        {
+            await connection.OpenAsync(cancellationToken);
+        }
+
+        try
+        {
+            await using var command = new NpgsqlCommand(sql, connection);
+            command.Parameters.AddWithValue("query", query);
+            command.Parameters.AddWithValue("embedding", new Vector(queryEmbedding));
+            command.Parameters.AddWithValue("customer_id", customerId);
+            command.Parameters.AddWithValue("contract_id", contractId);
+            command.Parameters.AddWithValue("as_of", asOf);
+            command.Parameters.AddWithValue("candidate_count", Math.Max(limit * 10, 20));
+            command.Parameters.AddWithValue("rrf_constant", ReciprocalRankConstant);
+            command.Parameters.AddWithValue("limit", limit);
+
+            var evidence = new List<KnowledgeEvidence>();
+            await using NpgsqlDataReader reader = await command.ExecuteReaderAsync(cancellationToken);
+
+            while (await reader.ReadAsync(cancellationToken))
+            {
+                evidence.Add(new KnowledgeEvidence(
+                    reader.GetGuid(0),
+                    reader.GetString(1),
+                    reader.GetString(2),
+                    Enum.Parse<KnowledgeDocumentType>(reader.GetString(3)),
+                    reader.GetString(4),
+                    reader.GetString(5),
+                    reader.IsDBNull(6) ? null : reader.GetGuid(6),
+                    reader.IsDBNull(7) ? null : reader.GetGuid(7),
+                    reader.GetFieldValue<DateOnly>(8),
+                    reader.GetString(9),
+                    reader.GetString(10),
+                    reader.GetInt32(11),
+                    reader.GetString(12),
+                    reader.GetDouble(13),
+                    reader.IsDBNull(14) ? null : reader.GetDouble(14),
+                    reader.IsDBNull(15) ? null : reader.GetDouble(15)));
+            }
+
+            return evidence;
+        }
+        finally
+        {
+            if (closeConnection)
+            {
+                await connection.CloseAsync();
+            }
+        }
+    }
+}

--- a/tests/ContractIQ.Application.Tests/Knowledge/IndexKnowledgeDocumentsHandlerTests.cs
+++ b/tests/ContractIQ.Application.Tests/Knowledge/IndexKnowledgeDocumentsHandlerTests.cs
@@ -1,0 +1,100 @@
+using ContractIQ.Application.Knowledge;
+using ContractIQ.Application.Knowledge.Indexing;
+using Xunit;
+
+namespace ContractIQ.Application.Tests.Knowledge;
+
+public sealed class IndexKnowledgeDocumentsHandlerTests
+{
+    [Fact]
+    public async Task HandleAsync_skips_an_unchanged_document_on_reindex()
+    {
+        KnowledgeDocumentSource source = CreateSource();
+        var index = new InMemoryKnowledgeIndex();
+        var handler = new IndexKnowledgeDocumentsHandler(
+            new Catalog(source),
+            new Embeddings(),
+            index,
+            new MarkdownKnowledgeChunker());
+
+        IndexKnowledgeDocumentsResult first = await handler.HandleAsync();
+        IndexKnowledgeDocumentsResult second = await handler.HandleAsync();
+
+        Assert.Equal(1, first.IndexedDocuments);
+        Assert.Equal(0, first.SkippedDocuments);
+        Assert.True(first.IndexedChunks > 0);
+        Assert.Equal(0, second.IndexedDocuments);
+        Assert.Equal(1, second.SkippedDocuments);
+        Assert.Equal(1, index.ReplaceCount);
+    }
+
+    private static KnowledgeDocumentSource CreateSource() => new(
+        "contract-acme",
+        "ACME Agreement",
+        KnowledgeDocumentType.Contract,
+        "1.0",
+        "en",
+        Guid.NewGuid(),
+        Guid.NewGuid(),
+        new DateOnly(2026, 1, 1),
+        null,
+        "contracts/acme.md",
+        "## Termination\n\nThirty days notice is required.");
+
+    private sealed class Catalog(KnowledgeDocumentSource source) : IKnowledgeDocumentCatalog
+    {
+        public Task<IReadOnlyList<KnowledgeDocumentSource>> ReadAllAsync(
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<KnowledgeDocumentSource>>([source]);
+    }
+
+    private sealed class Embeddings : IKnowledgeEmbeddingGenerator
+    {
+        public string ModelId => "test-embedding";
+
+        public int Dimensions => 3;
+
+        public Task<IReadOnlyList<float[]>> GenerateAsync(
+            IReadOnlyList<string> values,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<float[]>>(
+                values.Select(_ => new[] { 1f, 0f, 0f }).ToArray());
+    }
+
+    private sealed class InMemoryKnowledgeIndex : IKnowledgeIndex
+    {
+        private readonly HashSet<string> _checksums = [];
+
+        public int ReplaceCount { get; private set; }
+
+        public Task<bool> IsCurrentAsync(
+            string documentKey,
+            string version,
+            string contentChecksum,
+            string embeddingModel,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(_checksums.Contains(contentChecksum));
+
+        public Task ReplaceAsync(
+            KnowledgeDocumentSource source,
+            string contentChecksum,
+            string embeddingModel,
+            IReadOnlyList<KnowledgeChunk> chunks,
+            CancellationToken cancellationToken = default)
+        {
+            _checksums.Add(contentChecksum);
+            ReplaceCount++;
+            return Task.CompletedTask;
+        }
+
+        public Task<IReadOnlyList<KnowledgeEvidence>> SearchAsync(
+            string query,
+            float[] queryEmbedding,
+            Guid customerId,
+            Guid contractId,
+            DateOnly asOf,
+            int limit,
+            CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+    }
+}

--- a/tests/ContractIQ.Application.Tests/Knowledge/MarkdownKnowledgeChunkerTests.cs
+++ b/tests/ContractIQ.Application.Tests/Knowledge/MarkdownKnowledgeChunkerTests.cs
@@ -1,0 +1,34 @@
+using ContractIQ.Application.Knowledge;
+using Xunit;
+
+namespace ContractIQ.Application.Tests.Knowledge;
+
+public sealed class MarkdownKnowledgeChunkerTests
+{
+    [Fact]
+    public void Chunk_preserves_section_page_and_citation_content()
+    {
+        const string markdown = """
+            # Agreement
+
+            <!-- page: 2 -->
+
+            ## Termination
+
+            Thirty days notice is required.
+
+            A penalty may apply.
+            """;
+        var chunker = new MarkdownKnowledgeChunker();
+
+        IReadOnlyList<KnowledgeChunkDraft> chunks = chunker.Chunk(markdown);
+
+        Assert.Equal(3, chunks.Count);
+        Assert.Equal("Document", chunks[0].Section);
+        Assert.Equal(1, chunks[0].Page);
+        Assert.Equal("Termination", chunks[1].Section);
+        Assert.Equal(2, chunks[1].Page);
+        Assert.Equal("Thirty days notice is required.", chunks[1].Content);
+        Assert.Equal(64, chunks[1].Checksum.Length);
+    }
+}

--- a/tests/ContractIQ.Application.Tests/Knowledge/SearchKnowledgeHandlerTests.cs
+++ b/tests/ContractIQ.Application.Tests/Knowledge/SearchKnowledgeHandlerTests.cs
@@ -1,0 +1,60 @@
+using ContractIQ.Application.Common.Exceptions;
+using ContractIQ.Application.Knowledge;
+using ContractIQ.Application.Knowledge.Search;
+using Xunit;
+
+namespace ContractIQ.Application.Tests.Knowledge;
+
+public sealed class SearchKnowledgeHandlerTests
+{
+    [Fact]
+    public async Task HandleAsync_rejects_an_empty_customer_scope_before_embedding()
+    {
+        var embeddings = new Embeddings();
+        var handler = new SearchKnowledgeHandler(
+            embeddings,
+            new Index(),
+            new FrozenTimeProvider());
+
+        ApplicationValidationException exception = await Assert.ThrowsAsync<ApplicationValidationException>(
+            () => handler.HandleAsync(new SearchKnowledgeQuery(
+                "cancellation penalty",
+                Guid.Empty,
+                Guid.NewGuid())));
+
+        Assert.Equal("CustomerId", exception.Field);
+        Assert.Equal(0, embeddings.CallCount);
+    }
+
+    private sealed class Embeddings : IKnowledgeEmbeddingGenerator
+    {
+        public int CallCount { get; private set; }
+
+        public string ModelId => "test";
+
+        public int Dimensions => 3;
+
+        public Task<IReadOnlyList<float[]>> GenerateAsync(
+            IReadOnlyList<string> values,
+            CancellationToken cancellationToken = default)
+        {
+            CallCount++;
+            return Task.FromResult<IReadOnlyList<float[]>>([new[] { 1f, 0f, 0f }]);
+        }
+    }
+
+    private sealed class Index : IKnowledgeIndex
+    {
+        public Task<bool> IsCurrentAsync(string documentKey, string version, string contentChecksum, string embeddingModel, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public Task ReplaceAsync(KnowledgeDocumentSource source, string contentChecksum, string embeddingModel, IReadOnlyList<KnowledgeChunk> chunks, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public Task<IReadOnlyList<KnowledgeEvidence>> SearchAsync(string query, float[] queryEmbedding, Guid customerId, Guid contractId, DateOnly asOf, int limit, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    }
+
+    private sealed class FrozenTimeProvider : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() =>
+            new(2026, 8, 28, 0, 0, 0, TimeSpan.Zero);
+    }
+}

--- a/tests/ContractIQ.IntegrationTests/ApiEndpointsTests.cs
+++ b/tests/ContractIQ.IntegrationTests/ApiEndpointsTests.cs
@@ -1,5 +1,7 @@
 using System.Net;
+using System.Net.Http.Json;
 using System.Text.Json;
+using ContractIQ.Application.Knowledge.Indexing;
 using ContractIQ.Infrastructure;
 using ContractIQ.Infrastructure.Persistence;
 using Microsoft.Extensions.DependencyInjection;
@@ -344,6 +346,7 @@ public sealed class ApiEndpointsTests(PostgreSqlFixture postgres) : IAsyncLifeti
             "/api/v1/contracts/{contractId}",
             "/api/v1/contracts/{contractId}/cancellation-assessment",
             "/api/v1/contracts/{contractId}/cancellation-requests",
+            "/api/v1/knowledge/search",
         ];
 
         Assert.Equal(expectedPaths.Length, paths.EnumerateObject().Count());
@@ -366,6 +369,79 @@ public sealed class ApiEndpointsTests(PostgreSqlFixture postgres) : IAsyncLifeti
             idempotencyHeader.TryGetProperty("required", out JsonElement required) &&
             required.GetBoolean(),
             "OpenAPI must mark the Idempotency-Key header as required.");
+    }
+
+    [Fact]
+    public async Task Knowledge_search_returns_current_scoped_evidence_with_citation_metadata()
+    {
+        IndexKnowledgeDocumentsResult indexResult =
+            await _databaseFactory!.IndexKnowledgeDocumentsAsync();
+        IndexKnowledgeDocumentsResult reindexResult =
+            await _databaseFactory.IndexKnowledgeDocumentsAsync();
+        using var client = _databaseFactory.CreateClient();
+
+        using var response = await client.PostAsJsonAsync(
+            "/api/v1/knowledge/search",
+            new
+            {
+                Query = "penalty before commitment",
+                CustomerId = DemoDataIds.AcmeCustomer,
+                ContractId = DemoDataIds.AcmeActiveContract,
+                AsOf = "2026-08-28",
+                Limit = 5,
+            },
+            CancellationToken.None);
+
+        Assert.Equal(4, indexResult.IndexedDocuments);
+        Assert.Equal(0, reindexResult.IndexedDocuments);
+        Assert.Equal(4, reindexResult.SkippedDocuments);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        using JsonDocument document = await ReadJsonAsync(response);
+        JsonElement[] evidence = document.RootElement.EnumerateArray().ToArray();
+        Assert.NotEmpty(evidence);
+        Assert.DoesNotContain(
+            evidence,
+            item => item.GetProperty("documentKey").GetString() == "contract-globex");
+
+        JsonElement contractEvidence = evidence.Single(item =>
+            item.GetProperty("documentKey").GetString() == "contract-acme");
+        Assert.Equal("2.0", contractEvidence.GetProperty("version").GetString());
+        Assert.Equal("Termination for convenience", contractEvidence.GetProperty("section").GetString());
+        Assert.Equal(2, contractEvidence.GetProperty("page").GetInt32());
+        Assert.Equal("contracts/acme-v2.0.md", contractEvidence.GetProperty("sourcePath").GetString());
+        Assert.True(contractEvidence.GetProperty("score").GetDouble() > 0);
+        Assert.NotEqual(JsonValueKind.Null, contractEvidence.GetProperty("lexicalScore").ValueKind);
+        Assert.NotEqual(JsonValueKind.Null, contractEvidence.GetProperty("vectorScore").ValueKind);
+    }
+
+    [Fact]
+    public async Task Knowledge_search_selects_the_version_effective_as_of_the_requested_date()
+    {
+        await _databaseFactory!.IndexKnowledgeDocumentsAsync();
+        using var client = _databaseFactory.CreateClient();
+
+        using var response = await client.PostAsJsonAsync(
+            "/api/v1/knowledge/search",
+            new
+            {
+                Query = "penalty before commitment",
+                CustomerId = DemoDataIds.AcmeCustomer,
+                ContractId = DemoDataIds.AcmeActiveContract,
+                AsOf = "2026-03-01",
+                Limit = 5,
+            },
+            CancellationToken.None);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        using JsonDocument document = await ReadJsonAsync(response);
+        JsonElement contractEvidence = document.RootElement
+            .EnumerateArray()
+            .Single(item => item.GetProperty("documentKey").GetString() == "contract-acme");
+        Assert.Equal("1.0", contractEvidence.GetProperty("version").GetString());
+        Assert.Contains(
+            "forty percent",
+            contractEvidence.GetProperty("content").GetString(),
+            StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/tests/ContractIQ.IntegrationTests/ContractIqApiFactory.cs
+++ b/tests/ContractIQ.IntegrationTests/ContractIqApiFactory.cs
@@ -1,4 +1,6 @@
 using ContractIQ.Application.Abstractions.Persistence;
+using ContractIQ.Application.Knowledge;
+using ContractIQ.Application.Knowledge.Indexing;
 using ContractIQ.Infrastructure;
 using ContractIQ.Infrastructure.Persistence;
 using Microsoft.AspNetCore.Hosting;
@@ -53,6 +55,15 @@ internal sealed class ContractIqApiFactory(
         await DemoDataSeeder.SeedAsync(seedDbContext, cancellationToken);
     }
 
+    public async Task<IndexKnowledgeDocumentsResult> IndexKnowledgeDocumentsAsync(
+        CancellationToken cancellationToken = default)
+    {
+        await using AsyncServiceScope scope = Services.CreateAsyncScope();
+        return await scope.ServiceProvider
+            .GetRequiredService<IndexKnowledgeDocumentsHandler>()
+            .HandleAsync(cancellationToken);
+    }
+
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         builder.UseEnvironment(Environments.Development);
@@ -66,10 +77,118 @@ internal sealed class ContractIqApiFactory(
             services.RemoveAll<IConfigureOptions<HealthCheckServiceOptions>>();
             services.AddInfrastructure(connectionString);
 
+            services.RemoveAll<IKnowledgeEmbeddingGenerator>();
+            services.RemoveAll<IKnowledgeDocumentCatalog>();
+            services.AddSingleton<IKnowledgeEmbeddingGenerator, DeterministicEmbeddingGenerator>();
+            services.AddSingleton<IKnowledgeDocumentCatalog, TestKnowledgeDocumentCatalog>();
+            services.AddScoped<IndexKnowledgeDocumentsHandler>();
+
             services.RemoveAll<TimeProvider>();
             services.AddSingleton<TimeProvider>(
                 new FrozenTimeProvider(utcNow, localTimeZone ?? TimeZoneInfo.Utc));
         });
+    }
+
+    private sealed class DeterministicEmbeddingGenerator : IKnowledgeEmbeddingGenerator
+    {
+        public string ModelId => "integration-test-embedding-v1";
+
+        public int Dimensions => 768;
+
+        public Task<IReadOnlyList<float[]>> GenerateAsync(
+            IReadOnlyList<string> values,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<IReadOnlyList<float[]>>(
+                values.Select(CreateEmbedding).ToArray());
+        }
+
+        private static float[] CreateEmbedding(string value)
+        {
+            string normalized = value.ToLowerInvariant();
+            var embedding = new float[768];
+
+            if (normalized.Contains("penalty") ||
+                normalized.Contains("charge") ||
+                normalized.Contains("multa"))
+            {
+                embedding[0] = 1;
+            }
+            else if (normalized.Contains("notice") || normalized.Contains("aviso"))
+            {
+                embedding[1] = 1;
+            }
+            else
+            {
+                embedding[2] = 1;
+            }
+
+            return embedding;
+        }
+    }
+
+    private sealed class TestKnowledgeDocumentCatalog : IKnowledgeDocumentCatalog
+    {
+        public Task<IReadOnlyList<KnowledgeDocumentSource>> ReadAllAsync(
+            CancellationToken cancellationToken = default)
+        {
+            IReadOnlyList<KnowledgeDocumentSource> documents =
+            [
+                CreateAcmeDocument(
+                    "1.0",
+                    new DateOnly(2026, 1, 1),
+                    new DateOnly(2026, 6, 30),
+                    "A forty percent penalty applies before the commitment date."),
+                CreateAcmeDocument(
+                    "2.0",
+                    new DateOnly(2026, 7, 1),
+                    null,
+                    "A twenty-five percent penalty applies before the commitment date of January 1, 2028."),
+                new KnowledgeDocumentSource(
+                    "contract-globex",
+                    "Globex Agreement",
+                    KnowledgeDocumentType.Contract,
+                    "1.0",
+                    "en",
+                    DemoDataIds.GlobexCustomer,
+                    DemoDataIds.GlobexActiveContract,
+                    new DateOnly(2024, 1, 1),
+                    null,
+                    "contracts/globex.md",
+                    "<!-- page: 4 -->\n\n## Termination\n\nGlobex has no penalty."),
+                new KnowledgeDocumentSource(
+                    "policy-cancellation-en",
+                    "Cancellation Policy",
+                    KnowledgeDocumentType.Policy,
+                    "1.0",
+                    "en",
+                    null,
+                    null,
+                    new DateOnly(2026, 1, 1),
+                    null,
+                    "policies/cancellation.md",
+                    "<!-- page: 1 -->\n\n## Review\n\nEvery request remains pending review."),
+            ];
+
+            return Task.FromResult(documents);
+        }
+
+        private static KnowledgeDocumentSource CreateAcmeDocument(
+            string version,
+            DateOnly effectiveFrom,
+            DateOnly? effectiveTo,
+            string clause) => new(
+                "contract-acme",
+                "ACME Agreement",
+                KnowledgeDocumentType.Contract,
+                version,
+                "en",
+                DemoDataIds.AcmeCustomer,
+                DemoDataIds.AcmeActiveContract,
+                effectiveFrom,
+                effectiveTo,
+                $"contracts/acme-v{version}.md",
+                $"<!-- page: 2 -->\n\n## Termination for convenience\n\n{clause}");
     }
 
     private sealed class FrozenTimeProvider(

--- a/tools/ContractIQ.DocumentIndexer/ContractIQ.DocumentIndexer.csproj
+++ b/tools/ContractIQ.DocumentIndexer/ContractIQ.DocumentIndexer.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\ContractIQ.Application\ContractIQ.Application.csproj" />
+    <ProjectReference Include="..\..\src\ContractIQ.Infrastructure\ContractIQ.Infrastructure.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+</Project>

--- a/tools/ContractIQ.DocumentIndexer/Program.cs
+++ b/tools/ContractIQ.DocumentIndexer/Program.cs
@@ -1,0 +1,29 @@
+using ContractIQ.Application.Knowledge;
+using ContractIQ.Application.Knowledge.Indexing;
+using ContractIQ.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+var builder = Host.CreateApplicationBuilder(new HostApplicationBuilderSettings
+{
+    Args = args,
+    ContentRootPath = AppContext.BaseDirectory,
+});
+
+builder.Services.AddSingleton(TimeProvider.System);
+builder.Services.AddSingleton<MarkdownKnowledgeChunker>();
+builder.Services.AddScoped<IndexKnowledgeDocumentsHandler>();
+builder.Services.AddInfrastructure(builder.Configuration);
+
+using IHost host = builder.Build();
+await host.Services.InitializeDatabaseAsync();
+
+await using AsyncServiceScope scope = host.Services.CreateAsyncScope();
+IndexKnowledgeDocumentsResult result = await scope.ServiceProvider
+    .GetRequiredService<IndexKnowledgeDocumentsHandler>()
+    .HandleAsync();
+
+Console.WriteLine(
+    $"Knowledge index ready. Indexed documents: {result.IndexedDocuments}; " +
+    $"skipped unchanged documents: {result.SkippedDocuments}; " +
+    $"new chunks: {result.IndexedChunks}.");

--- a/tools/ContractIQ.DocumentIndexer/appsettings.json
+++ b/tools/ContractIQ.DocumentIndexer/appsettings.json
@@ -1,9 +1,6 @@
 {
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
-    }
+  "ConnectionStrings": {
+    "ContractIQ": "Host=localhost;Port=5432;Database=contractiq;Username=contractiq;Password=contractiq"
   },
   "Knowledge": {
     "ContentRoot": "sample-data/knowledge",
@@ -12,6 +9,5 @@
       "EmbeddingModel": "embeddinggemma",
       "Dimensions": 768
     }
-  },
-  "AllowedHosts": "*"
+  }
 }


### PR DESCRIPTION
## Summary

- ingest versioned fictional contracts and bilingual policies with customer, contract, effective-date, section, page, and source metadata
- generate local multilingual embeddings through `Microsoft.Extensions.AI` and Ollama `embeddinggemma`
- store generated `tsvector` data and 768-dimension pgvector embeddings with GIN and HNSW indexes
- retrieve scoped lexical and semantic candidates and fuse their ranks with Reciprocal Rank Fusion
- expose `POST /api/v1/knowledge/search` and return citation-ready evidence
- add an idempotent document indexer, optional `local-ai` Compose profile, ADR, setup guide, and executable API request

## Architecture and trade-offs

- AI remains outside domain authority: retrieval returns evidence and never calculates penalties or changes contract state.
- PostgreSQL `ts_rank_cd` is explicitly documented as lexical relevance, not BM25.
- Azure AI Search remains an optional future adapter; this MVP runs locally without an Azure subscription or usage charge.
- Ollama is optional for normal contract operations. Missing Ollama/model is reported as `503 ollama_unavailable` for knowledge search.
- CI uses deterministic test embeddings, so tests do not download a model or depend on a hosted AI provider.

## Verification

- `dotnet format ContractIQ.slnx --verify-no-changes --no-restore`
- `dotnet build ContractIQ.slnx --no-restore -m:1 -p:UseSharedCompilation=false`
- `dotnet test ContractIQ.slnx --no-build -m:1`
  - Application: 22 passed
  - Domain: 40 passed
  - Integration: 24 passed
- `docker compose config --quiet`

Integration coverage includes scope isolation, effective version selection, lexical and vector participation in RRF, citation metadata, idempotent reindexing, migrations, and pgvector availability.

## Local demo

```powershell
docker compose --profile local-ai up -d postgres ollama
docker compose exec ollama ollama pull embeddinggemma
dotnet run --project tools/ContractIQ.DocumentIndexer
dotnet run --project src/ContractIQ.Api
```

Then run the knowledge request in `src/ContractIQ.Api/ContractIQ.Api.http`.

## Limitations / follow-up

This PR implements retrieval, not the final conversational assistant. Grounded bilingual answer generation and application tool calling remain in M4. Telemetry/evaluations remain planned for M6.

Closes #8