### PR TITLE
Add configurable Kimi assistant provider

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,6 +14,7 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.AI" Version="10.9.0" />
+    <PackageVersion Include="Microsoft.Extensions.AI.OpenAI" Version="10.9.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.11" />
     <PackageVersion Include="Microsoft.OpenApi" Version="2.12.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -41,7 +41,7 @@ Customer, contract, and effective-date filters are applied before ranking. Postg
 
 Assistant orchestration is an application concern rather than a separate service. The current read-only flow validates customer and contract scope, calculates the deterministic cancellation assessment, retrieves supporting evidence, refuses when no applicable contract clause is available, and asks a provider-neutral answer generator for a bilingual explanation.
 
-The local adapter uses `IChatClient` through Ollama. Citations are assembled by the application from retrieved metadata rather than invented by the model. `FunctionInvokingChatClient` exposes scoped read and preparation tools; the write tool remains outside automatic invocation and requires a separate confirmed HTTP request.
+The provider adapter uses Microsoft's `IChatClient` through either local Ollama or the OpenAI-compatible Kimi API. The committed default remains local and hosted usage is explicitly enabled with secret configuration. Citations are assembled by the application from retrieved metadata rather than invented by the model. `FunctionInvokingChatClient` exposes scoped read and preparation tools; the write tool remains outside automatic invocation and requires a separate confirmed HTTP request.
 
 ## Dependency rule
 

--- a/docs/assistant/grounded-answers.md
+++ b/docs/assistant/grounded-answers.md
@@ -7,7 +7,18 @@ The grounded assistant explains a contract question in English or Brazilian Port
 
 The language model writes the explanation. It is not the authority for eligibility, dates, chargeable periods, penalty amounts, document scope, or state changes.
 
-## Local setup
+## Provider choice
+
+The committed default is local Ollama so cloning or starting the repository never
+creates a hosted-model charge. The assistant chat provider can be changed to Kimi
+through local configuration. Retrieval embeddings remain local through
+`embeddinggemma` in both modes, so changing the chat provider does not require
+reindexing documents.
+
+No chat provider is called during application startup or automated tests. A hosted
+request occurs only when a user submits a sufficiently grounded assistant question.
+
+## Local Ollama setup
 
 The assistant requires both local models:
 
@@ -22,6 +33,53 @@ dotnet run --project src/ContractIQ.Api
 `embeddinggemma` creates query and document embeddings. `qwen3:4b` generates the bilingual explanation. The model files stay in the local `contractiq-ollama-data` Docker volume. No Azure credential, hosted resource, or token charge is required.
 
 The chat model is a larger optional download of approximately 2.5 GB. Normal customer, contract, assessment, and cancellation-request endpoints remain available without it.
+
+## Kimi setup
+
+Kimi uses its OpenAI-compatible Chat Completions endpoint and supports the same
+function-calling flow used by the local adapter. You need a Kimi Open Platform API
+key with API credits. Do not commit the key, place it in React, or paste it into an
+issue or pull request.
+
+Store the provider selection and key in .NET user secrets on your own machine:
+
+```powershell
+dotnet user-secrets set "Assistant:Provider" "Kimi" --project src/ContractIQ.Api
+dotnet user-secrets set "Assistant:Kimi:ApiKey" "PASTE-YOUR-KEY-LOCALLY" --project src/ContractIQ.Api
+```
+
+The non-secret defaults are:
+
+```json
+{
+  "Assistant": {
+    "Kimi": {
+      "Endpoint": "https://api.moonshot.ai/v1",
+      "ChatModel": "kimi-k2.6"
+    }
+  }
+}
+```
+
+Alternatively, set the standard `MOONSHOT_API_KEY` environment variable and set
+only the provider through user secrets. Start PostgreSQL and Ollama for local
+embeddings, but the larger `qwen3:4b` chat model does not need to be loaded:
+
+```powershell
+docker compose --profile local-ai up -d postgres ollama
+dotnet run --project src/ContractIQ.Api
+```
+
+To return to the zero-cost local chat provider:
+
+```powershell
+dotnet user-secrets set "Assistant:Provider" "Ollama" --project src/ContractIQ.Api
+dotnet user-secrets remove "Assistant:Kimi:ApiKey" --project src/ContractIQ.Api
+```
+
+A Kimi Code subscription credential may use a different endpoint and may be
+restricted to coding agents. For this application, use a key issued by the Kimi
+Open Platform unless the account documentation explicitly states otherwise.
 
 ## API request
 
@@ -60,7 +118,7 @@ Run scoped hybrid knowledge retrieval
 build safe prompt     localized refusal
           |
           v
-IChatClient -> Ollama qwen3:4b
+IChatClient -> Ollama qwen3:4b or hosted Kimi
           |
           v
 answer + application-owned citations + assessment
@@ -115,6 +173,6 @@ These measures reduce prompt-injection risk but do not make model output authori
 
 ## Provider boundary
 
-The Application project depends on `IAssistantAnswerGenerator`. Infrastructure implements it with OllamaSharp behind Microsoft's `IChatClient` abstraction. This keeps the orchestration and tests independent from the provider and allows a later Microsoft Foundry adapter without moving domain authority into the model integration.
+The Application project depends on `IAssistantAnswerGenerator`. Infrastructure implements it behind Microsoft's `IChatClient` abstraction with either OllamaSharp or an OpenAI-compatible Kimi client. This keeps orchestration and tests independent from the provider and allows a later Microsoft Foundry adapter without moving domain authority into the model integration.
 
 The same assistant can now prepare a cancellation action through safe tool calling. See [Safe assistant tool calling](safe-tool-calling.md) for the human-confirmation and write boundary.

--- a/docs/assistant/grounded-answers.md
+++ b/docs/assistant/grounded-answers.md
@@ -41,6 +41,11 @@ function-calling flow used by the local adapter. You need a Kimi Open Platform A
 key with API credits. Do not commit the key, place it in React, or paste it into an
 issue or pull request.
 
+The Kimi adapter omits the generic `Temperature` setting because K2.6 accepts only
+provider-defined fixed values. It also explicitly disables K2.6 thinking so the
+provider-specific `reasoning_content` field is not required across the assistant's
+multi-step tool calls. These settings do not change deterministic domain decisions.
+
 Store the provider selection and key in .NET user secrets on your own machine:
 
 ```powershell

--- a/docs/assistant/safe-tool-calling.md
+++ b/docs/assistant/safe-tool-calling.md
@@ -16,7 +16,7 @@ The React experience then shows **Action prepared by the agent**. Selecting **Re
 
 ## Tools available to the model
 
-The local Ollama adapter uses Microsoft `IChatClient`, `AIFunctionFactory`, and `FunctionInvokingChatClient` to expose four functions:
+The provider adapter uses Microsoft `IChatClient`, `AIFunctionFactory`, and `FunctionInvokingChatClient` with either local Ollama or hosted Kimi to expose four functions:
 
 | Tool | Capability | Changes state |
 | --- | --- | --- |

--- a/docs/development.md
+++ b/docs/development.md
@@ -164,6 +164,12 @@ docker compose exec ollama ollama pull qwen3:4b
 
 The pulls download the local embedding model and conversational model to the named volume `contractiq-ollama-data`. They do not create an Azure resource or token charge, but they use local disk, memory, and CPU. `embeddinggemma` is approximately 622 MB and `qwen3:4b` is approximately 2.5 GB.
 
+The assistant can instead use Kimi for chat and tool calling while retaining local
+`embeddinggemma` retrieval. This avoids loading `qwen3:4b` into memory. The hosted
+provider is opt-in and requires a local secret, so repository builds and tests never
+consume Kimi credits. See [Grounded contract assistant](assistant/grounded-answers.md#kimi-setup)
+for configuration and credential boundaries.
+
 Index the committed fictional documents:
 
 ```powershell

--- a/src/ContractIQ.Api/ContractIQ.Api.csproj
+++ b/src/ContractIQ.Api/ContractIQ.Api.csproj
@@ -1,4 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <UserSecretsId>contractiq-api-local-development</UserSecretsId>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\ContractIQ.Application\ContractIQ.Application.csproj" />
     <ProjectReference Include="..\ContractIQ.Infrastructure\ContractIQ.Infrastructure.csproj" />

--- a/src/ContractIQ.Api/appsettings.json
+++ b/src/ContractIQ.Api/appsettings.json
@@ -14,11 +14,16 @@
     }
   },
   "Assistant": {
+    "Provider": "Ollama",
     "MaximumOutputTokens": 600,
     "Temperature": 0.1,
     "Ollama": {
       "Endpoint": "http://localhost:11434",
       "ChatModel": "qwen3:4b"
+    },
+    "Kimi": {
+      "Endpoint": "https://api.moonshot.ai/v1",
+      "ChatModel": "kimi-k2.6"
     }
   },
   "AllowedHosts": "*"

--- a/src/ContractIQ.Infrastructure/Assistant/AssistantOptions.cs
+++ b/src/ContractIQ.Infrastructure/Assistant/AssistantOptions.cs
@@ -3,19 +3,83 @@ using Microsoft.Extensions.Configuration;
 
 namespace ContractIQ.Infrastructure.Assistant;
 
-public sealed record AssistantOptions(
-    Uri OllamaEndpoint,
-    string ChatModel,
-    int MaximumOutputTokens,
-    float Temperature)
+public enum AssistantProvider
 {
+    Ollama,
+    Kimi,
+}
+
+public sealed class AssistantOptions
+{
+    public AssistantOptions(
+        AssistantProvider provider,
+        Uri endpoint,
+        string chatModel,
+        string? apiKey,
+        int maximumOutputTokens,
+        float temperature)
+    {
+        Provider = provider;
+        Endpoint = endpoint;
+        ChatModel = chatModel;
+        ApiKey = apiKey;
+        MaximumOutputTokens = maximumOutputTokens;
+        Temperature = temperature;
+    }
+
+    public AssistantProvider Provider { get; }
+
+    public Uri Endpoint { get; }
+
+    public string ChatModel { get; }
+
+    // A class is used instead of a record so its generated string representation
+    // cannot accidentally include the hosted provider credential in logs.
+    public string? ApiKey { get; }
+
+    public int MaximumOutputTokens { get; }
+
+    public float Temperature { get; }
+
     public static AssistantOptions FromConfiguration(IConfiguration configuration)
     {
-        string endpoint = configuration["Assistant:Ollama:Endpoint"]
-            ?? configuration["Knowledge:Ollama:Endpoint"]
-            ?? "http://localhost:11434";
-        string model = configuration["Assistant:Ollama:ChatModel"]
-            ?? "qwen3:4b";
+        string providerValue = configuration["Assistant:Provider"] ?? "Ollama";
+
+        if (!Enum.TryParse(providerValue, ignoreCase: true, out AssistantProvider provider))
+        {
+            throw new InvalidOperationException(
+                $"Assistant provider '{providerValue}' is not supported. Use 'Ollama' or 'Kimi'.");
+        }
+
+        string endpoint;
+        string model;
+        string? apiKey = null;
+
+        if (provider == AssistantProvider.Kimi)
+        {
+            endpoint = configuration["Assistant:Kimi:Endpoint"]
+                ?? "https://api.moonshot.ai/v1";
+            model = configuration["Assistant:Kimi:ChatModel"]
+                ?? "kimi-k2.6";
+            apiKey = configuration["Assistant:Kimi:ApiKey"]
+                ?? configuration["MOONSHOT_API_KEY"];
+
+            if (string.IsNullOrWhiteSpace(apiKey))
+            {
+                throw new InvalidOperationException(
+                    "Kimi is selected as the assistant provider, but no API key is configured. " +
+                    "Set 'Assistant:Kimi:ApiKey' with .NET user secrets or set MOONSHOT_API_KEY.");
+            }
+        }
+        else
+        {
+            endpoint = configuration["Assistant:Ollama:Endpoint"]
+                ?? configuration["Knowledge:Ollama:Endpoint"]
+                ?? "http://localhost:11434";
+            model = configuration["Assistant:Ollama:ChatModel"]
+                ?? "qwen3:4b";
+        }
+
         int maximumOutputTokens = int.TryParse(
             configuration["Assistant:MaximumOutputTokens"],
             out int configuredTokens)
@@ -42,8 +106,10 @@ public sealed record AssistantOptions(
         }
 
         return new AssistantOptions(
+            provider,
             new Uri(endpoint, UriKind.Absolute),
             model,
+            apiKey,
             maximumOutputTokens,
             temperature);
     }

--- a/src/ContractIQ.Infrastructure/Assistant/ChatClientAssistantAnswerGenerator.cs
+++ b/src/ContractIQ.Infrastructure/Assistant/ChatClientAssistantAnswerGenerator.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.AI;
 using OllamaSharp;
 using OllamaSharp.Models.Exceptions;
 using OpenAI;
+using OpenAIChatCompletionOptions = OpenAI.Chat.ChatCompletionOptions;
 
 namespace ContractIQ.Infrastructure.Assistant;
 
@@ -74,25 +75,36 @@ internal sealed class ChatClientAssistantAnswerGenerator : IAssistantAnswerGener
 
         try
         {
+            var chatOptions = new ChatOptions
+            {
+                ModelId = _options.ChatModel,
+                MaxOutputTokens = _options.MaximumOutputTokens,
+                // Kimi models have provider-defined fixed temperatures and reject
+                // the 0.1 value used by the local deterministic demo profile.
+                Temperature = _options.Provider == AssistantProvider.Ollama
+                    ? _options.Temperature
+                    : null,
+                AllowMultipleToolCalls = false,
+                Tools =
+                [
+                    getContract,
+                    assessCancellation,
+                    searchEvidence,
+                    prepareCancellation,
+                ],
+            };
+
+            if (_options.Provider == AssistantProvider.Kimi)
+            {
+                chatOptions.RawRepresentationFactory = _ => CreateKimiChatOptions();
+            }
+
             ChatResponse response = await _chatClient.GetResponseAsync(
                 [
                     new ChatMessage(ChatRole.System, prompt.SystemPrompt),
                     new ChatMessage(ChatRole.User, prompt.UserPrompt),
                 ],
-                new ChatOptions
-                {
-                    ModelId = _options.ChatModel,
-                    MaxOutputTokens = _options.MaximumOutputTokens,
-                    Temperature = _options.Temperature,
-                    AllowMultipleToolCalls = false,
-                    Tools =
-                    [
-                        getContract,
-                        assessCancellation,
-                        searchEvidence,
-                        prepareCancellation,
-                    ],
-                },
+                chatOptions,
                 cancellationToken);
 
             return new GeneratedAssistantAnswer(
@@ -132,6 +144,17 @@ internal sealed class ChatClientAssistantAnswerGenerator : IAssistantAnswerGener
 
         return new OllamaApiClient(options.Endpoint, options.ChatModel);
     }
+
+#pragma warning disable SCME0001 // Patch is required for Kimi's provider-specific request field.
+    private static OpenAIChatCompletionOptions CreateKimiChatOptions()
+    {
+        var options = new OpenAIChatCompletionOptions();
+        options.Patch.Set(
+            "$.thinking"u8,
+            BinaryData.FromString("""{"type":"disabled"}"""));
+        return options;
+    }
+#pragma warning restore SCME0001
 
     private ExternalDependencyUnavailableException CreateUnavailableException(
         Exception exception)

--- a/src/ContractIQ.Infrastructure/Assistant/ChatClientAssistantAnswerGenerator.cs
+++ b/src/ContractIQ.Infrastructure/Assistant/ChatClientAssistantAnswerGenerator.cs
@@ -1,26 +1,31 @@
+using System.ClientModel;
 using ContractIQ.Application.Assistant;
 using ContractIQ.Application.Assistant.Tools;
 using ContractIQ.Application.Common.Exceptions;
 using Microsoft.Extensions.AI;
 using OllamaSharp;
 using OllamaSharp.Models.Exceptions;
+using OpenAI;
 
 namespace ContractIQ.Infrastructure.Assistant;
 
-internal sealed class OllamaAssistantAnswerGenerator : IAssistantAnswerGenerator, IDisposable
+/// <summary>
+/// Exposes the same application-owned tools to either a local Ollama model or
+/// the hosted Kimi API. Business decisions and writes remain in the application.
+/// </summary>
+internal sealed class ChatClientAssistantAnswerGenerator : IAssistantAnswerGenerator, IDisposable
 {
     private readonly IChatClient _chatClient;
     private readonly AssistantOptions _options;
     private readonly ContractAssistantReadTools _readTools;
 
-    public OllamaAssistantAnswerGenerator(
+    public ChatClientAssistantAnswerGenerator(
         AssistantOptions options,
         ContractAssistantReadTools readTools)
     {
         _options = options;
         _readTools = readTools;
-        _chatClient = new FunctionInvokingChatClient(
-            new OllamaApiClient(options.OllamaEndpoint, options.ChatModel))
+        _chatClient = new FunctionInvokingChatClient(CreateProviderClient(options))
         {
             AllowConcurrentInvocation = false,
             IncludeDetailedErrors = false,
@@ -95,15 +100,49 @@ internal sealed class OllamaAssistantAnswerGenerator : IAssistantAnswerGenerator
                 _options.ChatModel,
                 proposedAction);
         }
-        catch (Exception exception) when (
-            exception is HttpRequestException or OllamaException)
+        catch (OperationCanceledException exception) when (!cancellationToken.IsCancellationRequested)
         {
-            throw new ExternalDependencyUnavailableException(
-                "ollama",
-                $"Ollama is unavailable or chat model '{_options.ChatModel}' is not installed.",
-                exception);
+            throw CreateUnavailableException(exception);
+        }
+        catch (Exception exception) when (
+            exception is HttpRequestException or OllamaException or ClientResultException)
+        {
+            throw CreateUnavailableException(exception);
         }
     }
 
     public void Dispose() => _chatClient.Dispose();
+
+    private static IChatClient CreateProviderClient(AssistantOptions options)
+    {
+        if (options.Provider == AssistantProvider.Kimi)
+        {
+            var clientOptions = new OpenAIClientOptions
+            {
+                Endpoint = options.Endpoint,
+            };
+            var openAiClient = new OpenAIClient(
+                new ApiKeyCredential(options.ApiKey!),
+                clientOptions);
+
+            return openAiClient
+                .GetChatClient(options.ChatModel)
+                .AsIChatClient();
+        }
+
+        return new OllamaApiClient(options.Endpoint, options.ChatModel);
+    }
+
+    private ExternalDependencyUnavailableException CreateUnavailableException(
+        Exception exception)
+    {
+        string dependency = _options.Provider == AssistantProvider.Kimi
+            ? "kimi"
+            : "ollama";
+        string message = _options.Provider == AssistantProvider.Kimi
+            ? $"Kimi is unavailable or model '{_options.ChatModel}' cannot be accessed."
+            : $"Ollama is unavailable or chat model '{_options.ChatModel}' is not installed.";
+
+        return new ExternalDependencyUnavailableException(dependency, message, exception);
+    }
 }

--- a/src/ContractIQ.Infrastructure/ContractIQ.Infrastructure.csproj
+++ b/src/ContractIQ.Infrastructure/ContractIQ.Infrastructure.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.Extensions.AI" />
+    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
     <PackageReference Include="OllamaSharp" />
     <PackageReference Include="Pgvector.EntityFrameworkCore" />

--- a/src/ContractIQ.Infrastructure/DependencyInjection.cs
+++ b/src/ContractIQ.Infrastructure/DependencyInjection.cs
@@ -43,8 +43,10 @@ public static class DependencyInjection
                 "embeddinggemma",
                 768),
             new AssistantOptions(
+                AssistantProvider.Ollama,
                 new Uri("http://localhost:11434"),
                 "qwen3:4b",
+                null,
                 600,
                 0.1f));
     }
@@ -58,8 +60,10 @@ public static class DependencyInjection
             connectionString,
             knowledgeOptions,
             new AssistantOptions(
+                AssistantProvider.Ollama,
                 new Uri("http://localhost:11434"),
                 "qwen3:4b",
+                null,
                 600,
                 0.1f));
     }
@@ -97,7 +101,7 @@ public static class DependencyInjection
         services.AddSingleton(assistantOptions);
         services.AddSingleton<IAssistantToolAudit, LoggingAssistantToolAudit>();
         services.AddScoped<IAssistantWriteTransaction, EfAssistantWriteTransaction>();
-        services.AddScoped<IAssistantAnswerGenerator, OllamaAssistantAnswerGenerator>();
+        services.AddScoped<IAssistantAnswerGenerator, ChatClientAssistantAnswerGenerator>();
 
         return services;
     }

--- a/tests/ContractIQ.IntegrationTests/AssistantOptionsTests.cs
+++ b/tests/ContractIQ.IntegrationTests/AssistantOptionsTests.cs
@@ -1,0 +1,75 @@
+using ContractIQ.Infrastructure.Assistant;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace ContractIQ.IntegrationTests;
+
+public sealed class AssistantOptionsTests
+{
+    [Fact]
+    public void Defaults_to_local_ollama_without_a_hosted_credential()
+    {
+        IConfiguration configuration = BuildConfiguration([]);
+
+        AssistantOptions options = AssistantOptions.FromConfiguration(configuration);
+
+        Assert.Equal(AssistantProvider.Ollama, options.Provider);
+        Assert.Equal(new Uri("http://localhost:11434"), options.Endpoint);
+        Assert.Equal("qwen3:4b", options.ChatModel);
+        Assert.Null(options.ApiKey);
+    }
+
+    [Fact]
+    public void Configures_kimi_from_provider_settings()
+    {
+        IConfiguration configuration = BuildConfiguration(
+            new Dictionary<string, string?>
+            {
+                ["Assistant:Provider"] = "Kimi",
+                ["Assistant:Kimi:ApiKey"] = "local-test-key",
+            });
+
+        AssistantOptions options = AssistantOptions.FromConfiguration(configuration);
+
+        Assert.Equal(AssistantProvider.Kimi, options.Provider);
+        Assert.Equal(new Uri("https://api.moonshot.ai/v1"), options.Endpoint);
+        Assert.Equal("kimi-k2.6", options.ChatModel);
+        Assert.Equal("local-test-key", options.ApiKey);
+    }
+
+    [Fact]
+    public void Rejects_kimi_without_an_api_key()
+    {
+        IConfiguration configuration = BuildConfiguration(
+            new Dictionary<string, string?>
+            {
+                ["Assistant:Provider"] = "Kimi",
+            });
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+            () => AssistantOptions.FromConfiguration(configuration));
+
+        Assert.Contains("no API key", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Rejects_an_unknown_provider()
+    {
+        IConfiguration configuration = BuildConfiguration(
+            new Dictionary<string, string?>
+            {
+                ["Assistant:Provider"] = "Unknown",
+            });
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+            () => AssistantOptions.FromConfiguration(configuration));
+
+        Assert.Contains("not supported", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static IConfiguration BuildConfiguration(
+        IEnumerable<KeyValuePair<string, string?>> values) =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(values)
+            .Build();
+}


### PR DESCRIPTION
## Summary
- adds Kimi as an opt-in OpenAI-compatible chat and tool-calling provider
- keeps local Ollama as the committed zero-cost default
- keeps mbeddinggemma, PostgreSQL hybrid retrieval, citations, and deterministic domain rules unchanged
- stores hosted credentials outside source control through .NET user secrets or MOONSHOT_API_KEY`n- documents setup, local resource trade-offs, and the distinction between Kimi Open Platform and Kimi Code credentials

## Safety and cost boundary
- no provider call happens during application startup
- no live Kimi call is used by tests or CI
- Kimi cannot be selected without an explicit local credential
- the API key is not represented by a record to reduce accidental exposure in logs
- write operations still require the existing explicit confirmation endpoint

## Validation
- dotnet build ContractIQ.slnx --configuration Release --no-restore --maxcpucount:1`n- dotnet format ContractIQ.slnx --verify-no-changes --no-restore`n- dotnet test ContractIQ.slnx --configuration Release --no-build --maxcpucount:1`n- 107 tests passed

Closes #23