### PR TITLE
[Observability] Add end-to-end OpenTelemetry and local dashboard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,10 @@ CONTRACTIQ_POSTGRES_DB=contractiq
 CONTRACTIQ_POSTGRES_USER=contractiq
 CONTRACTIQ_POSTGRES_PASSWORD=contractiq
 CONTRACTIQ_POSTGRES_PORT=5432
+
+# Optional local observability profile. The image is pulled only when that
+# profile is started explicitly.
+CONTRACTIQ_ASPIRE_DASHBOARD_IMAGE=mcr.microsoft.com/dotnet/aspire-dashboard:latest
+CONTRACTIQ_ASPIRE_DASHBOARD_PORT=18888
+CONTRACTIQ_OTLP_GRPC_PORT=4317
+CONTRACTIQ_OTLP_HTTP_PORT=4318

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,7 +19,13 @@
     <PackageVersion Include="Microsoft.OpenApi" Version="2.12.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.3" />
+    <PackageVersion Include="Npgsql.OpenTelemetry" Version="10.0.3" />
     <PackageVersion Include="OllamaSharp" Version="5.4.30" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.18.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.18.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.18.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.18.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.18.0" />
     <PackageVersion Include="Pgvector.EntityFrameworkCore" Version="0.3.0" />
     <PackageVersion Include="Respawn" Version="7.0.0" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.14.0" />

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The application answers contract questions using structured business data, deter
 
 ## Project status
 
-The foundation, bilingual React experience, deterministic cancellation vertical slice, PostgreSQL persistence, local hybrid retrieval, grounded bilingual assistant, and safe cancellation tool calling are implemented with automated tests. Delivery is tracked through GitHub Issues, milestones, short-lived branches, and linked pull requests.
+The foundation, bilingual React experience, deterministic cancellation vertical slice, PostgreSQL persistence, local hybrid retrieval, grounded bilingual assistant, safe cancellation tool calling, and end-to-end OpenTelemetry are implemented with automated tests. Delivery is tracked through GitHub Issues, milestones, short-lived branches, and linked pull requests.
 
 ## Planned technology
 
@@ -32,6 +32,7 @@ Cancellation eligibility, dates, penalties, validation, authorization, idempoten
 - [Local knowledge retrieval](docs/knowledge/local-retrieval.md)
 - [Grounded contract assistant](docs/assistant/grounded-answers.md)
 - [Safe assistant tool calling](docs/assistant/safe-tool-calling.md)
+- [Local OpenTelemetry and dashboard](docs/observability/local-telemetry.md)
 - [Delivery roadmap](docs/roadmap.md)
 - [Contributing](CONTRIBUTING.md)
 - [Architecture Decision Records](docs/adr)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,16 @@ services:
       retries: 10
       start_period: 15s
 
+  aspire-dashboard:
+    image: ${CONTRACTIQ_ASPIRE_DASHBOARD_IMAGE:-mcr.microsoft.com/dotnet/aspire-dashboard:latest}
+    profiles: ["observability"]
+    environment:
+      ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS: "true"
+    ports:
+      - "127.0.0.1:${CONTRACTIQ_ASPIRE_DASHBOARD_PORT:-18888}:18888"
+      - "127.0.0.1:${CONTRACTIQ_OTLP_GRPC_PORT:-4317}:18889"
+      - "127.0.0.1:${CONTRACTIQ_OTLP_HTTP_PORT:-4318}:18890"
+
 volumes:
   contractiq-postgres-data:
   contractiq-ollama-data:

--- a/docs/adr/0006-use-opentelemetry-with-an-optional-local-dashboard.md
+++ b/docs/adr/0006-use-opentelemetry-with-an-optional-local-dashboard.md
@@ -1,0 +1,45 @@
+# ADR 0006: Use OpenTelemetry with an optional local dashboard
+
+- Status: Accepted
+- Date: 2026-08-28
+
+## Context
+
+The portfolio demo needs correlated visibility across HTTP, PostgreSQL,
+retrieval, model calls, tools, and commands. The default development experience
+must remain local and free, while leaving a credible path to Azure Monitor and
+Application Insights later.
+
+Telemetry can expose sensitive contract information if prompts, document chunks,
+identifiers, request bodies, or secrets become attributes or logs. Observability
+therefore needs an explicit data boundary rather than broad payload capture.
+
+## Decision
+
+Use OpenTelemetry as the vendor-neutral instrumentation standard and the
+standalone .NET Aspire Dashboard as an opt-in Docker Compose profile.
+
+The API composition root configures OTLP exporters. Application use cases expose
+business operation spans and metrics through the native .NET `ActivitySource` and
+`Meter` APIs; the domain remains telemetry-independent. ASP.NET Core, `HttpClient`,
+runtime, and Npgsql use established instrumentation packages.
+
+Export is disabled by default. The local dashboard binds only to loopback, is
+started explicitly, and creates no Azure resources.
+
+Prompts, answers, document content, secrets, business identifiers, idempotency
+keys, and request/response bodies are not exported. Numeric token usage is
+recorded only when the provider supplies it.
+
+## Consequences
+
+- One trace connects transport, application orchestration, external providers,
+  tools, commands, and persistence.
+- Local demonstrations require only an additional container image and no cloud
+  subscription.
+- The same telemetry model can later target Azure Monitor or another OTLP
+  backend without changing deterministic business logic.
+- Export remains opt-in, so developers must enable it when they want to inspect
+  telemetry.
+- The local dashboard is a diagnostic experience, not a production retention,
+  alerting, or access-control solution.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -21,6 +21,7 @@ flowchart TB
     Infrastructure --> LocalAI[Local AI provider]
     Infrastructure --> Foundry[Microsoft Foundry]
     Infrastructure --> AzureSearch[Azure AI Search]
+    Api -. traces, metrics, logs .-> Dashboard[Local Aspire Dashboard]
 ```
 
 ## Logical boundaries
@@ -57,7 +58,7 @@ Commands and queries use separate request and handler types, but share the same 
 
 ## AI safety boundary
 
-The model may choose a tool. It cannot authoritatively calculate a penalty, validate a cancellation, assign a status, authorize a user, or write directly to the database. State-changing tools require explicit confirmation and execute application commands that recalculate and validate all business rules. Tool audit events contain identifiers, tool name, outcome, timestamp, and state-changing classification, but never prompts or document content.
+The model may choose a tool. It cannot authoritatively calculate a penalty, validate a cancellation, assign a status, authorize a user, or write directly to the database. State-changing tools require explicit confirmation and execute application commands that recalculate and validate all business rules. Tool audit events contain identifiers inside the application boundary, plus tool name, outcome, timestamp, and state-changing classification. Exported logs omit the business identifiers as well as prompts and document content.
 
 Retrieved document content is untrusted data. Instructions inside a document cannot change system behavior or enable tools.
 
@@ -68,3 +69,16 @@ Retrieved document content is untrusted data. Instructions inside a document can
 - `Azure`: optional Microsoft Foundry and Azure AI Search adapters.
 
 The default developer experience remains functional without Azure.
+
+## Observability boundary
+
+The API composition root configures OpenTelemetry and its optional OTLP exporter.
+Application handlers use the native .NET `ActivitySource` and `Meter` APIs to name
+business operations without depending on a telemetry backend. The domain remains
+free of observability dependencies.
+
+ASP.NET Core, `HttpClient`, Npgsql, RAG orchestration, model calls, tools, and
+cancellation commands participate in the same W3C trace. Export is disabled by
+default and the local Aspire Dashboard runs only through an explicit Docker
+Compose profile. See [Local telemetry](../observability/local-telemetry.md) for
+metrics, correlation, and the data protection policy.

--- a/docs/development.md
+++ b/docs/development.md
@@ -180,6 +180,22 @@ Run the same command again to verify idempotency. Unchanged document versions ar
 
 See [Local knowledge retrieval](knowledge/local-retrieval.md) for ranking and indexing details, and [Grounded contract assistant](assistant/grounded-answers.md) for generation, citations, refusal behavior, and safety boundaries.
 
+## Inspect local telemetry
+
+OpenTelemetry export and the Aspire Dashboard are optional. Start the local
+dashboard profile, enable export in the API terminal, and then generate requests:
+
+```powershell
+docker compose --profile observability up -d aspire-dashboard
+$env:OpenTelemetry__Enabled = 'true'
+$env:OpenTelemetry__OtlpEndpoint = 'http://localhost:4317'
+dotnet run --project src/ContractIQ.Api
+```
+
+Open `http://localhost:18888` to inspect correlated traces, structured logs, and
+metrics. No Azure account is used. See [Local telemetry](observability/local-telemetry.md)
+for the operation map, privacy boundary, health behavior, and troubleshooting.
+
 In a second terminal, start the React application:
 
 ```powershell

--- a/docs/observability/local-telemetry.md
+++ b/docs/observability/local-telemetry.md
@@ -1,0 +1,125 @@
+# Local telemetry
+
+ContractIQ uses vendor-neutral OpenTelemetry for traces, metrics, and structured
+logs. The optional standalone .NET Aspire Dashboard receives the telemetry on the
+developer machine. This profile does not create Azure resources and has no cloud
+telemetry charge.
+
+## Start the dashboard
+
+From the repository root, start only the optional observability service:
+
+```powershell
+docker compose --profile observability up -d aspire-dashboard
+docker compose --profile observability ps
+```
+
+Enable OTLP export for the current API terminal, then run the API:
+
+```powershell
+$env:OpenTelemetry__Enabled = 'true'
+$env:OpenTelemetry__OtlpEndpoint = 'http://localhost:4317'
+dotnet run --project src/ContractIQ.Api
+```
+
+Open `http://localhost:18888`. Anonymous access is enabled only for this local,
+loopback-bound dashboard. The API remains fully functional when telemetry export
+is disabled or the dashboard is not running.
+
+Use `src/ContractIQ.Api/ContractIQ.Api.http` or the React interface to generate
+traffic. Open a trace in the dashboard after asking the assistant a question. A
+complete request can include these nested operations:
+
+```text
+HTTP request
+└── contractiq.assistant.ask
+    ├── PostgreSQL contract query
+    ├── contractiq.knowledge.search
+    │   ├── contractiq.knowledge.embedding.generate
+    │   │   └── outbound model HTTP request
+    │   └── contractiq.knowledge.index.query
+    │       └── PostgreSQL hybrid search
+    └── contractiq.ai.model.generate
+        ├── outbound model HTTP request
+        └── contractiq.assistant.tool
+```
+
+A confirmed cancellation adds `contractiq.assistant.tool.execute` and
+`contractiq.cancellation.create` spans. PostgreSQL command spans are emitted by
+Npgsql and remain children of the same request trace.
+
+## Correlation
+
+Every HTTP response includes `X-Correlation-ID`. The value is the W3C trace ID
+used by OpenTelemetry and is also returned as `traceId` in API problem details.
+Exported structured logs include the same value through a logging scope, so a
+dashboard search can move from an error response to its logs and complete trace.
+Metrics use trace-based exemplars, allowing a backend that supports exemplars to
+link a representative measurement back to its sampled request trace.
+
+Incoming distributed traces should use the standard W3C `traceparent` header.
+ContractIQ does not accept an arbitrary caller-provided correlation value as a
+trusted trace identity.
+
+## Application metrics
+
+The dashboard receives runtime, ASP.NET Core, HTTP client, and Npgsql metrics in
+addition to these application-owned measurements:
+
+- `contractiq.assistant.requests` and `contractiq.assistant.request.duration`;
+- `contractiq.assistant.evidence.count` and `contractiq.assistant.citation.count`;
+- `contractiq.knowledge.searches`, duration, and result count;
+- `contractiq.ai.model.requests`, duration, and provider-reported token counts;
+- `contractiq.assistant.tool.calls` by tool, outcome, and state-changing class;
+- `contractiq.cancellation.commands` and command duration.
+
+Token metrics are emitted only when the provider reports usage. A missing value
+does not mean zero tokens were consumed.
+
+## Data protection boundary
+
+Telemetry intentionally excludes:
+
+- questions, prompts, answers, document chunks, and retrieved document content;
+- API keys, authorization headers, connection strings, and idempotency keys;
+- customer IDs, contract IDs, cancellation request IDs, and document paths;
+- token content or model reasoning content.
+
+Safe dimensions include operation name, provider and model name, language,
+outcome, duration, counts, and whether a tool is state-changing. The model HTTP
+instrumentation uses standard request metadata and does not capture request or
+response bodies. EF Core parameter value logging is not enabled.
+
+Tool audit events retain business identifiers inside the application boundary so
+a future authorized audit store can enforce access controls. The current exported
+log deliberately omits those identifiers.
+
+## Health endpoints
+
+- `/health/live` checks only whether the process is serving requests.
+- `/health/ready` and `/health` include PostgreSQL availability.
+
+Health responses also include `X-Correlation-ID`. Automated integration tests
+verify the liveness/readiness distinction and correlation between the response
+header and problem details.
+
+## Stop and troubleshoot
+
+Stop the dashboard without affecting PostgreSQL:
+
+```powershell
+docker compose --profile observability stop aspire-dashboard
+```
+
+If no telemetry appears, confirm that the dashboard is running, that port `4317`
+is available, and that the API was started after setting
+`OpenTelemetry__Enabled=true`. Export is batched, so allow a few seconds after
+generating a request.
+
+To change ports in `.env`, keep `CONTRACTIQ_OTLP_GRPC_PORT` and the API's
+`OpenTelemetry__OtlpEndpoint` value aligned.
+
+The OpenTelemetry instrumentation is intentionally backend-neutral. A future
+Azure deployment can export the same signals to Azure Monitor/Application
+Insights without moving observability concerns into the domain or application
+use cases.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -28,7 +28,7 @@ Add configurable Microsoft Entra ID authentication and optional Microsoft Foundr
 
 ## M6 - Portfolio Release
 
-Complete OpenTelemetry, local dashboards, AI evaluations, security review, demonstration material, and the first tagged release.
+OpenTelemetry and the optional local dashboard are implemented. Complete AI evaluations, security review, demonstration material, and the first tagged release.
 
 ## Definition of Ready
 

--- a/src/ContractIQ.Api/ContractIQ.Api.csproj
+++ b/src/ContractIQ.Api/ContractIQ.Api.csproj
@@ -12,5 +12,11 @@
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
     <!-- Pins the patched 2.x line used transitively by ASP.NET Core OpenAPI. -->
     <PackageReference Include="Microsoft.OpenApi" />
+    <PackageReference Include="Npgsql.OpenTelemetry" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" />
   </ItemGroup>
 </Project>

--- a/src/ContractIQ.Api/Errors/ApplicationExceptionHandler.cs
+++ b/src/ContractIQ.Api/Errors/ApplicationExceptionHandler.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics;
+using ContractIQ.Api.Observability;
 using ContractIQ.Application.Common.Exceptions;
 using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Mvc;
@@ -32,7 +32,8 @@ public sealed class ApplicationExceptionHandler(
         };
 
         problem.Extensions["code"] = mapping.Code;
-        problem.Extensions["traceId"] = Activity.Current?.Id ?? httpContext.TraceIdentifier;
+        problem.Extensions["traceId"] =
+            RequestCorrelationMiddleware.ResolveCorrelationId(httpContext);
 
         if (mapping.Field is not null)
         {

--- a/src/ContractIQ.Api/Observability/OpenTelemetryExtensions.cs
+++ b/src/ContractIQ.Api/Observability/OpenTelemetryExtensions.cs
@@ -1,0 +1,62 @@
+using ContractIQ.Application.Common.Observability;
+using Npgsql;
+using OpenTelemetry.Logs;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+
+namespace ContractIQ.Api.Observability;
+
+public static class OpenTelemetryExtensions
+{
+    public static WebApplicationBuilder AddContractIqOpenTelemetry(
+        this WebApplicationBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        OpenTelemetryOptions options = OpenTelemetryOptions.FromConfiguration(
+            builder.Configuration);
+
+        if (!options.Enabled)
+        {
+            return builder;
+        }
+
+        string serviceVersion = typeof(Program).Assembly
+            .GetName()
+            .Version?
+            .ToString() ?? "unknown";
+        ResourceBuilder resource = ResourceBuilder
+            .CreateDefault()
+            .AddService(options.ServiceName, serviceVersion: serviceVersion);
+
+        builder.Services
+            .AddOpenTelemetry()
+            .ConfigureResource(resourceBuilder =>
+                resourceBuilder.AddService(options.ServiceName, serviceVersion: serviceVersion))
+            .WithTracing(tracing => tracing
+                .AddSource(ContractIqTelemetry.ActivitySourceName)
+                .AddAspNetCoreInstrumentation()
+                .AddHttpClientInstrumentation()
+                .AddNpgsql()
+                .AddOtlpExporter(exporter => exporter.Endpoint = options.OtlpEndpoint))
+            .WithMetrics(metrics => metrics
+                .SetExemplarFilter(ExemplarFilterType.TraceBased)
+                .AddMeter(ContractIqTelemetry.MeterName)
+                .AddNpgsqlInstrumentation(_ => { })
+                .AddAspNetCoreInstrumentation()
+                .AddHttpClientInstrumentation()
+                .AddRuntimeInstrumentation()
+                .AddOtlpExporter(exporter => exporter.Endpoint = options.OtlpEndpoint));
+
+        builder.Logging.AddOpenTelemetry(logging =>
+        {
+            logging.IncludeFormattedMessage = true;
+            logging.IncludeScopes = true;
+            logging.SetResourceBuilder(resource);
+            logging.AddOtlpExporter(exporter => exporter.Endpoint = options.OtlpEndpoint);
+        });
+
+        return builder;
+    }
+}

--- a/src/ContractIQ.Api/Observability/OpenTelemetryOptions.cs
+++ b/src/ContractIQ.Api/Observability/OpenTelemetryOptions.cs
@@ -1,0 +1,35 @@
+namespace ContractIQ.Api.Observability;
+
+public sealed record OpenTelemetryOptions(
+    bool Enabled,
+    string ServiceName,
+    Uri OtlpEndpoint)
+{
+    public const string SectionName = "OpenTelemetry";
+
+    public static OpenTelemetryOptions FromConfiguration(IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        IConfigurationSection section = configuration.GetSection(SectionName);
+        bool enabled = bool.TryParse(section["Enabled"], out bool configuredEnabled) &&
+            configuredEnabled;
+        string serviceName = section["ServiceName"]?.Trim() ?? "ContractIQ.Api";
+        string endpointValue = section["OtlpEndpoint"]?.Trim() ?? "http://localhost:4317";
+
+        if (string.IsNullOrWhiteSpace(serviceName))
+        {
+            throw new InvalidOperationException(
+                $"{SectionName}:ServiceName must not be empty.");
+        }
+
+        if (!Uri.TryCreate(endpointValue, UriKind.Absolute, out Uri? endpoint) ||
+            endpoint.Scheme is not ("http" or "https"))
+        {
+            throw new InvalidOperationException(
+                $"{SectionName}:OtlpEndpoint must be an absolute HTTP or HTTPS URI.");
+        }
+
+        return new OpenTelemetryOptions(enabled, serviceName, endpoint);
+    }
+}

--- a/src/ContractIQ.Api/Observability/RequestCorrelationMiddleware.cs
+++ b/src/ContractIQ.Api/Observability/RequestCorrelationMiddleware.cs
@@ -1,0 +1,50 @@
+using System.Diagnostics;
+
+namespace ContractIQ.Api.Observability;
+
+public sealed class RequestCorrelationMiddleware(
+    RequestDelegate next,
+    ILogger<RequestCorrelationMiddleware> logger)
+{
+    public const string HeaderName = "X-Correlation-ID";
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        string correlationId = ResolveCorrelationId(context);
+        context.TraceIdentifier = correlationId;
+
+        context.Response.OnStarting(() =>
+        {
+            context.Response.Headers[HeaderName] = correlationId;
+            return Task.CompletedTask;
+        });
+
+        // The scope lets every structured log emitted during this request carry
+        // the same identifier as the trace returned to the caller.
+        using IDisposable? scope = logger.BeginScope(new Dictionary<string, object>
+        {
+            ["CorrelationId"] = correlationId,
+        });
+
+        await next(context);
+    }
+
+    public static string ResolveCorrelationId(HttpContext context)
+    {
+        if (Activity.Current is { TraceId: var traceId } &&
+            traceId != default)
+        {
+            return traceId.ToString();
+        }
+
+        if (ActivityContext.TryParse(
+            context.TraceIdentifier,
+            traceState: null,
+            out ActivityContext activityContext))
+        {
+            return activityContext.TraceId.ToString();
+        }
+
+        return context.TraceIdentifier;
+    }
+}

--- a/src/ContractIQ.Api/Program.cs
+++ b/src/ContractIQ.Api/Program.cs
@@ -3,6 +3,7 @@ using System.Text.Json.Serialization;
 using ContractIQ.Api.Endpoints;
 using ContractIQ.Api.Errors;
 using ContractIQ.Api.Health;
+using ContractIQ.Api.Observability;
 using ContractIQ.Application.Assistant;
 using ContractIQ.Application.Assistant.Tools;
 using ContractIQ.Application.Cancellations.CreateCancellationRequest;
@@ -17,7 +18,16 @@ using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Services.AddProblemDetails();
+builder.AddContractIqOpenTelemetry();
+
+builder.Services.AddProblemDetails(options =>
+{
+    options.CustomizeProblemDetails = context =>
+    {
+        context.ProblemDetails.Extensions["traceId"] =
+            RequestCorrelationMiddleware.ResolveCorrelationId(context.HttpContext);
+    };
+});
 builder.Services.AddExceptionHandler<ApplicationExceptionHandler>();
 builder.Services.AddHealthChecks();
 builder.Services.AddOpenApi();
@@ -44,6 +54,7 @@ var app = builder.Build();
 
 await app.Services.InitializeDatabaseAsync();
 
+app.UseMiddleware<RequestCorrelationMiddleware>();
 app.UseExceptionHandler();
 
 if (app.Environment.IsDevelopment())

--- a/src/ContractIQ.Api/appsettings.json
+++ b/src/ContractIQ.Api/appsettings.json
@@ -26,5 +26,10 @@
       "ChatModel": "kimi-k2.6"
     }
   },
+  "OpenTelemetry": {
+    "Enabled": false,
+    "ServiceName": "ContractIQ.Api",
+    "OtlpEndpoint": "http://localhost:4317"
+  },
   "AllowedHosts": "*"
 }

--- a/src/ContractIQ.Application/Assistant/AskContractQuestionHandler.cs
+++ b/src/ContractIQ.Application/Assistant/AskContractQuestionHandler.cs
@@ -1,7 +1,9 @@
+using System.Diagnostics;
 using ContractIQ.Application.Abstractions.Persistence;
 using ContractIQ.Application.Assistant.Tools;
 using ContractIQ.Application.Common.Exceptions;
 using ContractIQ.Application.Common.Models;
+using ContractIQ.Application.Common.Observability;
 using ContractIQ.Application.Contracts.AssessCancellation;
 using ContractIQ.Application.Knowledge;
 using ContractIQ.Application.Knowledge.Search;
@@ -22,96 +24,140 @@ public sealed class AskContractQuestionHandler(
         AskContractQuestionCommand command,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(command);
-        Validate(command);
+        long startedAt = Stopwatch.GetTimestamp();
+        int evidenceCount = 0;
+        using Activity? activity = ContractIqTelemetry.StartActivity(
+            "contractiq.assistant.ask");
 
-        AssistantLanguageParser.TryParse(command.Language, out AssistantLanguage language);
-
-        var contract = await contracts.GetByIdAsync(command.ContractId, cancellationToken);
-
-        if (contract is null || contract.CustomerId != command.CustomerId)
+        try
         {
-            throw new ResourceNotFoundException("Contract", command.ContractId);
-        }
+            ArgumentNullException.ThrowIfNull(command);
+            Validate(command);
 
-        var domainAssessment = contract.AssessCancellation(timeProvider);
-        var assessment = new CancellationAssessmentDto(
-            contract.Id,
-            domainAssessment.IsAllowed,
-            domainAssessment.Reason,
-            domainAssessment.RequestedOn,
-            domainAssessment.EarliestTerminationDate,
-            domainAssessment.ChargeableMonthlyPeriods,
-            MoneyDto.FromDomain(domainAssessment.Penalty),
-            domainAssessment.HasPenalty);
+            AssistantLanguageParser.TryParse(command.Language, out AssistantLanguage language);
+            activity?.SetTag("contractiq.assistant.language", language.ToCode());
 
-        IReadOnlyList<KnowledgeEvidence> evidence = await knowledgeSearch.HandleAsync(
-            new SearchKnowledgeQuery(
-                command.Question,
-                command.CustomerId,
-                command.ContractId,
+            var contract = await contracts.GetByIdAsync(command.ContractId, cancellationToken);
+
+            if (contract is null || contract.CustomerId != command.CustomerId)
+            {
+                throw new ResourceNotFoundException("Contract", command.ContractId);
+            }
+
+            var domainAssessment = contract.AssessCancellation(timeProvider);
+            var assessment = new CancellationAssessmentDto(
+                contract.Id,
+                domainAssessment.IsAllowed,
+                domainAssessment.Reason,
                 domainAssessment.RequestedOn,
-                EvidenceLimit),
-            cancellationToken);
+                domainAssessment.EarliestTerminationDate,
+                domainAssessment.ChargeableMonthlyPeriods,
+                MoneyDto.FromDomain(domainAssessment.Penalty),
+                domainAssessment.HasPenalty);
 
-        bool hasApplicableContractEvidence = evidence.Any(item =>
-            item.DocumentType == KnowledgeDocumentType.Contract &&
-            item.CustomerId == command.CustomerId &&
-            item.ContractId == command.ContractId);
+            IReadOnlyList<KnowledgeEvidence> evidence = await knowledgeSearch.HandleAsync(
+                new SearchKnowledgeQuery(
+                    command.Question,
+                    command.CustomerId,
+                    command.ContractId,
+                    domainAssessment.RequestedOn,
+                    EvidenceLimit),
+                cancellationToken);
+            evidenceCount = evidence.Count;
 
-        if (!hasApplicableContractEvidence)
-        {
-            return new ContractAnswer(
-                InsufficientEvidenceMessage(language),
-                language.ToCode(),
-                HasSufficientEvidence: false,
-                assessment,
-                Citations: [],
-                ModelId: null,
-                ProposedAction: null);
-        }
+            bool hasApplicableContractEvidence = evidence.Any(item =>
+                item.DocumentType == KnowledgeDocumentType.Contract &&
+                item.CustomerId == command.CustomerId &&
+                item.ContractId == command.ContractId);
 
-        AssistantPrompt prompt = promptBuilder.Build(
-            command.Question.Trim(),
-            language,
-            assessment,
-            evidence);
-        GeneratedAssistantAnswer generated = await answerGenerator.GenerateAsync(
-            prompt,
-            new AssistantToolContext(
+            if (!hasApplicableContractEvidence)
+            {
+                activity?.SetTag("contractiq.assistant.evidence.sufficient", false);
+                activity?.SetTag("contractiq.assistant.evidence.count", evidenceCount);
+                activity?.SetTag("contractiq.assistant.citation.count", 0);
+                activity?.SetStatus(ActivityStatusCode.Ok);
+                ContractIqTelemetry.RecordAssistantRequest(
+                    "insufficient_evidence",
+                    Stopwatch.GetElapsedTime(startedAt),
+                    evidenceCount,
+                    citationCount: 0);
+
+                return new ContractAnswer(
+                    InsufficientEvidenceMessage(language),
+                    language.ToCode(),
+                    HasSufficientEvidence: false,
+                    assessment,
+                    Citations: [],
+                    ModelId: null,
+                    ProposedAction: null);
+            }
+
+            AssistantPrompt prompt = promptBuilder.Build(
                 command.Question.Trim(),
-                command.CustomerId,
-                command.ContractId,
+                language,
+                assessment,
+                evidence);
+            GeneratedAssistantAnswer generated = await answerGenerator.GenerateAsync(
+                prompt,
+                new AssistantToolContext(
+                    command.Question.Trim(),
+                    command.CustomerId,
+                    command.ContractId,
+                    language.ToCode(),
+                    domainAssessment.RequestedOn),
+                cancellationToken);
+
+            if (string.IsNullOrWhiteSpace(generated.Text))
+            {
+                throw new ExternalDependencyUnavailableException(
+                    "assistant_model",
+                    "The assistant model returned an empty response.");
+            }
+
+            AssistantCitation[] citations = evidence
+                .Select((item, index) => new AssistantCitation(
+                    index + 1,
+                    item.DocumentKey,
+                    item.Title,
+                    item.Version,
+                    item.Section,
+                    item.Page,
+                    item.SourcePath))
+                .ToArray();
+
+            activity?.SetTag("contractiq.assistant.evidence.sufficient", true);
+            activity?.SetTag("contractiq.assistant.evidence.count", evidenceCount);
+            activity?.SetTag("contractiq.assistant.citation.count", citations.Length);
+            activity?.SetStatus(ActivityStatusCode.Ok);
+            ContractIqTelemetry.RecordAssistantRequest(
+                "succeeded",
+                Stopwatch.GetElapsedTime(startedAt),
+                evidenceCount,
+                citations.Length);
+
+            return new ContractAnswer(
+                generated.Text.Trim(),
                 language.ToCode(),
-                domainAssessment.RequestedOn),
-            cancellationToken);
-
-        if (string.IsNullOrWhiteSpace(generated.Text))
-        {
-            throw new ExternalDependencyUnavailableException(
-                "assistant_model",
-                "The assistant model returned an empty response.");
+                HasSufficientEvidence: true,
+                assessment,
+                citations,
+                generated.ModelId,
+                generated.ProposedAction);
         }
+        catch (Exception exception)
+        {
+            string outcome = exception is OperationCanceledException
+                ? "cancelled"
+                : "failed";
 
-        AssistantCitation[] citations = evidence
-            .Select((item, index) => new AssistantCitation(
-                index + 1,
-                item.DocumentKey,
-                item.Title,
-                item.Version,
-                item.Section,
-                item.Page,
-                item.SourcePath))
-            .ToArray();
-
-        return new ContractAnswer(
-            generated.Text.Trim(),
-            language.ToCode(),
-            HasSufficientEvidence: true,
-            assessment,
-            citations,
-            generated.ModelId,
-            generated.ProposedAction);
+            ContractIqTelemetry.MarkError(activity, exception);
+            ContractIqTelemetry.RecordAssistantRequest(
+                outcome,
+                Stopwatch.GetElapsedTime(startedAt),
+                evidenceCount,
+                citationCount: 0);
+            throw;
+        }
     }
 
     private static void Validate(AskContractQuestionCommand command)

--- a/src/ContractIQ.Application/Assistant/Tools/ConfirmCancellationActionHandler.cs
+++ b/src/ContractIQ.Application/Assistant/Tools/ConfirmCancellationActionHandler.cs
@@ -1,6 +1,8 @@
+using System.Diagnostics;
 using ContractIQ.Application.Abstractions.Persistence;
 using ContractIQ.Application.Cancellations.CreateCancellationRequest;
 using ContractIQ.Application.Common.Exceptions;
+using ContractIQ.Application.Common.Observability;
 
 namespace ContractIQ.Application.Assistant.Tools;
 
@@ -15,11 +17,18 @@ public sealed class ConfirmCancellationActionHandler(
         ConfirmCancellationActionCommand command,
         CancellationToken cancellationToken = default)
     {
+        using Activity? activity = ContractIqTelemetry.StartActivity(
+            "contractiq.assistant.tool.execute");
+        activity?.SetTag("gen_ai.tool.name", AssistantToolNames.CreateCancellation);
+        activity?.SetTag("contractiq.tool.state_changing", true);
+
         ArgumentNullException.ThrowIfNull(command);
 
         if (!command.Confirmed)
         {
             await RecordAsync(command, "confirmation_missing", cancellationToken);
+            activity?.SetTag("contractiq.outcome", "confirmation_missing");
+            activity?.SetStatus(ActivityStatusCode.Error, "ConfirmationMissing");
             throw new ApplicationValidationException(
                 nameof(command.Confirmed),
                 "Explicit user confirmation is required before executing this tool.");
@@ -31,6 +40,8 @@ public sealed class ConfirmCancellationActionHandler(
             StringComparison.Ordinal))
         {
             await RecordAsync(command, "invalid_intent", cancellationToken);
+            activity?.SetTag("contractiq.outcome", "invalid_intent");
+            activity?.SetStatus(ActivityStatusCode.Error, "InvalidIntent");
             throw new ApplicationValidationException(
                 nameof(command.Intent),
                 $"Intent must be '{AssistantToolNames.CreateCancellation}'.");
@@ -62,11 +73,23 @@ public sealed class ConfirmCancellationActionHandler(
                 command,
                 result.IsReplay ? "replayed" : "created",
                 cancellationToken);
+            activity?.SetTag(
+                "contractiq.outcome",
+                result.IsReplay ? "replayed" : "created");
+            activity?.SetStatus(ActivityStatusCode.Ok);
             return result;
         }
-        catch
+        catch (Exception exception)
         {
-            await RecordAsync(command, "rejected", cancellationToken);
+            string outcome = exception is OperationCanceledException
+                ? "cancelled"
+                : "rejected";
+
+            activity?.SetTag(
+                "contractiq.outcome",
+                outcome);
+            ContractIqTelemetry.MarkError(activity, exception);
+            await RecordAsync(command, outcome, CancellationToken.None);
             throw;
         }
     }

--- a/src/ContractIQ.Application/Assistant/Tools/ContractAssistantReadTools.cs
+++ b/src/ContractIQ.Application/Assistant/Tools/ContractAssistantReadTools.cs
@@ -1,4 +1,6 @@
+using System.Diagnostics;
 using ContractIQ.Application.Common.Exceptions;
+using ContractIQ.Application.Common.Observability;
 using ContractIQ.Application.Contracts.AssessCancellation;
 using ContractIQ.Application.Contracts.GetContractDetails;
 using ContractIQ.Application.Knowledge;
@@ -17,46 +19,53 @@ public sealed class ContractAssistantReadTools(
         AssistantToolContext context,
         CancellationToken cancellationToken = default)
     {
-        ContractDetailsDto contract = await GetScopedContractAsync(context, cancellationToken);
-        await RecordAsync(AssistantToolNames.GetContract, context, "succeeded", cancellationToken);
-        return contract;
+        return await ExecuteToolAsync(
+            AssistantToolNames.GetContract,
+            context,
+            token => GetScopedContractAsync(context, token),
+            _ => "succeeded",
+            cancellationToken);
     }
 
     public async Task<CancellationAssessmentDto> AssessCancellationAsync(
         AssistantToolContext context,
         CancellationToken cancellationToken = default)
     {
-        await GetScopedContractAsync(context, cancellationToken);
-        CancellationAssessmentDto assessment = await assessCancellation.HandleAsync(
-            new AssessCancellationQuery(context.ContractId),
-            cancellationToken);
-        await RecordAsync(
+        return await ExecuteToolAsync(
             AssistantToolNames.AssessCancellation,
             context,
-            assessment.IsAllowed ? "allowed" : "not_allowed",
+            async token =>
+            {
+                await GetScopedContractAsync(context, token);
+                return await assessCancellation.HandleAsync(
+                    new AssessCancellationQuery(context.ContractId),
+                    token);
+            },
+            assessment => assessment.IsAllowed ? "allowed" : "not_allowed",
             cancellationToken);
-        return assessment;
     }
 
     public async Task<IReadOnlyList<KnowledgeEvidence>> SearchEvidenceAsync(
         AssistantToolContext context,
         CancellationToken cancellationToken = default)
     {
-        await GetScopedContractAsync(context, cancellationToken);
-        IReadOnlyList<KnowledgeEvidence> evidence = await knowledgeSearch.HandleAsync(
-            new SearchKnowledgeQuery(
-                context.Question,
-                context.CustomerId,
-                context.ContractId,
-                context.AsOf,
-                5),
-            cancellationToken);
-        await RecordAsync(
+        return await ExecuteToolAsync(
             AssistantToolNames.SearchEvidence,
             context,
-            evidence.Count == 0 ? "no_evidence" : "evidence_found",
+            async token =>
+            {
+                await GetScopedContractAsync(context, token);
+                return await knowledgeSearch.HandleAsync(
+                    new SearchKnowledgeQuery(
+                        context.Question,
+                        context.CustomerId,
+                        context.ContractId,
+                        context.AsOf,
+                        5),
+                    token);
+            },
+            evidence => evidence.Count == 0 ? "no_evidence" : "evidence_found",
             cancellationToken);
-        return evidence;
     }
 
     public async Task<AssistantActionProposal> PrepareCancellationAsync(
@@ -64,24 +73,25 @@ public sealed class ContractAssistantReadTools(
         string intent,
         CancellationToken cancellationToken = default)
     {
-        string normalizedIntent = ValidateIntent(intent);
-        CancellationAssessmentDto assessment = await AssessCancellationAsync(
-            context,
-            cancellationToken);
-
-        var proposal = new AssistantActionProposal(
-            AssistantToolNames.CreateCancellation,
-            normalizedIntent,
-            RequiresConfirmation: true,
-            CanExecute: assessment.IsAllowed,
-            assessment);
-
-        await RecordAsync(
+        return await ExecuteToolAsync(
             AssistantToolNames.PrepareCancellation,
             context,
-            proposal.CanExecute ? "confirmation_required" : "not_allowed",
+            async token =>
+            {
+                string normalizedIntent = ValidateIntent(intent);
+                CancellationAssessmentDto assessment = await AssessCancellationAsync(
+                    context,
+                    token);
+
+                return new AssistantActionProposal(
+                    AssistantToolNames.CreateCancellation,
+                    normalizedIntent,
+                    RequiresConfirmation: true,
+                    CanExecute: assessment.IsAllowed,
+                    assessment);
+            },
+            proposal => proposal.CanExecute ? "confirmation_required" : "not_allowed",
             cancellationToken);
-        return proposal;
     }
 
     private async Task<ContractDetailsDto> GetScopedContractAsync(
@@ -116,6 +126,45 @@ public sealed class ContractAssistantReadTools(
                 StateChanging: false,
                 timeProvider.GetUtcNow()),
             cancellationToken);
+    }
+
+    private async Task<T> ExecuteToolAsync<T>(
+        string toolName,
+        AssistantToolContext context,
+        Func<CancellationToken, Task<T>> operation,
+        Func<T, string> outcomeSelector,
+        CancellationToken cancellationToken)
+    {
+        using Activity? activity = ContractIqTelemetry.StartActivity(
+            "contractiq.assistant.tool");
+        activity?.SetTag("gen_ai.tool.name", toolName);
+        activity?.SetTag("contractiq.tool.state_changing", false);
+
+        try
+        {
+            T result = await operation(cancellationToken);
+            string outcome = outcomeSelector(result);
+
+            activity?.SetTag("contractiq.outcome", outcome);
+            activity?.SetStatus(ActivityStatusCode.Ok);
+            await RecordAsync(toolName, context, outcome, cancellationToken);
+
+            return result;
+        }
+        catch (Exception exception)
+        {
+            string outcome = exception is OperationCanceledException
+                ? "cancelled"
+                : "failed";
+
+            activity?.SetTag("contractiq.outcome", outcome);
+            ContractIqTelemetry.MarkError(activity, exception);
+
+            // The audit implementation is local and non-blocking. A cancelled
+            // model request should still leave an outcome for diagnosis.
+            await RecordAsync(toolName, context, outcome, CancellationToken.None);
+            throw;
+        }
     }
 
     private static string ValidateIntent(string intent)

--- a/src/ContractIQ.Application/Cancellations/CreateCancellationRequest/CreateCancellationRequestHandler.cs
+++ b/src/ContractIQ.Application/Cancellations/CreateCancellationRequest/CreateCancellationRequestHandler.cs
@@ -1,6 +1,8 @@
+using System.Diagnostics;
 using ContractIQ.Application.Abstractions.Persistence;
 using ContractIQ.Application.Common.Exceptions;
 using ContractIQ.Application.Common.Models;
+using ContractIQ.Application.Common.Observability;
 using ContractIQ.Domain.Cancellations;
 using CancellationAssessment = ContractIQ.Domain.Contracts.CancellationAssessment;
 using Contract = ContractIQ.Domain.Contracts.Contract;
@@ -16,48 +18,99 @@ public sealed class CreateCancellationRequestHandler(
         CreateCancellationRequestCommand command,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(command);
+        long startedAt = Stopwatch.GetTimestamp();
+        using Activity? activity = ContractIqTelemetry.StartActivity(
+            "contractiq.cancellation.create");
 
-        string idempotencyKey = ValidateIdempotencyKey(command.IdempotencyKey);
-        DateTimeOffset now = timeProvider.GetUtcNow();
-
-        var replay = await cancellationRequests.FindByIdempotencyKeyAsync(
-            idempotencyKey,
-            cancellationToken);
-
-        if (replay is not null)
+        try
         {
-            EnsureReplayMatchesContract(replay, command.ContractId);
-            return ToResult(replay, isReplay: true);
+            ArgumentNullException.ThrowIfNull(command);
+
+            string idempotencyKey = ValidateIdempotencyKey(command.IdempotencyKey);
+            DateTimeOffset now = timeProvider.GetUtcNow();
+
+            var replay = await cancellationRequests.FindByIdempotencyKeyAsync(
+                idempotencyKey,
+                cancellationToken);
+
+            if (replay is not null)
+            {
+                EnsureReplayMatchesContract(replay, command.ContractId);
+                CreateCancellationRequestResult replayResult = ToResult(
+                    replay,
+                    isReplay: true);
+                RecordSuccess(activity, replayResult, startedAt);
+                return replayResult;
+            }
+
+            var contract = await contracts.GetByIdAsync(command.ContractId, cancellationToken)
+                ?? throw new ResourceNotFoundException("Contract", command.ContractId);
+
+            DateOnly requestedOn = DateOnly.FromDateTime(now.UtcDateTime);
+            var assessment = AssessForCreation(contract, requestedOn);
+
+            var request = CancellationRequest.Create(
+                contract.Id,
+                contract.CustomerId,
+                idempotencyKey,
+                now,
+                assessment);
+
+            var stored = await cancellationRequests.TryCreateAsync(request, cancellationToken);
+
+            CreateCancellationRequestResult result = stored.Outcome switch
+            {
+                CancellationRequestStoreOutcome.Created => ToResult(
+                    stored.Request,
+                    isReplay: false),
+                CancellationRequestStoreOutcome.Replayed => ReplayResult(
+                    stored.Request,
+                    command.ContractId),
+                CancellationRequestStoreOutcome.OpenRequestExists =>
+                    throw new ApplicationConflictException(
+                        "cancellation_request_already_open",
+                        "A different cancellation request is already open for this contract."),
+                CancellationRequestStoreOutcome.IdempotencyKeyConflict =>
+                    throw new ApplicationConflictException(
+                        "idempotency_key_conflict",
+                        "The idempotency key has already been used for a different operation."),
+                _ => throw new InvalidOperationException(
+                    $"Unsupported store outcome '{stored.Outcome}'."),
+            };
+
+            RecordSuccess(activity, result, startedAt);
+            return result;
         }
-
-        var contract = await contracts.GetByIdAsync(command.ContractId, cancellationToken)
-            ?? throw new ResourceNotFoundException("Contract", command.ContractId);
-
-        DateOnly requestedOn = DateOnly.FromDateTime(now.UtcDateTime);
-        var assessment = AssessForCreation(contract, requestedOn);
-
-        var request = CancellationRequest.Create(
-            contract.Id,
-            contract.CustomerId,
-            idempotencyKey,
-            now,
-            assessment);
-
-        var stored = await cancellationRequests.TryCreateAsync(request, cancellationToken);
-
-        return stored.Outcome switch
+        catch (Exception exception)
         {
-            CancellationRequestStoreOutcome.Created => ToResult(stored.Request, isReplay: false),
-            CancellationRequestStoreOutcome.Replayed => ReplayResult(stored.Request, command.ContractId),
-            CancellationRequestStoreOutcome.OpenRequestExists => throw new ApplicationConflictException(
-                "cancellation_request_already_open",
-                "A different cancellation request is already open for this contract."),
-            CancellationRequestStoreOutcome.IdempotencyKeyConflict => throw new ApplicationConflictException(
-                "idempotency_key_conflict",
-                "The idempotency key has already been used for a different operation."),
-            _ => throw new InvalidOperationException($"Unsupported store outcome '{stored.Outcome}'."),
-        };
+            string outcome = exception is OperationCanceledException
+                ? "cancelled"
+                : "failed";
+
+            activity?.SetTag("contractiq.outcome", outcome);
+            ContractIqTelemetry.MarkError(activity, exception);
+            ContractIqTelemetry.RecordCancellationCommand(
+                outcome,
+                isReplay: false,
+                Stopwatch.GetElapsedTime(startedAt));
+            throw;
+        }
+    }
+
+    private static void RecordSuccess(
+        Activity? activity,
+        CreateCancellationRequestResult result,
+        long startedAt)
+    {
+        string outcome = result.IsReplay ? "replayed" : "created";
+
+        activity?.SetTag("contractiq.outcome", outcome);
+        activity?.SetTag("contractiq.command.is_replay", result.IsReplay);
+        activity?.SetStatus(ActivityStatusCode.Ok);
+        ContractIqTelemetry.RecordCancellationCommand(
+            outcome,
+            result.IsReplay,
+            Stopwatch.GetElapsedTime(startedAt));
     }
 
     private static CancellationAssessment AssessForCreation(

--- a/src/ContractIQ.Application/Common/Observability/ContractIqTelemetry.cs
+++ b/src/ContractIQ.Application/Common/Observability/ContractIqTelemetry.cs
@@ -1,0 +1,185 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace ContractIQ.Application.Common.Observability;
+
+/// <summary>
+/// Defines the application-owned telemetry vocabulary. Dimensions deliberately
+/// exclude prompts, document text, identifiers, secrets, and other customer data.
+/// </summary>
+public static class ContractIqTelemetry
+{
+    public const string ActivitySourceName = "ContractIQ";
+    public const string MeterName = "ContractIQ";
+
+    private static readonly ActivitySource ActivitySource = new(ActivitySourceName);
+    private static readonly Meter Meter = new(MeterName);
+
+    private static readonly Counter<long> AssistantRequests = Meter.CreateCounter<long>(
+        "contractiq.assistant.requests",
+        description: "Number of contract assistant requests.");
+    private static readonly Histogram<double> AssistantDuration = Meter.CreateHistogram<double>(
+        "contractiq.assistant.request.duration",
+        unit: "s",
+        description: "End-to-end contract assistant request duration.");
+    private static readonly Histogram<long> AssistantEvidenceCount = Meter.CreateHistogram<long>(
+        "contractiq.assistant.evidence.count",
+        unit: "{item}",
+        description: "Evidence items retrieved for an assistant request.");
+    private static readonly Histogram<long> AssistantCitationCount = Meter.CreateHistogram<long>(
+        "contractiq.assistant.citation.count",
+        unit: "{item}",
+        description: "Citations returned by an assistant request.");
+
+    private static readonly Counter<long> KnowledgeSearches = Meter.CreateCounter<long>(
+        "contractiq.knowledge.searches",
+        description: "Number of hybrid knowledge searches.");
+    private static readonly Histogram<double> KnowledgeSearchDuration = Meter.CreateHistogram<double>(
+        "contractiq.knowledge.search.duration",
+        unit: "s",
+        description: "Hybrid knowledge search duration.");
+    private static readonly Histogram<long> KnowledgeSearchResultCount = Meter.CreateHistogram<long>(
+        "contractiq.knowledge.search.result.count",
+        unit: "{item}",
+        description: "Evidence items returned by hybrid search.");
+
+    private static readonly Counter<long> ModelRequests = Meter.CreateCounter<long>(
+        "contractiq.ai.model.requests",
+        description: "Number of assistant model requests.");
+    private static readonly Histogram<double> ModelRequestDuration = Meter.CreateHistogram<double>(
+        "contractiq.ai.model.request.duration",
+        unit: "s",
+        description: "Assistant model request duration, including model-selected read tools.");
+    private static readonly Counter<long> ModelTokens = Meter.CreateCounter<long>(
+        "contractiq.ai.model.tokens",
+        unit: "{token}",
+        description: "Token usage reported by the configured model provider.");
+
+    private static readonly Counter<long> ToolCalls = Meter.CreateCounter<long>(
+        "contractiq.assistant.tool.calls",
+        description: "Number of application tool outcomes.");
+    private static readonly Counter<long> CancellationCommands = Meter.CreateCounter<long>(
+        "contractiq.cancellation.commands",
+        description: "Number of cancellation command outcomes.");
+    private static readonly Histogram<double> CancellationCommandDuration = Meter.CreateHistogram<double>(
+        "contractiq.cancellation.command.duration",
+        unit: "s",
+        description: "Cancellation command duration.");
+
+    public static Activity? StartActivity(string name) =>
+        ActivitySource.StartActivity(name, ActivityKind.Internal);
+
+    public static void MarkError(Activity? activity, Exception exception)
+    {
+        activity?.SetTag("error.type", exception.GetType().Name);
+        activity?.SetStatus(ActivityStatusCode.Error, exception.GetType().Name);
+    }
+
+    public static void RecordAssistantRequest(
+        string outcome,
+        TimeSpan duration,
+        int evidenceCount,
+        int citationCount)
+    {
+        var tags = new TagList
+        {
+            { "contractiq.outcome", outcome },
+        };
+
+        AssistantRequests.Add(1, tags);
+        AssistantDuration.Record(duration.TotalSeconds, tags);
+        AssistantEvidenceCount.Record(evidenceCount, tags);
+        AssistantCitationCount.Record(citationCount, tags);
+    }
+
+    public static void RecordKnowledgeSearch(
+        string outcome,
+        TimeSpan duration,
+        int resultCount)
+    {
+        var tags = new TagList
+        {
+            { "contractiq.outcome", outcome },
+        };
+
+        KnowledgeSearches.Add(1, tags);
+        KnowledgeSearchDuration.Record(duration.TotalSeconds, tags);
+        KnowledgeSearchResultCount.Record(resultCount, tags);
+    }
+
+    public static void RecordModelRequest(
+        string provider,
+        string model,
+        string outcome,
+        TimeSpan duration,
+        long? inputTokens = null,
+        long? outputTokens = null,
+        long? totalTokens = null)
+    {
+        var tags = new TagList
+        {
+            { "gen_ai.provider.name", provider },
+            { "gen_ai.request.model", model },
+            { "contractiq.outcome", outcome },
+        };
+
+        ModelRequests.Add(1, tags);
+        ModelRequestDuration.Record(duration.TotalSeconds, tags);
+        RecordTokens(inputTokens, "input", provider, model, outcome);
+        RecordTokens(outputTokens, "output", provider, model, outcome);
+        RecordTokens(totalTokens, "total", provider, model, outcome);
+    }
+
+    public static void RecordToolCall(
+        string toolName,
+        string outcome,
+        bool stateChanging)
+    {
+        var tags = new TagList
+        {
+            { "gen_ai.tool.name", toolName },
+            { "contractiq.outcome", outcome },
+            { "contractiq.tool.state_changing", stateChanging },
+        };
+
+        ToolCalls.Add(1, tags);
+    }
+
+    public static void RecordCancellationCommand(
+        string outcome,
+        bool isReplay,
+        TimeSpan duration)
+    {
+        var tags = new TagList
+        {
+            { "contractiq.outcome", outcome },
+            { "contractiq.command.is_replay", isReplay },
+        };
+
+        CancellationCommands.Add(1, tags);
+        CancellationCommandDuration.Record(duration.TotalSeconds, tags);
+    }
+
+    private static void RecordTokens(
+        long? count,
+        string tokenType,
+        string provider,
+        string model,
+        string outcome)
+    {
+        if (count is not > 0)
+        {
+            return;
+        }
+
+        var tags = new TagList
+        {
+            { "gen_ai.provider.name", provider },
+            { "gen_ai.request.model", model },
+            { "contractiq.outcome", outcome },
+            { "gen_ai.token.type", tokenType },
+        };
+
+        ModelTokens.Add(count.Value, tags);
+    }
+}

--- a/src/ContractIQ.Application/Knowledge/Search/SearchKnowledgeHandler.cs
+++ b/src/ContractIQ.Application/Knowledge/Search/SearchKnowledgeHandler.cs
@@ -1,4 +1,6 @@
+using System.Diagnostics;
 using ContractIQ.Application.Common.Exceptions;
+using ContractIQ.Application.Common.Observability;
 
 namespace ContractIQ.Application.Knowledge.Search;
 
@@ -11,56 +13,119 @@ public sealed class SearchKnowledgeHandler(
         SearchKnowledgeQuery query,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(query);
+        long startedAt = Stopwatch.GetTimestamp();
+        using Activity? activity = ContractIqTelemetry.StartActivity(
+            "contractiq.knowledge.search");
 
-        if (string.IsNullOrWhiteSpace(query.Query) || query.Query.Trim().Length < 3)
+        try
         {
-            throw new ApplicationValidationException(
-                nameof(query.Query),
-                "Query must contain at least 3 characters.");
-        }
+            ArgumentNullException.ThrowIfNull(query);
 
-        if (query.CustomerId == Guid.Empty)
+            if (string.IsNullOrWhiteSpace(query.Query) || query.Query.Trim().Length < 3)
+            {
+                throw new ApplicationValidationException(
+                    nameof(query.Query),
+                    "Query must contain at least 3 characters.");
+            }
+
+            if (query.CustomerId == Guid.Empty)
+            {
+                throw new ApplicationValidationException(
+                    nameof(query.CustomerId),
+                    "Customer id is required.");
+            }
+
+            if (query.ContractId == Guid.Empty)
+            {
+                throw new ApplicationValidationException(
+                    nameof(query.ContractId),
+                    "Contract id is required.");
+            }
+
+            if (query.Limit is < 1 or > 20)
+            {
+                throw new ApplicationValidationException(
+                    nameof(query.Limit),
+                    "Limit must be between 1 and 20.");
+            }
+
+            activity?.SetTag("contractiq.knowledge.limit", query.Limit);
+
+            IReadOnlyList<float[]> embeddings;
+            using (Activity? embeddingActivity = ContractIqTelemetry.StartActivity(
+                "contractiq.knowledge.embedding.generate"))
+            {
+                embeddingActivity?.SetTag(
+                    "gen_ai.request.model",
+                    embeddingGenerator.ModelId);
+
+                try
+                {
+                    embeddings = await embeddingGenerator.GenerateAsync(
+                        [query.Query.Trim()],
+                        cancellationToken);
+                }
+                catch (Exception exception)
+                {
+                    ContractIqTelemetry.MarkError(embeddingActivity, exception);
+                    throw;
+                }
+            }
+
+            if (embeddings.Count != 1 || embeddings[0].Length != embeddingGenerator.Dimensions)
+            {
+                throw new InvalidOperationException(
+                    $"Embedding model '{embeddingGenerator.ModelId}' returned an unexpected shape.");
+            }
+
+            DateOnly asOf = query.AsOf ?? DateOnly.FromDateTime(
+                timeProvider.GetUtcNow().UtcDateTime);
+
+            IReadOnlyList<KnowledgeEvidence> evidence;
+            using (Activity? indexActivity = ContractIqTelemetry.StartActivity(
+                "contractiq.knowledge.index.query"))
+            {
+                try
+                {
+                    evidence = await knowledgeIndex.SearchAsync(
+                        query.Query.Trim(),
+                        embeddings[0],
+                        query.CustomerId,
+                        query.ContractId,
+                        asOf,
+                        query.Limit,
+                        cancellationToken);
+                }
+                catch (Exception exception)
+                {
+                    ContractIqTelemetry.MarkError(indexActivity, exception);
+                    throw;
+                }
+
+                indexActivity?.SetTag("contractiq.knowledge.result.count", evidence.Count);
+            }
+
+            activity?.SetTag("contractiq.knowledge.result.count", evidence.Count);
+            activity?.SetStatus(ActivityStatusCode.Ok);
+            ContractIqTelemetry.RecordKnowledgeSearch(
+                "succeeded",
+                Stopwatch.GetElapsedTime(startedAt),
+                evidence.Count);
+
+            return evidence;
+        }
+        catch (Exception exception)
         {
-            throw new ApplicationValidationException(
-                nameof(query.CustomerId),
-                "Customer id is required.");
+            string outcome = exception is OperationCanceledException
+                ? "cancelled"
+                : "failed";
+
+            ContractIqTelemetry.MarkError(activity, exception);
+            ContractIqTelemetry.RecordKnowledgeSearch(
+                outcome,
+                Stopwatch.GetElapsedTime(startedAt),
+                resultCount: 0);
+            throw;
         }
-
-        if (query.ContractId == Guid.Empty)
-        {
-            throw new ApplicationValidationException(
-                nameof(query.ContractId),
-                "Contract id is required.");
-        }
-
-        if (query.Limit is < 1 or > 20)
-        {
-            throw new ApplicationValidationException(
-                nameof(query.Limit),
-                "Limit must be between 1 and 20.");
-        }
-
-        IReadOnlyList<float[]> embeddings = await embeddingGenerator.GenerateAsync(
-            [query.Query.Trim()],
-            cancellationToken);
-
-        if (embeddings.Count != 1 || embeddings[0].Length != embeddingGenerator.Dimensions)
-        {
-            throw new InvalidOperationException(
-                $"Embedding model '{embeddingGenerator.ModelId}' returned an unexpected shape.");
-        }
-
-        DateOnly asOf = query.AsOf ?? DateOnly.FromDateTime(
-            timeProvider.GetUtcNow().UtcDateTime);
-
-        return await knowledgeIndex.SearchAsync(
-            query.Query.Trim(),
-            embeddings[0],
-            query.CustomerId,
-            query.ContractId,
-            asOf,
-            query.Limit,
-            cancellationToken);
     }
 }

--- a/src/ContractIQ.Infrastructure/Assistant/ChatClientAssistantAnswerGenerator.cs
+++ b/src/ContractIQ.Infrastructure/Assistant/ChatClientAssistantAnswerGenerator.cs
@@ -1,7 +1,9 @@
 using System.ClientModel;
+using System.Diagnostics;
 using ContractIQ.Application.Assistant;
 using ContractIQ.Application.Assistant.Tools;
 using ContractIQ.Application.Common.Exceptions;
+using ContractIQ.Application.Common.Observability;
 using Microsoft.Extensions.AI;
 using OllamaSharp;
 using OllamaSharp.Models.Exceptions;
@@ -40,6 +42,13 @@ internal sealed class ChatClientAssistantAnswerGenerator : IAssistantAnswerGener
         AssistantToolContext toolContext,
         CancellationToken cancellationToken = default)
     {
+        long startedAt = Stopwatch.GetTimestamp();
+        string provider = _options.Provider.ToString().ToLowerInvariant();
+        using Activity? activity = ContractIqTelemetry.StartActivity(
+            "contractiq.ai.model.generate");
+        activity?.SetTag("gen_ai.provider.name", provider);
+        activity?.SetTag("gen_ai.request.model", _options.ChatModel);
+
         AssistantActionProposal? proposedAction = null;
 
         async Task<AssistantActionProposal> PrepareCancellationAsync(
@@ -107,19 +116,43 @@ internal sealed class ChatClientAssistantAnswerGenerator : IAssistantAnswerGener
                 chatOptions,
                 cancellationToken);
 
+            activity?.SetTag("gen_ai.usage.input_tokens", response.Usage?.InputTokenCount);
+            activity?.SetTag("gen_ai.usage.output_tokens", response.Usage?.OutputTokenCount);
+            activity?.SetStatus(ActivityStatusCode.Ok);
+            ContractIqTelemetry.RecordModelRequest(
+                provider,
+                _options.ChatModel,
+                "succeeded",
+                Stopwatch.GetElapsedTime(startedAt),
+                response.Usage?.InputTokenCount,
+                response.Usage?.OutputTokenCount,
+                response.Usage?.TotalTokenCount);
+
             return new GeneratedAssistantAnswer(
                 response.Text,
                 _options.ChatModel,
                 proposedAction);
         }
+        catch (OperationCanceledException exception) when (cancellationToken.IsCancellationRequested)
+        {
+            RecordFailure(activity, provider, "cancelled", exception, startedAt);
+            throw;
+        }
         catch (OperationCanceledException exception) when (!cancellationToken.IsCancellationRequested)
         {
+            RecordFailure(activity, provider, "unavailable", exception, startedAt);
             throw CreateUnavailableException(exception);
         }
         catch (Exception exception) when (
             exception is HttpRequestException or OllamaException or ClientResultException)
         {
+            RecordFailure(activity, provider, "unavailable", exception, startedAt);
             throw CreateUnavailableException(exception);
+        }
+        catch (Exception exception)
+        {
+            RecordFailure(activity, provider, "failed", exception, startedAt);
+            throw;
         }
     }
 
@@ -167,5 +200,20 @@ internal sealed class ChatClientAssistantAnswerGenerator : IAssistantAnswerGener
             : $"Ollama is unavailable or chat model '{_options.ChatModel}' is not installed.";
 
         return new ExternalDependencyUnavailableException(dependency, message, exception);
+    }
+
+    private void RecordFailure(
+        Activity? activity,
+        string provider,
+        string outcome,
+        Exception exception,
+        long startedAt)
+    {
+        ContractIqTelemetry.MarkError(activity, exception);
+        ContractIqTelemetry.RecordModelRequest(
+            provider,
+            _options.ChatModel,
+            outcome,
+            Stopwatch.GetElapsedTime(startedAt));
     }
 }

--- a/src/ContractIQ.Infrastructure/Assistant/LoggingAssistantToolAudit.cs
+++ b/src/ContractIQ.Infrastructure/Assistant/LoggingAssistantToolAudit.cs
@@ -1,4 +1,5 @@
 using ContractIQ.Application.Assistant.Tools;
+using ContractIQ.Application.Common.Observability;
 using Microsoft.Extensions.Logging;
 
 namespace ContractIQ.Infrastructure.Assistant;
@@ -10,12 +11,15 @@ internal sealed class LoggingAssistantToolAudit(
         AssistantToolAuditEvent auditEvent,
         CancellationToken cancellationToken = default)
     {
+        ContractIqTelemetry.RecordToolCall(
+            auditEvent.ToolName,
+            auditEvent.Outcome,
+            auditEvent.StateChanging);
+
         logger.LogInformation(
-            "Assistant tool outcome: EventId={EventId}, Tool={ToolName}, CustomerId={CustomerId}, ContractId={ContractId}, Outcome={Outcome}, StateChanging={StateChanging}, OccurredAtUtc={OccurredAtUtc}",
+            "Assistant tool outcome: EventId={EventId}, Tool={ToolName}, Outcome={Outcome}, StateChanging={StateChanging}, OccurredAtUtc={OccurredAtUtc}",
             auditEvent.EventId,
             auditEvent.ToolName,
-            auditEvent.CustomerId,
-            auditEvent.ContractId,
             auditEvent.Outcome,
             auditEvent.StateChanging,
             auditEvent.OccurredAtUtc);

--- a/tests/ContractIQ.Application.Tests/Assistant/AskContractQuestionHandlerTests.cs
+++ b/tests/ContractIQ.Application.Tests/Assistant/AskContractQuestionHandlerTests.cs
@@ -1,5 +1,7 @@
+using System.Diagnostics;
 using ContractIQ.Application.Assistant;
 using ContractIQ.Application.Assistant.Tools;
+using ContractIQ.Application.Common.Observability;
 using ContractIQ.Application.Knowledge;
 using ContractIQ.Application.Knowledge.Search;
 using Xunit;
@@ -85,6 +87,54 @@ public sealed class AskContractQuestionHandlerTests
         Assert.Empty(result.Citations);
         Assert.Null(result.ModelId);
         Assert.Equal(0, generator.CallCount);
+    }
+
+    [Fact]
+    public async Task HandleAsync_emits_a_correlated_activity_without_business_identifiers()
+    {
+        Activity? completedActivity = null;
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source =>
+                source.Name == ContractIqTelemetry.ActivitySourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) =>
+                ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStopped = activity =>
+            {
+                if (activity.OperationName == "contractiq.assistant.ask")
+                {
+                    completedActivity = activity;
+                }
+            },
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        var search = new FakeKnowledgeSearch(CreateContractEvidence(
+            "A deterministic penalty applies."));
+        var generator = new FakeAnswerGenerator(
+            "ACME can request cancellation and a deterministic penalty applies [1].");
+        AskContractQuestionHandler handler = CreateHandler(search, generator);
+
+        await handler.HandleAsync(new AskContractQuestionCommand(
+            "Can ACME cancel now?",
+            ApplicationTestData.AcmeCustomerId,
+            ApplicationTestData.AcmeContractId,
+            "en"));
+
+        Assert.NotNull(completedActivity);
+        Assert.Equal(ActivityStatusCode.Ok, completedActivity.Status);
+        Assert.Equal(
+            "en",
+            completedActivity.GetTagItem("contractiq.assistant.language"));
+        Assert.Equal(
+            1,
+            completedActivity.GetTagItem("contractiq.assistant.citation.count"));
+        Assert.DoesNotContain(
+            completedActivity.TagObjects,
+            tag => tag.Key.Contains("customer", StringComparison.OrdinalIgnoreCase) ||
+                tag.Key.Contains("contract_id", StringComparison.OrdinalIgnoreCase) ||
+                tag.Key.Contains("question", StringComparison.OrdinalIgnoreCase) ||
+                tag.Key.Contains("prompt", StringComparison.OrdinalIgnoreCase));
     }
 
     private static AskContractQuestionHandler CreateHandler(

--- a/tests/ContractIQ.IntegrationTests/HealthEndpointTests.cs
+++ b/tests/ContractIQ.IntegrationTests/HealthEndpointTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Text.Json;
+using ContractIQ.Api.Observability;
 using Xunit;
 
 namespace ContractIQ.IntegrationTests;
@@ -37,6 +38,7 @@ public sealed class HealthEndpointTests : IAsyncLifetime
             CancellationToken.None);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        AssertCorrelationHeader(response);
     }
 
     [Fact]
@@ -47,6 +49,7 @@ public sealed class HealthEndpointTests : IAsyncLifetime
             CancellationToken.None);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        AssertCorrelationHeader(response);
 
         await using Stream content = await response.Content.ReadAsStreamAsync(
             CancellationToken.None);
@@ -60,5 +63,35 @@ public sealed class HealthEndpointTests : IAsyncLifetime
             .Single(check => check.GetProperty("name").GetString() == "postgresql");
 
         Assert.Equal("Healthy", postgresql.GetProperty("status").GetString());
+    }
+
+    [Fact]
+    public async Task Problem_details_and_response_header_share_the_trace_identifier()
+    {
+        using var response = await _client!.GetAsync(
+            "/api/v1/contracts/99999999-9999-4999-8999-999999999999",
+            CancellationToken.None);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        string correlationId = AssertCorrelationHeader(response);
+
+        await using Stream content = await response.Content.ReadAsStreamAsync(
+            CancellationToken.None);
+        using JsonDocument document = await JsonDocument.ParseAsync(
+            content,
+            cancellationToken: CancellationToken.None);
+
+        Assert.Equal(
+            correlationId,
+            document.RootElement.GetProperty("traceId").GetString());
+    }
+
+    private static string AssertCorrelationHeader(HttpResponseMessage response)
+    {
+        string correlationId = Assert.Single(
+            response.Headers.GetValues(RequestCorrelationMiddleware.HeaderName));
+
+        Assert.Matches("^[0-9a-f]{32}$", correlationId);
+        return correlationId;
     }
 }

--- a/tests/ContractIQ.IntegrationTests/OpenTelemetryOptionsTests.cs
+++ b/tests/ContractIQ.IntegrationTests/OpenTelemetryOptionsTests.cs
@@ -1,0 +1,43 @@
+using ContractIQ.Api.Observability;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace ContractIQ.IntegrationTests;
+
+public sealed class OpenTelemetryOptionsTests
+{
+    [Fact]
+    public void FromConfiguration_keeps_export_opt_in()
+    {
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["OpenTelemetry:ServiceName"] = "ContractIQ.Tests",
+                ["OpenTelemetry:OtlpEndpoint"] = "http://localhost:4317",
+            })
+            .Build();
+
+        OpenTelemetryOptions options = OpenTelemetryOptions.FromConfiguration(configuration);
+
+        Assert.False(options.Enabled);
+        Assert.Equal("ContractIQ.Tests", options.ServiceName);
+        Assert.Equal(new Uri("http://localhost:4317"), options.OtlpEndpoint);
+    }
+
+    [Fact]
+    public void FromConfiguration_rejects_a_non_http_exporter_endpoint()
+    {
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["OpenTelemetry:Enabled"] = "true",
+                ["OpenTelemetry:OtlpEndpoint"] = "file:///tmp/telemetry",
+            })
+            .Build();
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+            () => OpenTelemetryOptions.FromConfiguration(configuration));
+
+        Assert.Contains("absolute HTTP or HTTPS URI", exception.Message);
+    }
+}


### PR DESCRIPTION
## Summary

- add opt-in OpenTelemetry traces, metrics, and structured logs with W3C request correlation and trace-based metric exemplars
- instrument ASP.NET Core, outbound HTTP, Npgsql, hybrid retrieval, embeddings, LLM calls, tools, and cancellation commands
- add an optional standalone Aspire Dashboard Docker Compose profile; export remains disabled by default and requires no Azure resources
- exclude prompts, answers, document content, secrets, idempotency keys, and business identifiers from exported telemetry
- document the architecture decision, local workflow, health behavior, privacy boundary, and troubleshooting

## Verification

- `dotnet format ContractIQ.slnx --verify-no-changes --no-restore`
- `dotnet build ContractIQ.slnx --configuration Release --no-restore -m:1` — 0 warnings, 0 errors
- Application tests — 33 passed
- Domain tests — 40 passed
- Integration tests with PostgreSQL/Testcontainers — 38 passed
- React tests — 6 passed
- React lint and production build passed
- `docker compose --profile observability config --quiet`

## Cost and local resources

The dashboard profile is optional. This change did not start or download the dashboard image. When enabled, it runs locally and does not create Azure resources or cloud telemetry charges.

Closes #11