### PR TITLE
feat(ai): add Microsoft Foundry model adapters

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,6 +4,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageVersion Include="Azure.Identity" Version="1.21.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.11" />

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The model does not calculate penalties, authorize users, write to the database, 
 - .NET 10, ASP.NET Core, C#, DDD, Clean Architecture principles, CQRS, EF Core, PostgreSQL, and pgvector;
 - React 19 and TypeScript with an accessible, responsive English and Brazilian Portuguese workspace;
 - local RAG with document versioning, scoped lexical and vector retrieval, Reciprocal Rank Fusion, and application-owned citations;
-- provider-neutral chat and tool calling through `Microsoft.Extensions.AI`, using local Ollama or optional hosted Kimi;
+- provider-neutral chat, embeddings, and tool calling through `Microsoft.Extensions.AI`, using local Ollama, optional hosted Kimi, or keyless Microsoft Foundry;
 - explicit human confirmation, idempotency, transactions, and domain revalidation for AI-prepared writes;
 - OpenTelemetry traces, metrics, and structured logs with an optional local Aspire Dashboard;
 - automated domain, application, integration, frontend, security, and deterministic AI evaluation gates;
@@ -45,6 +45,7 @@ flowchart LR
     Ports --> Db[(PostgreSQL<br/>structured data + pgvector)]
     Ports --> Ollama[Ollama<br/>local embeddings and optional chat]
     Ports -. optional hosted chat .-> Kimi[Kimi API]
+    Ports -. optional hosted models .-> Foundry[Microsoft Foundry]
     Api -. OpenTelemetry .-> Aspire[Local Aspire Dashboard]
 ```
 
@@ -97,7 +98,7 @@ npm run dev
 
 Open `http://localhost:5173`. The API applies committed migrations and idempotently seeds ACME, Globex, and Initech. Customer navigation, structured contract details, deterministic cancellation assessments, and confirmed cancellation requests work with PostgreSQL alone.
 
-To enable cited RAG answers, index the fictional documents with local embeddings and choose either local Ollama chat or optional Kimi. Follow the [grounded assistant setup](docs/assistant/grounded-answers.md) rather than adding credentials to source files.
+To enable cited RAG answers, index the fictional documents and choose local Ollama, optional Kimi chat, or the optional keyless Foundry model adapters. Follow the [grounded assistant setup](docs/assistant/grounded-answers.md) rather than adding credentials to source files.
 
 ## Five-minute demonstration
 
@@ -130,7 +131,7 @@ The required GitHub Actions workflow restores locked dependencies, audits NuGet 
 
 Current release-candidate coverage includes:
 
-- 134 backend tests across domain, application, integration, and AI evaluation projects;
+- 144 backend tests across domain, application, integration, and AI evaluation projects;
 - 15 React component and workflow tests;
 - 12 deterministic AI safety scenarios covering grounding, citation integrity, bilingual behavior, refusal, and tool routing.
 
@@ -159,7 +160,7 @@ npm run build
 | Fully local assistant | None                                                            | Adds approximately 2.5 GB for `qwen3:4b` and local CPU/RAM usage |
 | Kimi assistant        | Provider API credits only when a grounded question is submitted | Local PostgreSQL and embeddings remain required                  |
 | Aspire observability  | None                                                            | Optional local container and telemetry storage                   |
-| Microsoft Azure       | None in v1; no Azure resources are created                      | Optional adapters remain roadmap work                            |
+| Microsoft Foundry     | No cost until explicitly provisioned and invoked; inference consumes Azure credit | Local application and PostgreSQL can remain running on the developer machine |
 
 See [cost and resource management](docs/operations/cost-and-resources.md) for startup, storage, cleanup, credential removal, and the future Azure boundary.
 
@@ -169,7 +170,7 @@ See [cost and resource management](docs/operations/cost-and-resources.md) for st
 src/
   ContractIQ.Domain/          Business rules and aggregates
   ContractIQ.Application/     CQRS use cases, ports, RAG and assistant orchestration
-  ContractIQ.Infrastructure/  EF Core, PostgreSQL, Ollama and Kimi adapters
+  ContractIQ.Infrastructure/  EF Core, PostgreSQL, Ollama, Kimi and Foundry adapters
   ContractIQ.Api/             HTTP composition root, security and telemetry
   ContractIQ.Web/             React and TypeScript product workspace
 tests/                        Domain, application, integration and AI evaluations
@@ -193,6 +194,7 @@ docs/                         Architecture, decisions, operations and demo mater
 - [Bilingual interview guide](docs/demo/interview-guide.md)
 - [Cost and resource management](docs/operations/cost-and-resources.md)
 - [Optional Azure AI implementation plan](docs/azure/implementation-plan.md)
+- [Microsoft Foundry model adapters](docs/azure/foundry-model-adapters.md)
 - [Azure infrastructure validation](infra/azure/README.md)
 - [v1.0.0 release checklist](docs/release/v1.0.0-checklist.md)
 - [Architecture Decision Records](docs/adr)
@@ -200,6 +202,6 @@ docs/                         Architecture, decisions, operations and demo mater
 
 ## Project status
 
-The local portfolio MVP is feature-complete and validated for the first `v1.0.0` release. The optional Microsoft Foundry and Azure AI Search profile is now being delivered incrementally, beginning with non-deploying infrastructure validation and cost controls. Microsoft Entra ID for end users remains a separate post-MVP item. None of these services is required to run or evaluate the local version.
+The local portfolio MVP is feature-complete and validated for the first `v1.0.0` release. The optional Microsoft Foundry model adapters and non-deploying Azure infrastructure foundation are implemented incrementally; Azure AI Search and Microsoft Entra ID for end users remain separate post-MVP items. None of these services is required to run or evaluate the local version.
 
 ContractIQ uses fictional companies, contracts, policies, and rules. It is a software engineering demonstration and does not provide legal advice.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -20,12 +20,13 @@ flowchart TB
     Infrastructure --> PostgreSQL[(PostgreSQL and pgvector)]
     Infrastructure --> Ollama[Ollama embeddings and optional chat]
     Infrastructure -. optional hosted chat .-> Kimi[Kimi API]
+    Infrastructure -. optional hosted models .-> Foundry[Microsoft Foundry]
     Api -. traces, metrics, logs .-> Dashboard[Local Aspire Dashboard]
 ```
 
-The diagram shows implemented v1 components. Microsoft Entra ID, Microsoft
-Foundry, and Azure AI Search are tracked future adapters, not runtime dependencies
-or provisioned resources in this release.
+The diagram includes the optional Foundry model adapters delivered after v1.
+Microsoft Entra ID for end users and Azure AI Search remain future adapters. No
+Azure resource or model deployment is required by the local runtime.
 
 ## Logical boundaries
 
@@ -45,7 +46,7 @@ Customer, contract, and effective-date filters are applied before ranking. Postg
 
 Assistant orchestration is an application concern rather than a separate service. The current read-only flow validates customer and contract scope, calculates the deterministic cancellation assessment, retrieves supporting evidence, refuses when no applicable contract clause is available, and asks a provider-neutral answer generator for a bilingual explanation.
 
-The provider adapter uses Microsoft's `IChatClient` through either local Ollama or the OpenAI-compatible Kimi API. The committed default remains local and hosted usage is explicitly enabled with secret configuration. Citations are assembled by the application from retrieved metadata rather than invented by the model. `FunctionInvokingChatClient` exposes scoped read and preparation tools; the write tool remains outside automatic invocation and requires a separate confirmed HTTP request.
+The provider adapter uses Microsoft's `IChatClient` through local Ollama, the OpenAI-compatible Kimi API, or the OpenAI-compatible Microsoft Foundry endpoint. The committed default remains local and hosted usage is explicitly enabled through configuration. Foundry authenticates with `DefaultAzureCredential`; Kimi retains its local API-key boundary. Citations are assembled by the application from retrieved metadata rather than invented by the model. `FunctionInvokingChatClient` exposes scoped read and preparation tools; the write tool remains outside automatic invocation and requires a separate confirmed HTTP request.
 
 ## Dependency rule
 
@@ -73,8 +74,10 @@ Retrieved document content is untrusted data. Instructions inside a document can
   external token charge.
 - `KimiChat`: Ollama continues to supply local embeddings while the explicitly
   configured hosted Kimi adapter supplies chat and tool calling.
-- `FutureAzure`: Microsoft Foundry and Azure AI Search remain planned behind the
-  existing application ports and are not implemented in v1.
+- `FoundryModels`: Microsoft Foundry can supply chat, embeddings, or both through
+  Entra RBAC while PostgreSQL remains the local retrieval store.
+- `FutureAzureSearch`: Azure AI Search remains planned behind the existing
+  retrieval ports.
 
 The default developer experience remains functional without Azure.
 
@@ -85,8 +88,8 @@ The default developer experience remains functional without Azure.
 | Structured persistence | PostgreSQL through EF Core/Npgsql     | No alternative required for the portfolio MVP               |
 | Lexical retrieval      | PostgreSQL full-text search           | Azure AI Search BM25                                        |
 | Vector retrieval       | pgvector cosine similarity            | Azure AI Search vector search                               |
-| Embeddings             | Ollama `embeddinggemma`               | Microsoft Foundry embedding deployment                      |
-| Chat and tool calling  | Ollama `qwen3:4b` or hosted Kimi      | Microsoft Foundry chat deployment                           |
+| Embeddings             | Ollama `embeddinggemma`               | Implemented optional Microsoft Foundry embedding deployment |
+| Chat and tool calling  | Ollama `qwen3:4b` or hosted Kimi      | Implemented optional Microsoft Foundry chat deployment      |
 | Identity               | Anonymous local `Development` profile | Microsoft Entra ID                                          |
 | Telemetry backend      | Optional local Aspire Dashboard       | Azure Monitor/Application Insights after a hosting decision |
 

--- a/docs/assistant/grounded-answers.md
+++ b/docs/assistant/grounded-answers.md
@@ -11,12 +11,17 @@ The language model writes the explanation. It is not the authority for eligibili
 
 The committed default is local Ollama so cloning or starting the repository never
 creates a hosted-model charge. The assistant chat provider can be changed to Kimi
-through local configuration. Retrieval embeddings remain local through
-`embeddinggemma` in both modes, so changing the chat provider does not require
-reindexing documents.
+or Microsoft Foundry through local configuration. Embeddings can independently
+remain on Ollama or use a Foundry embedding deployment.
 
 No chat provider is called during application startup or automated tests. A hosted
 request occurs only when a user submits a sufficiently grounded assistant question.
+
+When Foundry is selected, the same fictional question, assessment, bounded
+evidence, and tool schemas are sent to the configured Azure resource. Access is
+keyless through `DefaultAzureCredential` and Entra RBAC. See
+[Microsoft Foundry model adapters](../azure/foundry-model-adapters.md) for the
+configuration and cost boundary.
 
 When Kimi is selected, the question, deterministic assessment, bounded excerpts
 from the fictional contract and policies, tool schemas, and requested read-tool
@@ -129,7 +134,7 @@ Run scoped hybrid knowledge retrieval
 build safe prompt     localized refusal
           |
           v
-IChatClient -> Ollama qwen3:4b or hosted Kimi
+IChatClient -> Ollama, hosted Kimi, or Microsoft Foundry
           |
           v
 answer + application-owned citations + assessment
@@ -184,6 +189,6 @@ These measures reduce prompt-injection risk but do not make model output authori
 
 ## Provider boundary
 
-The Application project depends on `IAssistantAnswerGenerator`. Infrastructure implements it behind Microsoft's `IChatClient` abstraction with either OllamaSharp or an OpenAI-compatible Kimi client. This keeps orchestration and tests independent from the provider and allows a later Microsoft Foundry adapter without moving domain authority into the model integration.
+The Application project depends on `IAssistantAnswerGenerator`. Infrastructure implements it behind Microsoft's `IChatClient` abstraction with OllamaSharp, an OpenAI-compatible Kimi client, or a keyless Microsoft Foundry client. Embeddings use the same provider-neutral approach. This keeps orchestration and tests independent from the provider without moving domain authority into model integration.
 
 The same assistant can now prepare a cancellation action through safe tool calling. See [Safe assistant tool calling](safe-tool-calling.md) for the human-confirmation and write boundary.

--- a/docs/assistant/safe-tool-calling.md
+++ b/docs/assistant/safe-tool-calling.md
@@ -16,7 +16,7 @@ The React experience then shows **Action prepared by the agent**. Selecting **Re
 
 ## Tools available to the model
 
-The provider adapter uses Microsoft `IChatClient`, `AIFunctionFactory`, and `FunctionInvokingChatClient` with either local Ollama or hosted Kimi to expose four functions:
+The provider adapter uses Microsoft `IChatClient`, `AIFunctionFactory`, and `FunctionInvokingChatClient` with local Ollama, hosted Kimi, or Microsoft Foundry to expose four functions:
 
 | Tool | Capability | Changes state |
 | --- | --- | --- |

--- a/docs/azure/foundry-model-adapters.md
+++ b/docs/azure/foundry-model-adapters.md
@@ -1,0 +1,76 @@
+# Microsoft Foundry model adapters
+
+ContractIQ can use Microsoft Foundry for chat and embeddings without changing
+the application or domain layers. The committed defaults remain Ollama for both
+capabilities, so restore, startup, tests, and the local demonstration do not
+contact Azure.
+
+## Provider boundary
+
+The Foundry adapters implement the existing application-owned ports through
+`Microsoft.Extensions.AI`:
+
+- `IAssistantAnswerGenerator` continues to expose the same four scoped read and
+  preparation tools through `FunctionInvokingChatClient`;
+- `IKnowledgeEmbeddingGenerator` returns the same 768-dimension vectors expected
+  by the committed pgvector schema;
+- domain rules, CQRS handlers, confirmations, transactions, citations, and
+  PostgreSQL persistence are unchanged.
+
+The Foundry project endpoint is not used for embeddings. Both chat completions
+and embeddings use the resource's OpenAI-compatible endpoint:
+
+```text
+https://<resource-name>.openai.azure.com/openai/v1/
+```
+
+## Keyless authentication
+
+The adapters create an OpenAI-compatible client with `DefaultAzureCredential`.
+On a developer machine it can use the current Azure CLI login. A future hosted
+API can use a managed identity without changing application code.
+
+No Foundry API key is read, stored, logged, sent to React, or committed. The
+caller must have the `Cognitive Services OpenAI User` role on the Foundry
+resource.
+
+## Configuration
+
+Select chat and embedding providers independently:
+
+```powershell
+dotnet user-secrets set "Assistant:Provider" "Foundry" --project src/ContractIQ.Api
+dotnet user-secrets set "Knowledge:EmbeddingProvider" "Foundry" --project src/ContractIQ.Api
+dotnet user-secrets set "Foundry:OpenAIEndpoint" "https://<resource-name>.openai.azure.com/openai/v1/" --project src/ContractIQ.Api
+dotnet user-secrets set "Foundry:ChatDeployment" "<chat-deployment-name>" --project src/ContractIQ.Api
+dotnet user-secrets set "Foundry:EmbeddingDeployment" "<embedding-deployment-name>" --project src/ContractIQ.Api
+dotnet user-secrets set "Foundry:EmbeddingDimensions" "768" --project src/ContractIQ.Api
+```
+
+The endpoint must use HTTPS and end with `/openai/v1/`. Deployment names cannot
+be empty. Embedding dimensions must be explicitly configured and must equal 768
+while the local pgvector schema remains `vector(768)`.
+
+Changing the embedding deployment changes the stored embedding model identity.
+Run the document indexer again so document chunks are regenerated consistently.
+
+## Failure and telemetry behavior
+
+Authentication, HTTP, provider, rate-limit, and timeout failures are translated
+to the existing safe `ExternalDependencyUnavailableException` boundary. The API
+therefore returns the established dependency-unavailable response without
+exposing Azure SDK details.
+
+Chat and embedding dependency spans and metrics record only operation, provider,
+deployment, duration, token counts when supplied, and outcome. Prompts, document
+content, answers, credentials, and retrieved evidence are not telemetry tags.
+
+## Cost and test boundary
+
+Selecting `Foundry` does not itself deploy a model. Requests work only after the
+separate infrastructure, region, deployment, SKU, and quota steps are explicitly
+approved and completed. Model calls can consume Azure credit.
+
+Automated tests replace chat and embeddings with deterministic implementations.
+They validate configuration, provider selection, orchestration, safety, and
+shape constraints without acquiring an Azure token or making a live model call.

--- a/docs/azure/implementation-plan.md
+++ b/docs/azure/implementation-plan.md
@@ -35,14 +35,18 @@ ContractIQ does not deploy a second hosted agent in Foundry for this increment. 
 
 ## Delivery slices
 
-### 1. Azure foundation
+Status on 2026-08-31: the Azure foundation definitions and Foundry model
+adapters are implemented and validated without provisioning resources. The
+Azure AI Search adapter is the next delivery slice.
+
+### 1. Azure foundation — implemented, not deployed
 
 - validate the subscription, ownership, quota, and provider availability;
 - review Bicep with a subscription budget, one resource group, a Foundry account/project, free Azure AI Search, and RBAC;
 - run `what-if` and stop for explicit provisioning approval;
 - provision no model until its live SKU and quota are verified.
 
-### 2. Foundry adapters
+### 2. Foundry adapters — implemented, not invoked live
 
 - add a `Foundry` assistant provider without changing the local default;
 - authenticate with `DefaultAzureCredential` and the developer's Azure CLI session;

--- a/docs/operations/cost-and-resources.md
+++ b/docs/operations/cost-and-resources.md
@@ -11,7 +11,7 @@ ContractIQ v1 is designed to be evaluated without an Azure subscription and with
 | Fully local assistant | Local retrieval + Ollama `qwen3:4b`       | No external charge                                                      | Approximately 2.5 GB more disk plus local RAM/CPU during generation |
 | Kimi assistant        | Local retrieval + Kimi API                | Consumes the account's provider credits per submitted grounded question | The larger local chat model is not required                         |
 | Local observability   | Any profile + Aspire Dashboard            | No external charge                                                      | Dashboard image, container memory, and temporary telemetry storage  |
-| Planned Azure         | Foundry + free Azure AI Search             | Search Free has no hourly charge; Foundry model inference will consume credit only after a model is deployed and invoked | Infrastructure plan is tracked separately in issue #13          |
+| Optional Azure profile | Foundry + free Azure AI Search            | Search Free has no hourly charge; Foundry model inference consumes credit only after a model is deployed and invoked | Adapters and infrastructure definitions do not create resources by themselves |
 
 Model sizes are approximate and can change when a model image is updated. Docker images, package caches, database records, and generated build artifacts require additional local disk space.
 
@@ -116,7 +116,7 @@ ContractIQ v1 remains locally runnable without Azure credentials or automatic pr
 
 - cloning, building, testing, and demonstrating v1 creates no Azure resource;
 - no Azure resource group exists until an explicit subscription deployment is approved;
-- Microsoft Foundry and Azure AI Search remain optional adapters, not runtime dependencies;
+- Microsoft Foundry model adapters are implemented but remain optional; Azure AI Search is the next optional adapter and neither is a local runtime dependency;
 - the free Search profile stays keyless for inbound application calls through Entra RBAC, while application-owned code generates and uploads embeddings;
 - Search-managed outbound identity, integrated vectorization, semantic ranking, and dedicated capacity remain a documented Basic-or-higher production evolution;
 - issue #13 records resource assumptions, budgets, keyless authentication, infrastructure as code, and the exact teardown boundary before deployment;

--- a/infra/azure/README.md
+++ b/infra/azure/README.md
@@ -14,6 +14,9 @@ This folder contains the reviewed infrastructure boundary for ContractIQ's optio
 
 No model deployment is declared yet. Model name, version, SKU, capacity, and region must be resolved against the live catalog and subscription quota immediately before a separate approved deployment.
 
+The template outputs `foundryOpenAIEndpoint` in the form expected by the .NET
+chat and embedding adapters: `https://<resource-name>.openai.azure.com/openai/v1/`.
+
 ## Security choices
 
 - Local development uses the signed-in Microsoft Entra identity through `DefaultAzureCredential`.

--- a/infra/azure/main.bicep
+++ b/infra/azure/main.bicep
@@ -104,5 +104,6 @@ output resourceGroupName string = resourceGroup.name
 output foundryAccountName string = aiPlatform.outputs.foundryAccountName
 output foundryProjectName string = aiPlatform.outputs.foundryProjectName
 output foundryEndpoint string = aiPlatform.outputs.foundryEndpoint
+output foundryOpenAIEndpoint string = aiPlatform.outputs.foundryOpenAIEndpoint
 output searchServiceName string = aiPlatform.outputs.searchServiceName
 output searchEndpoint string = aiPlatform.outputs.searchEndpoint

--- a/infra/azure/modules/ai-platform.bicep
+++ b/infra/azure/modules/ai-platform.bicep
@@ -122,5 +122,6 @@ resource searchDataRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = i
 output foundryAccountName string = foundryAccount.name
 output foundryProjectName string = foundryProject.name
 output foundryEndpoint string = foundryAccount.properties.endpoint
+output foundryOpenAIEndpoint string = 'https://${foundryAccount.name}.openai.azure.com/openai/v1/'
 output searchServiceName string = searchService.name
 output searchEndpoint string = 'https://${searchService.name}.search.windows.net'

--- a/src/ContractIQ.Api/appsettings.json
+++ b/src/ContractIQ.Api/appsettings.json
@@ -7,11 +7,18 @@
   },
   "Knowledge": {
     "ContentRoot": "sample-data/knowledge",
+    "EmbeddingProvider": "Ollama",
     "Ollama": {
       "Endpoint": "http://localhost:11434",
       "EmbeddingModel": "embeddinggemma",
       "Dimensions": 768
     }
+  },
+  "Foundry": {
+    "OpenAIEndpoint": "",
+    "ChatDeployment": "",
+    "EmbeddingDeployment": "",
+    "EmbeddingDimensions": 768
   },
   "Assistant": {
     "Provider": "Ollama",

--- a/src/ContractIQ.Api/packages.lock.json
+++ b/src/ContractIQ.Api/packages.lock.json
@@ -72,6 +72,23 @@
           "OpenTelemetry.Api": "[1.18.0, 2.0.0)"
         }
       },
+      "Azure.Core": {
+        "type": "Transitive",
+        "resolved": "1.53.0",
+        "contentHash": "x9c/toFMOtRrlTdFuE7rlGCVAduQzWVfKmLz5juj41zJAXEhYD5hluiUyyAEzJ6OxpBnKtiaBztzwpZITAVjtg==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.3",
+          "Microsoft.Identity.Client": "4.83.1",
+          "Microsoft.Identity.Client.Extensions.Msal": "4.83.1",
+          "System.ClientModel": "1.10.0",
+          "System.Memory.Data": "10.0.3"
+        }
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "TV62UsrJZPX6gbt3c4WrtXh7bmaDIcMqf9uft1cc4L6gJXOU07hDGEh+bFQh/L2Az0R1WVOkiT66lFqS6G2NmA=="
+      },
       "Microsoft.EntityFrameworkCore.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.11",
@@ -86,6 +103,28 @@
         "type": "Transitive",
         "resolved": "10.9.0",
         "contentHash": "//nASHMCJVxnYfE/WSzfaLOao6/q816kPpgB9rxU0gfSmAny1u3rfQT0D4xAmcIo4yQqJs7rAeBB+M/dIMdZYA=="
+      },
+      "Microsoft.Identity.Client": {
+        "type": "Transitive",
+        "resolved": "4.83.1",
+        "contentHash": "jOLIrZ3cynoqHLLO1cXplFFabrhrMEYs/EuKHvmCyrOm1axqiVFT6nCSnHxk7w5+d2BeQfCdM12Yf/0X7OeS1g==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Abstractions": "8.14.0"
+        }
+      },
+      "Microsoft.Identity.Client.Extensions.Msal": {
+        "type": "Transitive",
+        "resolved": "4.83.1",
+        "contentHash": "I3k4J4Hj4KbLEFanjeUzzDOVecukETaTgEkJ7h2pP/Yazs6SLp6TVUTo/Eo+ptPXMwvc+iX7rBFtMSUrA7R+Mg==",
+        "dependencies": {
+          "Microsoft.Identity.Client": "4.83.1",
+          "System.Security.Cryptography.ProtectedData": "4.5.0"
+        }
+      },
+      "Microsoft.IdentityModel.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.14.0",
+        "contentHash": "iwbCpSjD3ehfTwBhtSNEtKPK0ICun6ov7Ibx6ISNA9bfwIyzI2Siwyi9eJFCJBwxowK9xcA1mj+jBWiigeqgcQ=="
       },
       "Npgsql": {
         "type": "Transitive",
@@ -147,6 +186,11 @@
         "resolved": "10.0.11",
         "contentHash": "4jNNt67NhCqf3bf2FN0mrsC+EH60L7Sny6poqVeiviB27Kw7TQzMmgn8HIaPc8E9EcuGusUyfeu21gLfzcBpDA=="
       },
+      "System.Security.Cryptography.ProtectedData": {
+        "type": "Transitive",
+        "resolved": "4.5.0",
+        "contentHash": "wLBKzFnDCxP12VL9ANydSYhk59fC4cvOr9ypYQLPnAj48NQIhqnjdD2yhP8yEKyBJEjERWS9DisKL7rX5eU25Q=="
+      },
       "contractiq.application": {
         "type": "Project",
         "dependencies": {
@@ -159,6 +203,7 @@
       "contractiq.infrastructure": {
         "type": "Project",
         "dependencies": {
+          "Azure.Identity": "[1.21.0, )",
           "ContractIQ.Application": "[1.0.0, )",
           "Microsoft.EntityFrameworkCore": "[10.0.11, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.11, )",
@@ -168,6 +213,15 @@
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.3, )",
           "OllamaSharp": "[5.4.30, )",
           "Pgvector.EntityFrameworkCore": "[0.3.0, )"
+        }
+      },
+      "Azure.Identity": {
+        "type": "CentralTransitive",
+        "requested": "[1.21.0, )",
+        "resolved": "1.21.0",
+        "contentHash": "GeFv8sGwRKvDKwI2WFy8r0mhmlxEVZg24Sit2NogTjiSO8RVjllWM65OT6e1sKjOvG8V74y7hAbaELUUPjZQSw==",
+        "dependencies": {
+          "Azure.Core": "1.53.0"
         }
       },
       "Microsoft.EntityFrameworkCore": {

--- a/src/ContractIQ.Application/Common/Observability/ContractIqTelemetry.cs
+++ b/src/ContractIQ.Application/Common/Observability/ContractIqTelemetry.cs
@@ -54,6 +54,13 @@ public static class ContractIqTelemetry
         "contractiq.ai.model.tokens",
         unit: "{token}",
         description: "Token usage reported by the configured model provider.");
+    private static readonly Counter<long> EmbeddingRequests = Meter.CreateCounter<long>(
+        "contractiq.ai.embedding.requests",
+        description: "Number of embedding-provider requests.");
+    private static readonly Histogram<double> EmbeddingRequestDuration = Meter.CreateHistogram<double>(
+        "contractiq.ai.embedding.request.duration",
+        unit: "s",
+        description: "Embedding-provider request duration.");
 
     private static readonly Counter<long> ToolCalls = Meter.CreateCounter<long>(
         "contractiq.assistant.tool.calls",
@@ -143,6 +150,24 @@ public static class ContractIqTelemetry
         };
 
         ToolCalls.Add(1, tags);
+    }
+
+    public static void RecordEmbeddingRequest(
+        string provider,
+        string model,
+        string outcome,
+        TimeSpan duration)
+    {
+        var tags = new TagList
+        {
+            { "gen_ai.operation.name", "embeddings" },
+            { "gen_ai.provider.name", provider },
+            { "gen_ai.request.model", model },
+            { "contractiq.outcome", outcome },
+        };
+
+        EmbeddingRequests.Add(1, tags);
+        EmbeddingRequestDuration.Record(duration.TotalSeconds, tags);
     }
 
     public static void RecordCancellationCommand(

--- a/src/ContractIQ.Infrastructure/AI/FoundryOpenAIClientFactory.cs
+++ b/src/ContractIQ.Infrastructure/AI/FoundryOpenAIClientFactory.cs
@@ -1,0 +1,36 @@
+using System.ClientModel.Primitives;
+using Azure.Core;
+using OpenAI;
+
+namespace ContractIQ.Infrastructure.AI;
+
+/// <summary>
+/// Creates OpenAI-compatible clients for a Microsoft Foundry resource without
+/// storing an API key. DefaultAzureCredential is supplied by dependency
+/// injection so local Azure CLI credentials and future managed identities use
+/// the same application code.
+/// </summary>
+internal sealed class FoundryOpenAIClientFactory(TokenCredential credential)
+{
+    private const string FoundryTokenScope = "https://ai.azure.com/.default";
+
+    public OpenAIClient Create(Uri endpoint)
+    {
+        var tokenPolicy = new BearerTokenPolicy(credential, FoundryTokenScope);
+        var clientOptions = new OpenAIClientOptions
+        {
+            Endpoint = endpoint,
+        };
+
+        // The official Foundry keyless .NET pattern currently exposes this
+        // authentication-policy constructor behind OPENAI001. Keep the
+        // acknowledgement local so other experimental APIs still fail builds.
+#pragma warning disable OPENAI001
+        var client = new OpenAIClient(
+            authenticationPolicy: tokenPolicy,
+            options: clientOptions);
+#pragma warning restore OPENAI001
+
+        return client;
+    }
+}

--- a/src/ContractIQ.Infrastructure/Assistant/AssistantOptions.cs
+++ b/src/ContractIQ.Infrastructure/Assistant/AssistantOptions.cs
@@ -7,6 +7,7 @@ public enum AssistantProvider
 {
     Ollama,
     Kimi,
+    Foundry,
 }
 
 public sealed class AssistantOptions
@@ -48,14 +49,26 @@ public sealed class AssistantOptions
         if (!Enum.TryParse(providerValue, ignoreCase: true, out AssistantProvider provider))
         {
             throw new InvalidOperationException(
-                $"Assistant provider '{providerValue}' is not supported. Use 'Ollama' or 'Kimi'.");
+                $"Assistant provider '{providerValue}' is not supported. " +
+                "Use 'Ollama', 'Kimi', or 'Foundry'.");
         }
 
         string endpoint;
         string model;
         string? apiKey = null;
 
-        if (provider == AssistantProvider.Kimi)
+        if (provider == AssistantProvider.Foundry)
+        {
+            endpoint = GetRequiredSetting(
+                configuration,
+                "Foundry:OpenAIEndpoint",
+                "Foundry is selected as the assistant provider, but no OpenAI endpoint is configured.");
+            model = GetRequiredSetting(
+                configuration,
+                "Foundry:ChatDeployment",
+                "Foundry is selected as the assistant provider, but no chat deployment is configured.");
+        }
+        else if (provider == AssistantProvider.Kimi)
         {
             endpoint = configuration["Assistant:Kimi:Endpoint"]
                 ?? "https://api.moonshot.ai/v1";
@@ -107,10 +120,20 @@ public sealed class AssistantOptions
 
         var endpointUri = new Uri(endpoint, UriKind.Absolute);
 
-        if (provider == AssistantProvider.Kimi && endpointUri.Scheme != Uri.UriSchemeHttps)
+        if (provider is AssistantProvider.Kimi or AssistantProvider.Foundry &&
+            endpointUri.Scheme != Uri.UriSchemeHttps)
         {
             throw new InvalidOperationException(
-                "Kimi endpoint must use HTTPS because the hosted request contains an API key.");
+                $"{provider} endpoint must use HTTPS because it is a hosted provider.");
+        }
+
+        if (provider == AssistantProvider.Foundry &&
+            !endpointUri.AbsolutePath.TrimEnd('/').EndsWith(
+                "/openai/v1",
+                StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(
+                "Foundry OpenAI endpoint must end with '/openai/v1/'.");
         }
 
         return new AssistantOptions(
@@ -120,5 +143,19 @@ public sealed class AssistantOptions
             apiKey,
             maximumOutputTokens,
             temperature);
+    }
+
+    private static string GetRequiredSetting(
+        IConfiguration configuration,
+        string key,
+        string errorMessage)
+    {
+        string? value = configuration[key];
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new InvalidOperationException(errorMessage);
+        }
+
+        return value.Trim();
     }
 }

--- a/src/ContractIQ.Infrastructure/Assistant/ChatClientAssistantAnswerGenerator.cs
+++ b/src/ContractIQ.Infrastructure/Assistant/ChatClientAssistantAnswerGenerator.cs
@@ -1,9 +1,11 @@
 using System.ClientModel;
 using System.Diagnostics;
+using Azure.Identity;
 using ContractIQ.Application.Assistant;
 using ContractIQ.Application.Assistant.Tools;
 using ContractIQ.Application.Common.Exceptions;
 using ContractIQ.Application.Common.Observability;
+using ContractIQ.Infrastructure.AI;
 using Microsoft.Extensions.AI;
 using OllamaSharp;
 using OllamaSharp.Models.Exceptions;
@@ -13,8 +15,8 @@ using OpenAIChatCompletionOptions = OpenAI.Chat.ChatCompletionOptions;
 namespace ContractIQ.Infrastructure.Assistant;
 
 /// <summary>
-/// Exposes the same application-owned tools to either a local Ollama model or
-/// the hosted Kimi API. Business decisions and writes remain in the application.
+/// Exposes the same application-owned tools to local Ollama, hosted Kimi, or
+/// Microsoft Foundry. Business decisions and writes remain in the application.
 /// </summary>
 internal sealed class ChatClientAssistantAnswerGenerator : IAssistantAnswerGenerator, IDisposable
 {
@@ -24,11 +26,13 @@ internal sealed class ChatClientAssistantAnswerGenerator : IAssistantAnswerGener
 
     public ChatClientAssistantAnswerGenerator(
         AssistantOptions options,
-        ContractAssistantReadTools readTools)
+        ContractAssistantReadTools readTools,
+        FoundryOpenAIClientFactory foundryClientFactory)
     {
         _options = options;
         _readTools = readTools;
-        _chatClient = new FunctionInvokingChatClient(CreateProviderClient(options))
+        _chatClient = new FunctionInvokingChatClient(
+            CreateProviderClient(options, foundryClientFactory))
         {
             AllowConcurrentInvocation = false,
             IncludeDetailedErrors = false,
@@ -144,7 +148,11 @@ internal sealed class ChatClientAssistantAnswerGenerator : IAssistantAnswerGener
             throw CreateUnavailableException(exception);
         }
         catch (Exception exception) when (
-            exception is HttpRequestException or OllamaException or ClientResultException)
+            exception is HttpRequestException or
+                OllamaException or
+                ClientResultException or
+                AuthenticationFailedException or
+                CredentialUnavailableException)
         {
             RecordFailure(activity, provider, "unavailable", exception, startedAt);
             throw CreateUnavailableException(exception);
@@ -158,8 +166,18 @@ internal sealed class ChatClientAssistantAnswerGenerator : IAssistantAnswerGener
 
     public void Dispose() => _chatClient.Dispose();
 
-    private static IChatClient CreateProviderClient(AssistantOptions options)
+    private static IChatClient CreateProviderClient(
+        AssistantOptions options,
+        FoundryOpenAIClientFactory foundryClientFactory)
     {
+        if (options.Provider == AssistantProvider.Foundry)
+        {
+            return foundryClientFactory
+                .Create(options.Endpoint)
+                .GetChatClient(options.ChatModel)
+                .AsIChatClient();
+        }
+
         if (options.Provider == AssistantProvider.Kimi)
         {
             var clientOptions = new OpenAIClientOptions
@@ -192,12 +210,21 @@ internal sealed class ChatClientAssistantAnswerGenerator : IAssistantAnswerGener
     private ExternalDependencyUnavailableException CreateUnavailableException(
         Exception exception)
     {
-        string dependency = _options.Provider == AssistantProvider.Kimi
-            ? "kimi"
-            : "ollama";
-        string message = _options.Provider == AssistantProvider.Kimi
-            ? $"Kimi is unavailable or model '{_options.ChatModel}' cannot be accessed."
-            : $"Ollama is unavailable or chat model '{_options.ChatModel}' is not installed.";
+        string dependency = _options.Provider switch
+        {
+            AssistantProvider.Foundry => "foundry",
+            AssistantProvider.Kimi => "kimi",
+            _ => "ollama",
+        };
+        string message = _options.Provider switch
+        {
+            AssistantProvider.Foundry =>
+                $"Microsoft Foundry is unavailable or chat deployment '{_options.ChatModel}' cannot be accessed.",
+            AssistantProvider.Kimi =>
+                $"Kimi is unavailable or model '{_options.ChatModel}' cannot be accessed.",
+            _ =>
+                $"Ollama is unavailable or chat model '{_options.ChatModel}' is not installed.",
+        };
 
         return new ExternalDependencyUnavailableException(dependency, message, exception);
     }

--- a/src/ContractIQ.Infrastructure/ContractIQ.Infrastructure.csproj
+++ b/src/ContractIQ.Infrastructure/ContractIQ.Infrastructure.csproj
@@ -4,6 +4,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
       <PrivateAssets>all</PrivateAssets>

--- a/src/ContractIQ.Infrastructure/DependencyInjection.cs
+++ b/src/ContractIQ.Infrastructure/DependencyInjection.cs
@@ -1,7 +1,10 @@
+using Azure.Core;
+using Azure.Identity;
 using ContractIQ.Application.Abstractions.Persistence;
 using ContractIQ.Application.Assistant;
 using ContractIQ.Application.Assistant.Tools;
 using ContractIQ.Application.Knowledge;
+using ContractIQ.Infrastructure.AI;
 using ContractIQ.Infrastructure.Assistant;
 using ContractIQ.Infrastructure.Knowledge;
 using ContractIQ.Infrastructure.Persistence;
@@ -39,6 +42,7 @@ public static class DependencyInjection
             connectionString,
             new KnowledgeOptions(
                 "sample-data/knowledge",
+                KnowledgeEmbeddingProvider.Ollama,
                 new Uri("http://localhost:11434"),
                 "embeddinggemma",
                 768),
@@ -97,7 +101,16 @@ public static class DependencyInjection
         services.AddScoped<IKnowledgeIndex, PostgresKnowledgeIndex>();
         services.AddSingleton(knowledgeOptions);
         services.AddSingleton<IKnowledgeDocumentCatalog, FileSystemKnowledgeDocumentCatalog>();
-        services.AddSingleton<IKnowledgeEmbeddingGenerator, OllamaKnowledgeEmbeddingGenerator>();
+        services.AddSingleton<TokenCredential>(_ => new DefaultAzureCredential());
+        services.AddSingleton<FoundryOpenAIClientFactory>();
+        if (knowledgeOptions.EmbeddingProvider == KnowledgeEmbeddingProvider.Foundry)
+        {
+            services.AddSingleton<IKnowledgeEmbeddingGenerator, FoundryKnowledgeEmbeddingGenerator>();
+        }
+        else
+        {
+            services.AddSingleton<IKnowledgeEmbeddingGenerator, OllamaKnowledgeEmbeddingGenerator>();
+        }
         services.AddSingleton(assistantOptions);
         services.AddSingleton<IAssistantToolAudit, LoggingAssistantToolAudit>();
         services.AddScoped<IAssistantWriteTransaction, EfAssistantWriteTransaction>();

--- a/src/ContractIQ.Infrastructure/Knowledge/FoundryKnowledgeEmbeddingGenerator.cs
+++ b/src/ContractIQ.Infrastructure/Knowledge/FoundryKnowledgeEmbeddingGenerator.cs
@@ -1,0 +1,114 @@
+using System.ClientModel;
+using System.Diagnostics;
+using Azure.Identity;
+using ContractIQ.Application.Common.Exceptions;
+using ContractIQ.Application.Common.Observability;
+using ContractIQ.Application.Knowledge;
+using ContractIQ.Infrastructure.AI;
+using Microsoft.Extensions.AI;
+
+namespace ContractIQ.Infrastructure.Knowledge;
+
+internal sealed class FoundryKnowledgeEmbeddingGenerator : IKnowledgeEmbeddingGenerator
+{
+    private const string ProviderName = "foundry";
+    private readonly IEmbeddingGenerator<string, Embedding<float>> _generator;
+
+    public FoundryKnowledgeEmbeddingGenerator(
+        KnowledgeOptions options,
+        FoundryOpenAIClientFactory clientFactory)
+    {
+        ModelId = options.EmbeddingModel;
+        Dimensions = options.EmbeddingDimensions;
+        _generator = clientFactory
+            .Create(options.EmbeddingEndpoint)
+            .GetEmbeddingClient(ModelId)
+            .AsIEmbeddingGenerator(Dimensions);
+    }
+
+    public string ModelId { get; }
+
+    public int Dimensions { get; }
+
+    public async Task<IReadOnlyList<float[]>> GenerateAsync(
+        IReadOnlyList<string> values,
+        CancellationToken cancellationToken = default)
+    {
+        long startedAt = Stopwatch.GetTimestamp();
+        using Activity? activity = ContractIqTelemetry.StartActivity(
+            "contractiq.ai.embedding.request");
+        activity?.SetTag("gen_ai.operation.name", "embeddings");
+        activity?.SetTag("gen_ai.provider.name", ProviderName);
+        activity?.SetTag("gen_ai.request.model", ModelId);
+
+        try
+        {
+            GeneratedEmbeddings<Embedding<float>> embeddings = await _generator.GenerateAsync(
+                values,
+                new EmbeddingGenerationOptions
+                {
+                    ModelId = ModelId,
+                    Dimensions = Dimensions,
+                },
+                cancellationToken);
+
+            activity?.SetStatus(ActivityStatusCode.Ok);
+            ContractIqTelemetry.RecordEmbeddingRequest(
+                ProviderName,
+                ModelId,
+                "succeeded",
+                Stopwatch.GetElapsedTime(startedAt));
+
+            return embeddings
+                .Select(embedding => embedding.Vector.ToArray())
+                .ToArray();
+        }
+        catch (OperationCanceledException exception) when (cancellationToken.IsCancellationRequested)
+        {
+            RecordFailure(activity, "cancelled", exception, startedAt);
+            throw;
+        }
+        catch (OperationCanceledException exception)
+        {
+            RecordFailure(activity, "unavailable", exception, startedAt);
+            throw CreateUnavailableException(exception);
+        }
+        catch (Exception exception) when (IsUnavailable(exception))
+        {
+            RecordFailure(activity, "unavailable", exception, startedAt);
+            throw CreateUnavailableException(exception);
+        }
+        catch (Exception exception)
+        {
+            RecordFailure(activity, "failed", exception, startedAt);
+            throw;
+        }
+    }
+
+    private static bool IsUnavailable(Exception exception) =>
+        exception is HttpRequestException or
+            ClientResultException or
+            AuthenticationFailedException or
+            CredentialUnavailableException;
+
+    private ExternalDependencyUnavailableException CreateUnavailableException(
+        Exception exception) =>
+        new(
+            ProviderName,
+            $"Microsoft Foundry is unavailable or embedding deployment '{ModelId}' cannot be accessed.",
+            exception);
+
+    private void RecordFailure(
+        Activity? activity,
+        string outcome,
+        Exception exception,
+        long startedAt)
+    {
+        ContractIqTelemetry.MarkError(activity, exception);
+        ContractIqTelemetry.RecordEmbeddingRequest(
+            ProviderName,
+            ModelId,
+            outcome,
+            Stopwatch.GetElapsedTime(startedAt));
+    }
+}

--- a/src/ContractIQ.Infrastructure/Knowledge/KnowledgeOptions.cs
+++ b/src/ContractIQ.Infrastructure/Knowledge/KnowledgeOptions.cs
@@ -1,8 +1,15 @@
 namespace ContractIQ.Infrastructure.Knowledge;
 
+public enum KnowledgeEmbeddingProvider
+{
+    Ollama,
+    Foundry,
+}
+
 public sealed record KnowledgeOptions(
     string ContentRoot,
-    Uri OllamaEndpoint,
+    KnowledgeEmbeddingProvider EmbeddingProvider,
+    Uri EmbeddingEndpoint,
     string EmbeddingModel,
     int EmbeddingDimensions)
 {
@@ -13,15 +20,47 @@ public sealed record KnowledgeOptions(
     {
         string contentRoot = configuration["Knowledge:ContentRoot"]
             ?? "sample-data/knowledge";
-        string endpoint = configuration["Knowledge:Ollama:Endpoint"]
-            ?? "http://localhost:11434";
-        string model = configuration["Knowledge:Ollama:EmbeddingModel"]
-            ?? "embeddinggemma";
-        int dimensions = int.TryParse(
-            configuration["Knowledge:Ollama:Dimensions"],
-            out int configuredDimensions)
-            ? configuredDimensions
-            : StoredEmbeddingDimensions;
+        string providerValue = configuration["Knowledge:EmbeddingProvider"] ?? "Ollama";
+
+        if (!Enum.TryParse(
+            providerValue,
+            ignoreCase: true,
+            out KnowledgeEmbeddingProvider provider))
+        {
+            throw new InvalidOperationException(
+                $"Knowledge embedding provider '{providerValue}' is not supported. " +
+                "Use 'Ollama' or 'Foundry'.");
+        }
+
+        string endpoint;
+        string model;
+        int dimensions;
+
+        if (provider == KnowledgeEmbeddingProvider.Foundry)
+        {
+            endpoint = GetRequiredSetting(
+                configuration,
+                "Foundry:OpenAIEndpoint",
+                "Foundry is selected as the embedding provider, but no OpenAI endpoint is configured.");
+            model = GetRequiredSetting(
+                configuration,
+                "Foundry:EmbeddingDeployment",
+                "Foundry is selected as the embedding provider, but no embedding deployment is configured.");
+            dimensions = ParseRequiredDimensions(
+                configuration["Foundry:EmbeddingDimensions"]);
+        }
+        else
+        {
+            endpoint = configuration["Knowledge:Ollama:Endpoint"]
+                ?? "http://localhost:11434";
+            model = configuration["Knowledge:Ollama:EmbeddingModel"]
+                ?? "embeddinggemma";
+            dimensions = int.TryParse(
+                configuration["Knowledge:Ollama:Dimensions"],
+                out int configuredDimensions)
+                ? configuredDimensions
+                : StoredEmbeddingDimensions;
+        }
 
         if (dimensions != StoredEmbeddingDimensions)
         {
@@ -29,10 +68,48 @@ public sealed record KnowledgeOptions(
                 $"The current pgvector schema requires {StoredEmbeddingDimensions}-dimension embeddings.");
         }
 
-        return new KnowledgeOptions(
-            contentRoot,
-            new Uri(endpoint, UriKind.Absolute),
-            model,
-            dimensions);
+        var endpointUri = new Uri(endpoint, UriKind.Absolute);
+        if (provider == KnowledgeEmbeddingProvider.Foundry &&
+            endpointUri.Scheme != Uri.UriSchemeHttps)
+        {
+            throw new InvalidOperationException(
+                "Foundry embedding endpoint must use HTTPS.");
+        }
+
+        if (provider == KnowledgeEmbeddingProvider.Foundry &&
+            !endpointUri.AbsolutePath.TrimEnd('/').EndsWith(
+                "/openai/v1",
+                StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(
+                "Foundry OpenAI endpoint must end with '/openai/v1/'.");
+        }
+
+        return new KnowledgeOptions(contentRoot, provider, endpointUri, model, dimensions);
+    }
+
+    private static int ParseRequiredDimensions(string? value)
+    {
+        if (!int.TryParse(value, out int dimensions))
+        {
+            throw new InvalidOperationException(
+                "Foundry embedding dimensions must be configured as an integer.");
+        }
+
+        return dimensions;
+    }
+
+    private static string GetRequiredSetting(
+        Microsoft.Extensions.Configuration.IConfiguration configuration,
+        string key,
+        string errorMessage)
+    {
+        string? value = configuration[key];
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new InvalidOperationException(errorMessage);
+        }
+
+        return value.Trim();
     }
 }

--- a/src/ContractIQ.Infrastructure/Knowledge/OllamaKnowledgeEmbeddingGenerator.cs
+++ b/src/ContractIQ.Infrastructure/Knowledge/OllamaKnowledgeEmbeddingGenerator.cs
@@ -13,7 +13,7 @@ internal sealed class OllamaKnowledgeEmbeddingGenerator : IKnowledgeEmbeddingGen
     {
         ModelId = options.EmbeddingModel;
         Dimensions = options.EmbeddingDimensions;
-        _generator = new OllamaApiClient(options.OllamaEndpoint, ModelId);
+        _generator = new OllamaApiClient(options.EmbeddingEndpoint, ModelId);
     }
 
     public string ModelId { get; }

--- a/src/ContractIQ.Infrastructure/packages.lock.json
+++ b/src/ContractIQ.Infrastructure/packages.lock.json
@@ -2,6 +2,15 @@
   "version": 2,
   "dependencies": {
     "net10.0": {
+      "Azure.Identity": {
+        "type": "Direct",
+        "requested": "[1.21.0, )",
+        "resolved": "1.21.0",
+        "contentHash": "GeFv8sGwRKvDKwI2WFy8r0mhmlxEVZg24Sit2NogTjiSO8RVjllWM65OT6e1sKjOvG8V74y7hAbaELUUPjZQSw==",
+        "dependencies": {
+          "Azure.Core": "1.53.0"
+        }
+      },
       "Microsoft.EntityFrameworkCore": {
         "type": "Direct",
         "requested": "[10.0.11, )",
@@ -126,10 +135,29 @@
           "Pgvector": "0.3.2"
         }
       },
+      "Azure.Core": {
+        "type": "Transitive",
+        "resolved": "1.53.0",
+        "contentHash": "x9c/toFMOtRrlTdFuE7rlGCVAduQzWVfKmLz5juj41zJAXEhYD5hluiUyyAEzJ6OxpBnKtiaBztzwpZITAVjtg==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.3",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.3",
+          "Microsoft.Identity.Client": "4.83.1",
+          "Microsoft.Identity.Client.Extensions.Msal": "4.83.1",
+          "System.ClientModel": "1.10.0",
+          "System.Memory.Data": "10.0.3"
+        }
+      },
       "Humanizer.Core": {
         "type": "Transitive",
         "resolved": "2.14.1",
         "contentHash": "lQKvtaTDOXnoVJ20ibTuSIOf2i0uO0MPbDhd1jm238I+U/2ZnRENj0cktKZhtchBMtCUSRQ5v4xBCUbKNmyVMw=="
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "TV62UsrJZPX6gbt3c4WrtXh7bmaDIcMqf9uft1cc4L6gJXOU07hDGEh+bFQh/L2Az0R1WVOkiT66lFqS6G2NmA=="
       },
       "Microsoft.Build.Framework": {
         "type": "Transitive",
@@ -326,6 +354,28 @@
         "resolved": "10.0.11",
         "contentHash": "SXcz+kF+4Oo9b1+55zntpJFYfwb1jw66ioxptyNOOTDc8g2FHnBFWjZpsWfCvZIhzr0x+4e2trVTs4OKwQfBtw=="
       },
+      "Microsoft.Identity.Client": {
+        "type": "Transitive",
+        "resolved": "4.83.1",
+        "contentHash": "jOLIrZ3cynoqHLLO1cXplFFabrhrMEYs/EuKHvmCyrOm1axqiVFT6nCSnHxk7w5+d2BeQfCdM12Yf/0X7OeS1g==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Abstractions": "8.14.0"
+        }
+      },
+      "Microsoft.Identity.Client.Extensions.Msal": {
+        "type": "Transitive",
+        "resolved": "4.83.1",
+        "contentHash": "I3k4J4Hj4KbLEFanjeUzzDOVecukETaTgEkJ7h2pP/Yazs6SLp6TVUTo/Eo+ptPXMwvc+iX7rBFtMSUrA7R+Mg==",
+        "dependencies": {
+          "Microsoft.Identity.Client": "4.83.1",
+          "System.Security.Cryptography.ProtectedData": "4.5.0"
+        }
+      },
+      "Microsoft.IdentityModel.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.14.0",
+        "contentHash": "iwbCpSjD3ehfTwBhtSNEtKPK0ICun6ov7Ibx6ISNA9bfwIyzI2Siwyi9eJFCJBwxowK9xcA1mj+jBWiigeqgcQ=="
+      },
       "Microsoft.VisualStudio.SolutionPersistence": {
         "type": "Transitive",
         "resolved": "1.0.52",
@@ -441,6 +491,11 @@
         "type": "Transitive",
         "resolved": "10.0.11",
         "contentHash": "4jNNt67NhCqf3bf2FN0mrsC+EH60L7Sny6poqVeiviB27Kw7TQzMmgn8HIaPc8E9EcuGusUyfeu21gLfzcBpDA=="
+      },
+      "System.Security.Cryptography.ProtectedData": {
+        "type": "Transitive",
+        "resolved": "4.5.0",
+        "contentHash": "wLBKzFnDCxP12VL9ANydSYhk59fC4cvOr9ypYQLPnAj48NQIhqnjdD2yhP8yEKyBJEjERWS9DisKL7rX5eU25Q=="
       },
       "contractiq.application": {
         "type": "Project",

--- a/tests/ContractIQ.IntegrationTests/AssistantOptionsTests.cs
+++ b/tests/ContractIQ.IntegrationTests/AssistantOptionsTests.cs
@@ -70,6 +70,62 @@ public sealed class AssistantOptionsTests
     }
 
     [Fact]
+    public void Configures_foundry_with_keyless_deployment_settings()
+    {
+        IConfiguration configuration = BuildConfiguration(
+            new Dictionary<string, string?>
+            {
+                ["Assistant:Provider"] = "Foundry",
+                ["Foundry:OpenAIEndpoint"] =
+                    "https://aif-contractiq-dev.example/openai/v1/",
+                ["Foundry:ChatDeployment"] = "contractiq-chat",
+            });
+
+        AssistantOptions options = AssistantOptions.FromConfiguration(configuration);
+
+        Assert.Equal(AssistantProvider.Foundry, options.Provider);
+        Assert.Equal(
+            new Uri("https://aif-contractiq-dev.example/openai/v1/"),
+            options.Endpoint);
+        Assert.Equal("contractiq-chat", options.ChatModel);
+        Assert.Null(options.ApiKey);
+    }
+
+    [Fact]
+    public void Rejects_foundry_without_a_chat_deployment()
+    {
+        IConfiguration configuration = BuildConfiguration(
+            new Dictionary<string, string?>
+            {
+                ["Assistant:Provider"] = "Foundry",
+                ["Foundry:OpenAIEndpoint"] =
+                    "https://aif-contractiq-dev.example/openai/v1/",
+            });
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+            () => AssistantOptions.FromConfiguration(configuration));
+
+        Assert.Contains("chat deployment", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Rejects_foundry_without_the_openai_v1_endpoint()
+    {
+        IConfiguration configuration = BuildConfiguration(
+            new Dictionary<string, string?>
+            {
+                ["Assistant:Provider"] = "Foundry",
+                ["Foundry:OpenAIEndpoint"] = "https://aif-contractiq-dev.example/",
+                ["Foundry:ChatDeployment"] = "contractiq-chat",
+            });
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+            () => AssistantOptions.FromConfiguration(configuration));
+
+        Assert.Contains("/openai/v1/", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void Rejects_an_unknown_provider()
     {
         IConfiguration configuration = BuildConfiguration(

--- a/tests/ContractIQ.IntegrationTests/KnowledgeOptionsTests.cs
+++ b/tests/ContractIQ.IntegrationTests/KnowledgeOptionsTests.cs
@@ -1,0 +1,153 @@
+using ContractIQ.Application.Knowledge;
+using ContractIQ.Infrastructure;
+using ContractIQ.Infrastructure.Assistant;
+using ContractIQ.Infrastructure.Knowledge;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace ContractIQ.IntegrationTests;
+
+public sealed class KnowledgeOptionsTests
+{
+    [Fact]
+    public void Defaults_to_local_ollama_embeddings()
+    {
+        IConfiguration configuration = BuildConfiguration([]);
+
+        KnowledgeOptions options = KnowledgeOptions.FromConfiguration(configuration);
+
+        Assert.Equal(KnowledgeEmbeddingProvider.Ollama, options.EmbeddingProvider);
+        Assert.Equal(new Uri("http://localhost:11434"), options.EmbeddingEndpoint);
+        Assert.Equal("embeddinggemma", options.EmbeddingModel);
+        Assert.Equal(768, options.EmbeddingDimensions);
+    }
+
+    [Fact]
+    public void Configures_foundry_embeddings_with_validated_dimensions()
+    {
+        IConfiguration configuration = BuildConfiguration(
+            new Dictionary<string, string?>
+            {
+                ["Knowledge:EmbeddingProvider"] = "Foundry",
+                ["Foundry:OpenAIEndpoint"] =
+                    "https://aif-contractiq-dev.example/openai/v1/",
+                ["Foundry:EmbeddingDeployment"] = "contractiq-embeddings",
+                ["Foundry:EmbeddingDimensions"] = "768",
+            });
+
+        KnowledgeOptions options = KnowledgeOptions.FromConfiguration(configuration);
+
+        Assert.Equal(KnowledgeEmbeddingProvider.Foundry, options.EmbeddingProvider);
+        Assert.Equal(
+            new Uri("https://aif-contractiq-dev.example/openai/v1/"),
+            options.EmbeddingEndpoint);
+        Assert.Equal("contractiq-embeddings", options.EmbeddingModel);
+        Assert.Equal(768, options.EmbeddingDimensions);
+    }
+
+    [Fact]
+    public void Rejects_foundry_without_explicit_embedding_dimensions()
+    {
+        IConfiguration configuration = BuildConfiguration(
+            FoundryConfigurationWithoutDimensions());
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+            () => KnowledgeOptions.FromConfiguration(configuration));
+
+        Assert.Contains("dimensions", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Rejects_foundry_without_an_embedding_deployment()
+    {
+        IConfiguration configuration = BuildConfiguration(
+            new Dictionary<string, string?>
+            {
+                ["Knowledge:EmbeddingProvider"] = "Foundry",
+                ["Foundry:OpenAIEndpoint"] =
+                    "https://aif-contractiq-dev.example/openai/v1/",
+                ["Foundry:EmbeddingDimensions"] = "768",
+            });
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+            () => KnowledgeOptions.FromConfiguration(configuration));
+
+        Assert.Contains(
+            "embedding deployment",
+            exception.Message,
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Rejects_foundry_without_the_openai_v1_endpoint()
+    {
+        Dictionary<string, string?> values = FoundryConfigurationWithoutDimensions();
+        values["Foundry:OpenAIEndpoint"] = "https://aif-contractiq-dev.example/";
+        values["Foundry:EmbeddingDimensions"] = "768";
+        IConfiguration configuration = BuildConfiguration(values);
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+            () => KnowledgeOptions.FromConfiguration(configuration));
+
+        Assert.Contains("/openai/v1/", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Rejects_foundry_dimensions_that_do_not_match_the_pgvector_schema()
+    {
+        Dictionary<string, string?> values = FoundryConfigurationWithoutDimensions();
+        values["Foundry:EmbeddingDimensions"] = "1536";
+        IConfiguration configuration = BuildConfiguration(values);
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+            () => KnowledgeOptions.FromConfiguration(configuration));
+
+        Assert.Contains("768-dimension", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Dependency_injection_selects_foundry_without_calling_a_model()
+    {
+        var knowledgeOptions = new KnowledgeOptions(
+            "sample-data/knowledge",
+            KnowledgeEmbeddingProvider.Foundry,
+            new Uri("https://aif-contractiq-dev.example/openai/v1/"),
+            "contractiq-embeddings",
+            768);
+        var assistantOptions = new AssistantOptions(
+            AssistantProvider.Ollama,
+            new Uri("http://localhost:11434"),
+            "qwen3:4b",
+            null,
+            600,
+            0.1f);
+        var services = new ServiceCollection();
+        services.AddInfrastructure(
+            "Host=localhost;Database=contractiq;Username=test;Password=test",
+            knowledgeOptions,
+            assistantOptions);
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        IKnowledgeEmbeddingGenerator generator = provider
+            .GetRequiredService<IKnowledgeEmbeddingGenerator>();
+
+        Assert.Equal("contractiq-embeddings", generator.ModelId);
+        Assert.Equal(768, generator.Dimensions);
+    }
+
+    private static Dictionary<string, string?> FoundryConfigurationWithoutDimensions() =>
+        new()
+        {
+            ["Knowledge:EmbeddingProvider"] = "Foundry",
+            ["Foundry:OpenAIEndpoint"] =
+                "https://aif-contractiq-dev.example/openai/v1/",
+            ["Foundry:EmbeddingDeployment"] = "contractiq-embeddings",
+        };
+
+    private static IConfiguration BuildConfiguration(
+        IEnumerable<KeyValuePair<string, string?>> values) =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(values)
+            .Build();
+}

--- a/tests/ContractIQ.IntegrationTests/packages.lock.json
+++ b/tests/ContractIQ.IntegrationTests/packages.lock.json
@@ -61,6 +61,20 @@
         "resolved": "3.1.4",
         "contentHash": "5mj99LvCqrq3CNi06xYdyIAXOEh+5b33F2nErCzI5zWiDdLHXiPXEWFSUAF8zlIv0ZWqjZNCwHTQeAPYbF3pCg=="
       },
+      "Azure.Core": {
+        "type": "Transitive",
+        "resolved": "1.53.0",
+        "contentHash": "x9c/toFMOtRrlTdFuE7rlGCVAduQzWVfKmLz5juj41zJAXEhYD5hluiUyyAEzJ6OxpBnKtiaBztzwpZITAVjtg==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.3",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.3",
+          "Microsoft.Identity.Client": "4.83.1",
+          "Microsoft.Identity.Client.Extensions.Msal": "4.83.1",
+          "System.ClientModel": "1.10.0",
+          "System.Memory.Data": "10.0.3"
+        }
+      },
       "BouncyCastle.Cryptography": {
         "type": "Transitive",
         "resolved": "2.7.0",
@@ -131,6 +145,11 @@
         "type": "Transitive",
         "resolved": "10.0.11",
         "contentHash": "IVGNbZVxLuL80y7cmXYfhIFoTGneHkp4D7xXarYe6V/wjo8/2qiSLUwWax1/h2eHtJ3Y5cuqmtpOyWMnXIsUMA=="
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "TV62UsrJZPX6gbt3c4WrtXh7bmaDIcMqf9uft1cc4L6gJXOU07hDGEh+bFQh/L2Az0R1WVOkiT66lFqS6G2NmA=="
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
@@ -430,6 +449,28 @@
         "resolved": "10.0.11",
         "contentHash": "SXcz+kF+4Oo9b1+55zntpJFYfwb1jw66ioxptyNOOTDc8g2FHnBFWjZpsWfCvZIhzr0x+4e2trVTs4OKwQfBtw=="
       },
+      "Microsoft.Identity.Client": {
+        "type": "Transitive",
+        "resolved": "4.83.1",
+        "contentHash": "jOLIrZ3cynoqHLLO1cXplFFabrhrMEYs/EuKHvmCyrOm1axqiVFT6nCSnHxk7w5+d2BeQfCdM12Yf/0X7OeS1g==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Abstractions": "8.14.0"
+        }
+      },
+      "Microsoft.Identity.Client.Extensions.Msal": {
+        "type": "Transitive",
+        "resolved": "4.83.1",
+        "contentHash": "I3k4J4Hj4KbLEFanjeUzzDOVecukETaTgEkJ7h2pP/Yazs6SLp6TVUTo/Eo+ptPXMwvc+iX7rBFtMSUrA7R+Mg==",
+        "dependencies": {
+          "Microsoft.Identity.Client": "4.83.1",
+          "System.Security.Cryptography.ProtectedData": "4.5.0"
+        }
+      },
+      "Microsoft.IdentityModel.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.14.0",
+        "contentHash": "iwbCpSjD3ehfTwBhtSNEtKPK0ICun6ov7Ibx6ISNA9bfwIyzI2Siwyi9eJFCJBwxowK9xcA1mj+jBWiigeqgcQ=="
+      },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
         "resolved": "17.14.1",
@@ -538,6 +579,11 @@
         "resolved": "10.0.11",
         "contentHash": "4jNNt67NhCqf3bf2FN0mrsC+EH60L7Sny6poqVeiviB27Kw7TQzMmgn8HIaPc8E9EcuGusUyfeu21gLfzcBpDA=="
       },
+      "System.Security.Cryptography.ProtectedData": {
+        "type": "Transitive",
+        "resolved": "4.5.0",
+        "contentHash": "wLBKzFnDCxP12VL9ANydSYhk59fC4cvOr9ypYQLPnAj48NQIhqnjdD2yhP8yEKyBJEjERWS9DisKL7rX5eU25Q=="
+      },
       "Testcontainers": {
         "type": "Transitive",
         "resolved": "4.14.0",
@@ -617,6 +663,7 @@
       "contractiq.infrastructure": {
         "type": "Project",
         "dependencies": {
+          "Azure.Identity": "[1.21.0, )",
           "ContractIQ.Application": "[1.0.0, )",
           "Microsoft.EntityFrameworkCore": "[10.0.11, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.11, )",
@@ -628,6 +675,15 @@
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.3, )",
           "OllamaSharp": "[5.4.30, )",
           "Pgvector.EntityFrameworkCore": "[0.3.0, )"
+        }
+      },
+      "Azure.Identity": {
+        "type": "CentralTransitive",
+        "requested": "[1.21.0, )",
+        "resolved": "1.21.0",
+        "contentHash": "GeFv8sGwRKvDKwI2WFy8r0mhmlxEVZg24Sit2NogTjiSO8RVjllWM65OT6e1sKjOvG8V74y7hAbaELUUPjZQSw==",
+        "dependencies": {
+          "Azure.Core": "1.53.0"
         }
       },
       "Microsoft.AspNetCore.OpenApi": {

--- a/tools/ContractIQ.DocumentIndexer/packages.lock.json
+++ b/tools/ContractIQ.DocumentIndexer/packages.lock.json
@@ -32,6 +32,25 @@
           "Microsoft.Extensions.Options": "10.0.11"
         }
       },
+      "Azure.Core": {
+        "type": "Transitive",
+        "resolved": "1.53.0",
+        "contentHash": "x9c/toFMOtRrlTdFuE7rlGCVAduQzWVfKmLz5juj41zJAXEhYD5hluiUyyAEzJ6OxpBnKtiaBztzwpZITAVjtg==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.3",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.3",
+          "Microsoft.Identity.Client": "4.83.1",
+          "Microsoft.Identity.Client.Extensions.Msal": "4.83.1",
+          "System.ClientModel": "1.10.0",
+          "System.Memory.Data": "10.0.3"
+        }
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "TV62UsrJZPX6gbt3c4WrtXh7bmaDIcMqf9uft1cc4L6gJXOU07hDGEh+bFQh/L2Az0R1WVOkiT66lFqS6G2NmA=="
+      },
       "Microsoft.EntityFrameworkCore.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.11",
@@ -320,6 +339,28 @@
         "resolved": "10.0.11",
         "contentHash": "SXcz+kF+4Oo9b1+55zntpJFYfwb1jw66ioxptyNOOTDc8g2FHnBFWjZpsWfCvZIhzr0x+4e2trVTs4OKwQfBtw=="
       },
+      "Microsoft.Identity.Client": {
+        "type": "Transitive",
+        "resolved": "4.83.1",
+        "contentHash": "jOLIrZ3cynoqHLLO1cXplFFabrhrMEYs/EuKHvmCyrOm1axqiVFT6nCSnHxk7w5+d2BeQfCdM12Yf/0X7OeS1g==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Abstractions": "8.14.0"
+        }
+      },
+      "Microsoft.Identity.Client.Extensions.Msal": {
+        "type": "Transitive",
+        "resolved": "4.83.1",
+        "contentHash": "I3k4J4Hj4KbLEFanjeUzzDOVecukETaTgEkJ7h2pP/Yazs6SLp6TVUTo/Eo+ptPXMwvc+iX7rBFtMSUrA7R+Mg==",
+        "dependencies": {
+          "Microsoft.Identity.Client": "4.83.1",
+          "System.Security.Cryptography.ProtectedData": "4.5.0"
+        }
+      },
+      "Microsoft.IdentityModel.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.14.0",
+        "contentHash": "iwbCpSjD3ehfTwBhtSNEtKPK0ICun6ov7Ibx6ISNA9bfwIyzI2Siwyi9eJFCJBwxowK9xcA1mj+jBWiigeqgcQ=="
+      },
       "Npgsql": {
         "type": "Transitive",
         "resolved": "10.0.3",
@@ -370,6 +411,11 @@
         "resolved": "10.0.11",
         "contentHash": "4jNNt67NhCqf3bf2FN0mrsC+EH60L7Sny6poqVeiviB27Kw7TQzMmgn8HIaPc8E9EcuGusUyfeu21gLfzcBpDA=="
       },
+      "System.Security.Cryptography.ProtectedData": {
+        "type": "Transitive",
+        "resolved": "4.5.0",
+        "contentHash": "wLBKzFnDCxP12VL9ANydSYhk59fC4cvOr9ypYQLPnAj48NQIhqnjdD2yhP8yEKyBJEjERWS9DisKL7rX5eU25Q=="
+      },
       "contractiq.application": {
         "type": "Project",
         "dependencies": {
@@ -382,6 +428,7 @@
       "contractiq.infrastructure": {
         "type": "Project",
         "dependencies": {
+          "Azure.Identity": "[1.21.0, )",
           "ContractIQ.Application": "[1.0.0, )",
           "Microsoft.EntityFrameworkCore": "[10.0.11, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.11, )",
@@ -393,6 +440,15 @@
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.3, )",
           "OllamaSharp": "[5.4.30, )",
           "Pgvector.EntityFrameworkCore": "[0.3.0, )"
+        }
+      },
+      "Azure.Identity": {
+        "type": "CentralTransitive",
+        "requested": "[1.21.0, )",
+        "resolved": "1.21.0",
+        "contentHash": "GeFv8sGwRKvDKwI2WFy8r0mhmlxEVZg24Sit2NogTjiSO8RVjllWM65OT6e1sKjOvG8V74y7hAbaELUUPjZQSw==",
+        "dependencies": {
+          "Azure.Core": "1.53.0"
         }
       },
       "Microsoft.EntityFrameworkCore": {


### PR DESCRIPTION
## Summary

- adds configuration-selected Microsoft Foundry adapters for chat and embeddings behind the existing application ports
- authenticates keylessly with `DefaultAzureCredential` and keeps Azure SDK types inside Infrastructure
- preserves scoped tool calling, human confirmation, deterministic domain rules, PostgreSQL citations, and the local Ollama default
- validates the OpenAI v1 endpoint, deployment names, and the 768-dimension pgvector contract
- adds content-safe telemetry, configuration tests, Bicep endpoint output, and setup/cost documentation

## Validation

- `dotnet format ContractIQ.slnx --verify-no-changes --no-restore`
- `dotnet build ContractIQ.slnx --configuration Release --no-restore -m:1 -nr:false` — 0 warnings, 0 errors
- 89/89 domain, application, and deterministic AI evaluation tests passed
- 17/17 provider/options tests passed without an Azure token or model call
- `bicep build infra/azure/main.bicep` passed
- all NuGet projects report no known vulnerable packages
- the remaining database integration tests are delegated to GitHub CI because Docker Desktop is not running locally

## Cost and safety boundary

This PR creates no Azure resource, deploys no model, acquires no Azure token during tests, and makes no billable model call. The committed runtime defaults remain local Ollama.

Closes #50
Part of #13