### PR TITLE
feat(rag): add Azure AI Search hybrid adapter

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,6 +5,7 @@
 
   <ItemGroup>
     <PackageVersion Include="Azure.Identity" Version="1.21.0" />
+    <PackageVersion Include="Azure.Search.Documents" Version="12.0.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.11" />

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A contract-operations user needs to answer questions such as:
 ContractIQ brings three kinds of information into one traceable workflow:
 
 1. structured customer and contract data from PostgreSQL;
-2. contract clauses and internal policies retrieved through local hybrid search;
+2. contract clauses and internal policies retrieved through a scoped hybrid index;
 3. a language model that explains the result and may select safe application tools.
 
 The model does not calculate penalties, authorize users, write to the database, or invent citations. The .NET domain recalculates and validates the operation immediately before persistence.
@@ -26,7 +26,7 @@ The model does not calculate penalties, authorize users, write to the database, 
 
 - .NET 10, ASP.NET Core, C#, DDD, Clean Architecture principles, CQRS, EF Core, PostgreSQL, and pgvector;
 - React 19 and TypeScript with an accessible, responsive English and Brazilian Portuguese workspace;
-- local RAG with document versioning, scoped lexical and vector retrieval, Reciprocal Rank Fusion, and application-owned citations;
+- provider-neutral RAG with document versioning, scoped lexical and vector retrieval, and application-owned citations through PostgreSQL/pgvector or optional Azure AI Search;
 - provider-neutral chat, embeddings, and tool calling through `Microsoft.Extensions.AI`, using local Ollama, optional hosted Kimi, or keyless Microsoft Foundry;
 - explicit human confirmation, idempotency, transactions, and domain revalidation for AI-prepared writes;
 - OpenTelemetry traces, metrics, and structured logs with an optional local Aspire Dashboard;
@@ -46,6 +46,7 @@ flowchart LR
     Ports --> Ollama[Ollama<br/>local embeddings and optional chat]
     Ports -. optional hosted chat .-> Kimi[Kimi API]
     Ports -. optional hosted models .-> Foundry[Microsoft Foundry]
+    Ports -. optional hybrid index .-> Search[Azure AI Search]
     Api -. OpenTelemetry .-> Aspire[Local Aspire Dashboard]
 ```
 
@@ -131,7 +132,7 @@ The required GitHub Actions workflow restores locked dependencies, audits NuGet 
 
 Current release-candidate coverage includes:
 
-- 144 backend tests across domain, application, integration, and AI evaluation projects;
+- 156 backend tests across domain, application, integration, and AI evaluation projects;
 - 15 React component and workflow tests;
 - 12 deterministic AI safety scenarios covering grounding, citation integrity, bilingual behavior, refusal, and tool routing.
 
@@ -160,7 +161,7 @@ npm run build
 | Fully local assistant | None                                                            | Adds approximately 2.5 GB for `qwen3:4b` and local CPU/RAM usage |
 | Kimi assistant        | Provider API credits only when a grounded question is submitted | Local PostgreSQL and embeddings remain required                  |
 | Aspire observability  | None                                                            | Optional local container and telemetry storage                   |
-| Microsoft Foundry     | No cost until explicitly provisioned and invoked; inference consumes Azure credit | Local application and PostgreSQL can remain running on the developer machine |
+| Optional Azure AI     | No cost until explicitly provisioned; Search Free has no hourly charge and Foundry inference consumes credit only when invoked | Local application and PostgreSQL remain available |
 
 See [cost and resource management](docs/operations/cost-and-resources.md) for startup, storage, cleanup, credential removal, and the future Azure boundary.
 
@@ -170,7 +171,7 @@ See [cost and resource management](docs/operations/cost-and-resources.md) for st
 src/
   ContractIQ.Domain/          Business rules and aggregates
   ContractIQ.Application/     CQRS use cases, ports, RAG and assistant orchestration
-  ContractIQ.Infrastructure/  EF Core, PostgreSQL, Ollama, Kimi and Foundry adapters
+  ContractIQ.Infrastructure/  EF Core, PostgreSQL, Azure AI Search, Ollama, Kimi and Foundry adapters
   ContractIQ.Api/             HTTP composition root, security and telemetry
   ContractIQ.Web/             React and TypeScript product workspace
 tests/                        Domain, application, integration and AI evaluations
@@ -195,6 +196,7 @@ docs/                         Architecture, decisions, operations and demo mater
 - [Cost and resource management](docs/operations/cost-and-resources.md)
 - [Optional Azure AI implementation plan](docs/azure/implementation-plan.md)
 - [Microsoft Foundry model adapters](docs/azure/foundry-model-adapters.md)
+- [Azure AI Search adapter](docs/azure/azure-ai-search-adapter.md)
 - [Azure infrastructure validation](infra/azure/README.md)
 - [v1.0.0 release checklist](docs/release/v1.0.0-checklist.md)
 - [Architecture Decision Records](docs/adr)
@@ -202,6 +204,6 @@ docs/                         Architecture, decisions, operations and demo mater
 
 ## Project status
 
-The local portfolio MVP is feature-complete and validated for the first `v1.0.0` release. The optional Microsoft Foundry model adapters and non-deploying Azure infrastructure foundation are implemented incrementally; Azure AI Search and Microsoft Entra ID for end users remain separate post-MVP items. None of these services is required to run or evaluate the local version.
+The local portfolio MVP is feature-complete and validated for the first `v1.0.0` release. The optional Microsoft Foundry and Azure AI Search adapters plus the non-deploying Azure infrastructure foundation are implemented incrementally. Live Azure validation and Microsoft Entra ID for end users remain separate post-MVP items. None of these services is required to run or evaluate the local version.
 
 ContractIQ uses fictional companies, contracts, policies, and rules. It is a software engineering demonstration and does not provide legal advice.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -21,12 +21,13 @@ flowchart TB
     Infrastructure --> Ollama[Ollama embeddings and optional chat]
     Infrastructure -. optional hosted chat .-> Kimi[Kimi API]
     Infrastructure -. optional hosted models .-> Foundry[Microsoft Foundry]
+    Infrastructure -. optional hybrid index .-> Search[Azure AI Search]
     Api -. traces, metrics, logs .-> Dashboard[Local Aspire Dashboard]
 ```
 
-The diagram includes the optional Foundry model adapters delivered after v1.
-Microsoft Entra ID for end users and Azure AI Search remain future adapters. No
-Azure resource or model deployment is required by the local runtime.
+The diagram includes the optional Foundry model and Azure AI Search adapters
+delivered after v1. Microsoft Entra ID for end users remains a future adapter.
+No Azure resource or model deployment is required by the local runtime.
 
 ## Logical boundaries
 
@@ -38,9 +39,9 @@ The current deterministic rules are documented in [Contract cancellation rules](
 
 ### Knowledge
 
-The knowledge module owns document ingestion, versioning, chunking, embeddings, indexing, retrieval, and citations. It never decides whether a contract can be cancelled. Its application ports are provider-neutral; the current local adapters use Ollama for multilingual embeddings and PostgreSQL for lexical and vector retrieval.
+The knowledge module owns document ingestion, versioning, chunking, embeddings, indexing, retrieval, and citations. It never decides whether a contract can be cancelled. Its application ports are provider-neutral; the default local adapters use Ollama for multilingual embeddings and PostgreSQL for lexical and vector retrieval. The optional Azure profile sends the same application-owned chunks and vectors to Azure AI Search.
 
-Customer, contract, and effective-date filters are applied before ranking. PostgreSQL lexical and cosine-similarity candidate lists are fused with Reciprocal Rank Fusion. See [Local knowledge retrieval](../knowledge/local-retrieval.md) for the concrete flow and trade-offs.
+Customer, contract, and effective-date filters are applied before ranking. PostgreSQL lexical and cosine-similarity candidate lists are fused with Reciprocal Rank Fusion. Azure AI Search performs one prefiltered BM25 and HNSW hybrid request and returns its fused score. See [Local knowledge retrieval](../knowledge/local-retrieval.md) and the [Azure AI Search adapter](../azure/azure-ai-search-adapter.md) for the concrete flows and trade-offs.
 
 ### Assistant orchestration
 
@@ -76,8 +77,8 @@ Retrieved document content is untrusted data. Instructions inside a document can
   configured hosted Kimi adapter supplies chat and tool calling.
 - `FoundryModels`: Microsoft Foundry can supply chat, embeddings, or both through
   Entra RBAC while PostgreSQL remains the local retrieval store.
-- `FutureAzureSearch`: Azure AI Search remains planned behind the existing
-  retrieval ports.
+- `AzureAiSearch`: Foundry or Ollama can generate embeddings while Azure AI
+  Search supplies the optional BM25 and vector hybrid index through Entra RBAC.
 
 The default developer experience remains functional without Azure.
 
@@ -86,8 +87,8 @@ The default developer experience remains functional without Azure.
 | Capability             | v1 implementation                     | Planned option                                              |
 | ---------------------- | ------------------------------------- | ----------------------------------------------------------- |
 | Structured persistence | PostgreSQL through EF Core/Npgsql     | No alternative required for the portfolio MVP               |
-| Lexical retrieval      | PostgreSQL full-text search           | Azure AI Search BM25                                        |
-| Vector retrieval       | pgvector cosine similarity            | Azure AI Search vector search                               |
+| Lexical retrieval      | PostgreSQL full-text search           | Implemented optional Azure AI Search BM25                   |
+| Vector retrieval       | pgvector cosine similarity            | Implemented optional Azure AI Search HNSW                   |
 | Embeddings             | Ollama `embeddinggemma`               | Implemented optional Microsoft Foundry embedding deployment |
 | Chat and tool calling  | Ollama `qwen3:4b` or hosted Kimi      | Implemented optional Microsoft Foundry chat deployment      |
 | Identity               | Anonymous local `Development` profile | Microsoft Entra ID                                          |

--- a/docs/assistant/grounded-answers.md
+++ b/docs/assistant/grounded-answers.md
@@ -3,7 +3,7 @@
 The grounded assistant explains a contract question in English or Brazilian Portuguese by combining two application-owned inputs:
 
 - a deterministic cancellation assessment calculated by the .NET domain model;
-- citation-ready contract and policy evidence retrieved from the local knowledge index.
+- citation-ready contract and policy evidence retrieved from the configured knowledge index.
 
 The language model writes the explanation. It is not the authority for eligibility, dates, chargeable periods, penalty amounts, document scope, or state changes.
 
@@ -13,6 +13,10 @@ The committed default is local Ollama so cloning or starting the repository neve
 creates a hosted-model charge. The assistant chat provider can be changed to Kimi
 or Microsoft Foundry through local configuration. Embeddings can independently
 remain on Ollama or use a Foundry embedding deployment.
+
+Retrieval independently defaults to PostgreSQL full-text search plus pgvector.
+The optional Azure AI Search adapter uses the same application-owned scope and
+citation contract. See [Azure AI Search adapter](../azure/azure-ai-search-adapter.md).
 
 No chat provider is called during application startup or automated tests. A hosted
 request occurs only when a user submits a sufficiently grounded assistant question.

--- a/docs/azure/azure-ai-search-adapter.md
+++ b/docs/azure/azure-ai-search-adapter.md
@@ -1,0 +1,136 @@
+# Azure AI Search adapter
+
+ContractIQ can use Azure AI Search as an optional knowledge index while
+PostgreSQL remains the structured system of record. The committed default is
+still PostgreSQL full-text search plus pgvector, so local startup, tests, and
+the interview demonstration do not contact Azure.
+
+## Responsibility boundary
+
+The existing application-owned indexing and retrieval flow is unchanged:
+
+1. `IKnowledgeDocumentCatalog` reads the fictional Markdown documents.
+2. `MarkdownKnowledgeChunker` produces stable, citation-ready chunks.
+3. `IKnowledgeEmbeddingGenerator` uses either Ollama or Microsoft Foundry.
+4. `IKnowledgeIndex` selects PostgreSQL or Azure AI Search through configuration.
+5. `SearchKnowledgeHandler` validates customer, contract, date, query, and limit
+   before calling the selected adapter.
+
+Azure AI Search does not calculate cancellation eligibility or penalties and
+does not write contract operations to PostgreSQL. It stores only the optional
+RAG index used to retrieve evidence.
+
+## Versioned schema
+
+The default index name is `contractiq-knowledge-v1`, and every chunk also stores
+schema version `1`. The schema contains:
+
+- a deterministic chunk key;
+- document key, type, version, language, and content checksum;
+- optional customer and contract scope;
+- effective-from and effective-to dates;
+- title, source path, section, page, and chunk text for citations;
+- embedding model identity and a 768-dimension vector.
+
+Changing an immutable field or vector dimension requires a new index name such
+as `contractiq-knowledge-v2`. This avoids mutating an incompatible live schema.
+
+## Idempotent indexing
+
+Before generating embeddings, the application asks whether the same document
+key, version, checksum, embedding model, and schema version already exist. An
+unchanged document is skipped.
+
+When replacement is required, chunk keys are derived deterministically from the
+schema version, document key, document version, and chunk position. Existing
+keys are updated with `mergeOrUpload`, while stale keys from a shortened document
+are deleted. Running the same indexer again therefore does not create duplicate
+chunks.
+
+## One scoped hybrid query
+
+Each retrieval executes one Azure AI Search request containing both:
+
+- the user's validated text for BM25 keyword ranking;
+- the application-generated query vector for HNSW similarity ranking.
+
+Azure AI Search combines the ranking lists. The vector configuration explicitly
+uses `PreFilter`, and the same top-level OData filter limits candidates by schema
+version, effective date, customer, and contract before vector ranking. The
+adapter maps the fused score and stored metadata back to the application-owned
+`KnowledgeEvidence` record. Individual lexical and vector subscores are not
+returned by this profile, so those optional fields remain `null`.
+
+## Keyless authentication
+
+The adapter uses the shared `TokenCredential`. For this local portfolio profile,
+`DefaultAzureCredential` reads the signed-in Azure CLI identity. No Search admin
+key is stored or committed.
+
+The developer identity needs both roles already declared by the reviewed Bicep:
+
+- `Search Service Contributor` to create or update the index schema;
+- `Search Index Data Contributor` to query and update index documents.
+
+A future Azure-hosted API should replace the local credential chain with a
+specific managed identity while keeping the same application ports.
+
+## Configuration after explicit provisioning
+
+Do not configure this profile until the Azure resource has been separately
+reviewed and provisioned. The API can use .NET user secrets:
+
+```powershell
+dotnet user-secrets set "Knowledge:IndexProvider" "AzureAiSearch" --project src/ContractIQ.Api
+dotnet user-secrets set "AzureSearch:Endpoint" "https://<search-name>.search.windows.net" --project src/ContractIQ.Api
+dotnet user-secrets set "AzureSearch:IndexName" "contractiq-knowledge-v1" --project src/ContractIQ.Api
+```
+
+The document indexer is a separate process. Configure its current PowerShell
+session without saving a key:
+
+```powershell
+$env:Knowledge__IndexProvider = "AzureAiSearch"
+$env:AzureSearch__Endpoint = "https://<search-name>.search.windows.net"
+$env:AzureSearch__IndexName = "contractiq-knowledge-v1"
+dotnet run --project tools/ContractIQ.DocumentIndexer
+```
+
+Embedding configuration remains independent. Local Ollama embeddings can be
+pushed to Search, or the Foundry embedding profile can be selected using the
+settings in [Microsoft Foundry model adapters](foundry-model-adapters.md).
+
+Remove the temporary environment variables after indexing:
+
+```powershell
+Remove-Item Env:Knowledge__IndexProvider
+Remove-Item Env:AzureSearch__Endpoint
+Remove-Item Env:AzureSearch__IndexName
+```
+
+Return the API to local retrieval with:
+
+```powershell
+dotnet user-secrets set "Knowledge:IndexProvider" "PostgreSql" --project src/ContractIQ.Api
+```
+
+## Failure, telemetry, and testing
+
+Authentication, HTTP, timeout, throttling, and service failures cross the
+existing safe `ExternalDependencyUnavailableException` boundary. Azure SDK
+details are not exposed to the client.
+
+Dependency telemetry records provider, operation, duration, item count, and
+outcome. It excludes queries, document bodies, customer and contract identifiers,
+endpoints, credentials, and vectors.
+
+Automated tests inspect the versioned schema, verify one prefiltered hybrid
+request, simulate idempotent replacement and citation mapping, and exercise safe
+failure translation. They do not request an Azure token or contact Azure.
+
+## Cost boundary
+
+The adapter and its tests create no resource. A free Azure AI Search service has
+no hourly charge but has strict capacity limits and must still be provisioned
+explicitly. Foundry embeddings and chat can consume promotional credit only
+after their model deployments are separately approved and invoked.

--- a/docs/azure/implementation-plan.md
+++ b/docs/azure/implementation-plan.md
@@ -27,7 +27,8 @@ The Azure profile implements existing application ports:
 
 - `IAssistantAnswerGenerator` gets a Foundry-backed `IChatClient` adapter;
 - `IKnowledgeEmbeddingGenerator` gets a Foundry embedding adapter;
-- `IKnowledgeIndex` and `IKnowledgeSearch` get Azure AI Search adapters.
+- `IKnowledgeIndex` gets an Azure AI Search adapter while the application-owned
+  `SearchKnowledgeHandler` continues to implement `IKnowledgeSearch`.
 
 The domain remains unchanged. Cancellation eligibility, penalty calculation, validation, idempotency, state changes, and transactions remain in .NET and PostgreSQL. The model may choose a bounded tool, but it cannot directly write business state.
 
@@ -35,9 +36,9 @@ ContractIQ does not deploy a second hosted agent in Foundry for this increment. 
 
 ## Delivery slices
 
-Status on 2026-08-31: the Azure foundation definitions and Foundry model
-adapters are implemented and validated without provisioning resources. The
-Azure AI Search adapter is the next delivery slice.
+Status on 2026-08-31: the Azure foundation definitions, Foundry model adapters,
+and Azure AI Search adapter are implemented and validated without provisioning
+resources. Manual keyless smoke testing is the next delivery slice.
 
 ### 1. Azure foundation — implemented, not deployed
 
@@ -54,7 +55,7 @@ Azure AI Search adapter is the next delivery slice.
 - translate external failures to the existing safe application exceptions;
 - record dependency duration and result without prompt or document bodies.
 
-### 3. Azure AI Search adapters
+### 3. Azure AI Search adapters — implemented, not invoked live
 
 - define a versioned index schema for document identity, scope, version, chunk text, citation metadata, and vectors;
 - generate embeddings through the application-owned Foundry adapter and push vectors to Search;

--- a/docs/operations/cost-and-resources.md
+++ b/docs/operations/cost-and-resources.md
@@ -116,7 +116,7 @@ ContractIQ v1 remains locally runnable without Azure credentials or automatic pr
 
 - cloning, building, testing, and demonstrating v1 creates no Azure resource;
 - no Azure resource group exists until an explicit subscription deployment is approved;
-- Microsoft Foundry model adapters are implemented but remain optional; Azure AI Search is the next optional adapter and neither is a local runtime dependency;
+- Microsoft Foundry and Azure AI Search adapters are implemented but remain optional and are not local runtime dependencies;
 - the free Search profile stays keyless for inbound application calls through Entra RBAC, while application-owned code generates and uploads embeddings;
 - Search-managed outbound identity, integrated vectorization, semantic ranking, and dedicated capacity remain a documented Basic-or-higher production evolution;
 - issue #13 records resource assumptions, budgets, keyless authentication, infrastructure as code, and the exact teardown boundary before deployment;

--- a/src/ContractIQ.Api/appsettings.json
+++ b/src/ContractIQ.Api/appsettings.json
@@ -8,6 +8,7 @@
   "Knowledge": {
     "ContentRoot": "sample-data/knowledge",
     "EmbeddingProvider": "Ollama",
+    "IndexProvider": "PostgreSql",
     "Ollama": {
       "Endpoint": "http://localhost:11434",
       "EmbeddingModel": "embeddinggemma",
@@ -19,6 +20,10 @@
     "ChatDeployment": "",
     "EmbeddingDeployment": "",
     "EmbeddingDimensions": 768
+  },
+  "AzureSearch": {
+    "Endpoint": "",
+    "IndexName": "contractiq-knowledge-v1"
   },
   "Assistant": {
     "Provider": "Ollama",

--- a/src/ContractIQ.Api/packages.lock.json
+++ b/src/ContractIQ.Api/packages.lock.json
@@ -74,8 +74,8 @@
       },
       "Azure.Core": {
         "type": "Transitive",
-        "resolved": "1.53.0",
-        "contentHash": "x9c/toFMOtRrlTdFuE7rlGCVAduQzWVfKmLz5juj41zJAXEhYD5hluiUyyAEzJ6OxpBnKtiaBztzwpZITAVjtg==",
+        "resolved": "1.54.0",
+        "contentHash": "m6hHbx1q9+GCBZ5A9ykzFylPdTwscX2APH7PlnqV+yu+DH3RRtuIDJMRqdU17cMyinv0hCPofpegoyQ6qWPW7g==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "10.0.3",
           "Microsoft.Identity.Client": "4.83.1",
@@ -204,6 +204,7 @@
         "type": "Project",
         "dependencies": {
           "Azure.Identity": "[1.21.0, )",
+          "Azure.Search.Documents": "[12.0.0, )",
           "ContractIQ.Application": "[1.0.0, )",
           "Microsoft.EntityFrameworkCore": "[10.0.11, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.11, )",
@@ -222,6 +223,15 @@
         "contentHash": "GeFv8sGwRKvDKwI2WFy8r0mhmlxEVZg24Sit2NogTjiSO8RVjllWM65OT6e1sKjOvG8V74y7hAbaELUUPjZQSw==",
         "dependencies": {
           "Azure.Core": "1.53.0"
+        }
+      },
+      "Azure.Search.Documents": {
+        "type": "CentralTransitive",
+        "requested": "[12.0.0, )",
+        "resolved": "12.0.0",
+        "contentHash": "HziwTmbadPNT/Q0Bau3n7ubQQJde5AWGi2LpzA30JwDasJiY5ogyrp7pALpvUy5HYcgSMRrRdLtahgTT5TPyrA==",
+        "dependencies": {
+          "Azure.Core": "1.54.0"
         }
       },
       "Microsoft.EntityFrameworkCore": {

--- a/src/ContractIQ.Application/Common/Observability/ContractIqTelemetry.cs
+++ b/src/ContractIQ.Application/Common/Observability/ContractIqTelemetry.cs
@@ -42,6 +42,17 @@ public static class ContractIqTelemetry
         "contractiq.knowledge.search.result.count",
         unit: "{item}",
         description: "Evidence items returned by hybrid search.");
+    private static readonly Counter<long> KnowledgeIndexDependencyRequests = Meter.CreateCounter<long>(
+        "contractiq.knowledge.index.dependency.requests",
+        description: "Number of knowledge-index dependency operations.");
+    private static readonly Histogram<double> KnowledgeIndexDependencyDuration = Meter.CreateHistogram<double>(
+        "contractiq.knowledge.index.dependency.duration",
+        unit: "s",
+        description: "Knowledge-index dependency operation duration.");
+    private static readonly Histogram<long> KnowledgeIndexDependencyResultCount = Meter.CreateHistogram<long>(
+        "contractiq.knowledge.index.dependency.result.count",
+        unit: "{item}",
+        description: "Items affected or returned by a knowledge-index dependency operation.");
 
     private static readonly Counter<long> ModelRequests = Meter.CreateCounter<long>(
         "contractiq.ai.model.requests",
@@ -112,6 +123,25 @@ public static class ContractIqTelemetry
         KnowledgeSearches.Add(1, tags);
         KnowledgeSearchDuration.Record(duration.TotalSeconds, tags);
         KnowledgeSearchResultCount.Record(resultCount, tags);
+    }
+
+    public static void RecordKnowledgeIndexDependency(
+        string provider,
+        string operation,
+        string outcome,
+        TimeSpan duration,
+        int resultCount)
+    {
+        var tags = new TagList
+        {
+            { "db.system.name", provider },
+            { "db.operation.name", operation },
+            { "contractiq.outcome", outcome },
+        };
+
+        KnowledgeIndexDependencyRequests.Add(1, tags);
+        KnowledgeIndexDependencyDuration.Record(duration.TotalSeconds, tags);
+        KnowledgeIndexDependencyResultCount.Record(resultCount, tags);
     }
 
     public static void RecordModelRequest(

--- a/src/ContractIQ.Infrastructure/ContractIQ.Infrastructure.csproj
+++ b/src/ContractIQ.Infrastructure/ContractIQ.Infrastructure.csproj
@@ -5,6 +5,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Identity" />
+    <PackageReference Include="Azure.Search.Documents" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
       <PrivateAssets>all</PrivateAssets>
@@ -19,5 +20,9 @@
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
     <PackageReference Include="OllamaSharp" />
     <PackageReference Include="Pgvector.EntityFrameworkCore" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="ContractIQ.IntegrationTests" />
   </ItemGroup>
 </Project>

--- a/src/ContractIQ.Infrastructure/DependencyInjection.cs
+++ b/src/ContractIQ.Infrastructure/DependencyInjection.cs
@@ -7,6 +7,7 @@ using ContractIQ.Application.Knowledge;
 using ContractIQ.Infrastructure.AI;
 using ContractIQ.Infrastructure.Assistant;
 using ContractIQ.Infrastructure.Knowledge;
+using ContractIQ.Infrastructure.Knowledge.AzureSearch;
 using ContractIQ.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
@@ -30,8 +31,14 @@ public static class DependencyInjection
                 $"Connection string '{ConnectionStringName}' is not configured.");
 
         KnowledgeOptions knowledgeOptions = KnowledgeOptions.FromConfiguration(configuration);
+        KnowledgeIndexOptions knowledgeIndexOptions =
+            KnowledgeIndexOptions.FromConfiguration(configuration);
         AssistantOptions assistantOptions = AssistantOptions.FromConfiguration(configuration);
-        return services.AddInfrastructure(connectionString, knowledgeOptions, assistantOptions);
+        return services.AddInfrastructure(
+            connectionString,
+            knowledgeOptions,
+            assistantOptions,
+            knowledgeIndexOptions);
     }
 
     public static IServiceCollection AddInfrastructure(
@@ -52,7 +59,8 @@ public static class DependencyInjection
                 "qwen3:4b",
                 null,
                 600,
-                0.1f));
+                0.1f),
+            KnowledgeIndexOptions.Local);
     }
 
     public static IServiceCollection AddInfrastructure(
@@ -69,17 +77,20 @@ public static class DependencyInjection
                 "qwen3:4b",
                 null,
                 600,
-                0.1f));
+                0.1f),
+            KnowledgeIndexOptions.Local);
     }
 
     public static IServiceCollection AddInfrastructure(
         this IServiceCollection services,
         string connectionString,
         KnowledgeOptions knowledgeOptions,
-        AssistantOptions assistantOptions)
+        AssistantOptions assistantOptions,
+        KnowledgeIndexOptions? knowledgeIndexOptions = null)
     {
         ArgumentNullException.ThrowIfNull(services);
         ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
+        knowledgeIndexOptions ??= KnowledgeIndexOptions.Local;
 
         services.AddDbContext<ContractIqDbContext>(options =>
             options.UseNpgsql(
@@ -98,10 +109,19 @@ public static class DependencyInjection
         services.AddScoped<ICustomerRepository, PostgresCustomerRepository>();
         services.AddScoped<IContractRepository, PostgresContractRepository>();
         services.AddScoped<ICancellationRequestStore, PostgresCancellationRequestStore>();
-        services.AddScoped<IKnowledgeIndex, PostgresKnowledgeIndex>();
         services.AddSingleton(knowledgeOptions);
+        services.AddSingleton(knowledgeIndexOptions);
         services.AddSingleton<IKnowledgeDocumentCatalog, FileSystemKnowledgeDocumentCatalog>();
         services.AddSingleton<TokenCredential>(_ => new DefaultAzureCredential());
+        if (knowledgeIndexOptions.Provider == KnowledgeIndexProvider.AzureAiSearch)
+        {
+            services.AddSingleton<IAzureSearchGateway, AzureSearchGateway>();
+            services.AddScoped<IKnowledgeIndex, AzureAiSearchKnowledgeIndex>();
+        }
+        else
+        {
+            services.AddScoped<IKnowledgeIndex, PostgresKnowledgeIndex>();
+        }
         services.AddSingleton<FoundryOpenAIClientFactory>();
         if (knowledgeOptions.EmbeddingProvider == KnowledgeEmbeddingProvider.Foundry)
         {

--- a/src/ContractIQ.Infrastructure/Knowledge/AzureSearch/AzureAiSearchKnowledgeIndex.cs
+++ b/src/ContractIQ.Infrastructure/Knowledge/AzureSearch/AzureAiSearchKnowledgeIndex.cs
@@ -1,0 +1,262 @@
+using System.Diagnostics;
+using System.Security.Cryptography;
+using System.Text;
+using Azure;
+using Azure.Identity;
+using ContractIQ.Application.Common.Exceptions;
+using ContractIQ.Application.Common.Observability;
+using ContractIQ.Application.Knowledge;
+
+namespace ContractIQ.Infrastructure.Knowledge.AzureSearch;
+
+internal sealed class AzureAiSearchKnowledgeIndex(
+    IAzureSearchGateway gateway) : IKnowledgeIndex
+{
+    private const string ProviderName = "azure_ai_search";
+
+    public Task<bool> IsCurrentAsync(
+        string documentKey,
+        string version,
+        string contentChecksum,
+        string embeddingModel,
+        CancellationToken cancellationToken = default) =>
+        ExecuteAsync(
+            "is_current",
+            () => gateway.IsCurrentAsync(
+                new AzureSearchDocumentVersion(
+                    documentKey,
+                    version,
+                    contentChecksum,
+                    embeddingModel),
+                cancellationToken),
+            isCurrent => isCurrent ? 1 : 0,
+            cancellationToken);
+
+    public Task ReplaceAsync(
+        KnowledgeDocumentSource source,
+        string contentChecksum,
+        string embeddingModel,
+        IReadOnlyList<KnowledgeChunk> chunks,
+        CancellationToken cancellationToken = default)
+    {
+        AzureSearchKnowledgeChunkDocument[] documents = chunks
+            .Select(chunk => MapDocument(source, contentChecksum, embeddingModel, chunk))
+            .ToArray();
+
+        return ExecuteAsync(
+            "replace",
+            () => gateway.ReplaceAsync(
+                source.DocumentKey,
+                source.Version,
+                documents,
+                cancellationToken),
+            documents.Length,
+            cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<KnowledgeEvidence>> SearchAsync(
+        string query,
+        float[] queryEmbedding,
+        Guid customerId,
+        Guid contractId,
+        DateOnly asOf,
+        int limit,
+        CancellationToken cancellationToken = default)
+    {
+        int candidateCount = Math.Max(limit * 10, 20);
+        IReadOnlyList<AzureSearchHit> hits = await ExecuteAsync(
+            "hybrid_search",
+            () => gateway.HybridSearchAsync(
+                new AzureSearchHybridQuery(
+                    query,
+                    queryEmbedding,
+                    customerId,
+                    contractId,
+                    asOf,
+                    candidateCount),
+                cancellationToken),
+            result => result.Count,
+            cancellationToken);
+
+        return hits
+            .Select(MapEvidence)
+            .Take(limit)
+            .ToArray();
+    }
+
+    private static AzureSearchKnowledgeChunkDocument MapDocument(
+        KnowledgeDocumentSource source,
+        string contentChecksum,
+        string embeddingModel,
+        KnowledgeChunk chunk)
+    {
+        Guid chunkId = CreateChunkId(source.DocumentKey, source.Version, chunk.Index);
+
+        return new AzureSearchKnowledgeChunkDocument
+        {
+            Id = chunkId.ToString("N"),
+            SchemaVersion = AzureSearchGateway.SchemaVersion,
+            DocumentKey = source.DocumentKey,
+            Title = source.Title,
+            DocumentType = source.DocumentType.ToString(),
+            Version = source.Version,
+            Language = source.Language,
+            CustomerId = source.CustomerId?.ToString("D"),
+            ContractId = source.ContractId?.ToString("D"),
+            EffectiveFrom = ToUtcDateTimeOffset(source.EffectiveFrom),
+            EffectiveTo = source.EffectiveTo is { } effectiveTo
+                ? ToUtcDateTimeOffset(effectiveTo)
+                : null,
+            SourcePath = source.SourcePath,
+            ContentChecksum = contentChecksum,
+            EmbeddingModel = embeddingModel,
+            ChunkIndex = chunk.Index,
+            Section = chunk.Section,
+            Page = chunk.Page,
+            Content = chunk.Content,
+            ChunkChecksum = chunk.Checksum,
+            Embedding = chunk.Embedding,
+        };
+    }
+
+    private static KnowledgeEvidence MapEvidence(AzureSearchHit hit)
+    {
+        AzureSearchKnowledgeChunkDocument document = hit.Document;
+
+        return new KnowledgeEvidence(
+            Guid.ParseExact(document.Id, "N"),
+            document.DocumentKey,
+            document.Title,
+            Enum.Parse<KnowledgeDocumentType>(document.DocumentType),
+            document.Version,
+            document.Language,
+            ParseOptionalGuid(document.CustomerId),
+            ParseOptionalGuid(document.ContractId),
+            DateOnly.FromDateTime(document.EffectiveFrom.UtcDateTime),
+            document.SourcePath,
+            document.Section,
+            document.Page,
+            document.Content,
+            hit.Score,
+            LexicalScore: null,
+            VectorScore: null);
+    }
+
+    private static Guid CreateChunkId(
+        string documentKey,
+        string version,
+        int chunkIndex)
+    {
+        byte[] source = Encoding.UTF8.GetBytes(
+            $"{AzureSearchGateway.SchemaVersion}:{documentKey}:{version}:{chunkIndex}");
+        byte[] hash = SHA256.HashData(source);
+        return new Guid(hash.AsSpan(0, 16));
+    }
+
+    private static DateTimeOffset ToUtcDateTimeOffset(DateOnly value) =>
+        new(value.ToDateTime(TimeOnly.MinValue), TimeSpan.Zero);
+
+    private static Guid? ParseOptionalGuid(string? value) =>
+        value is null ? null : Guid.Parse(value);
+
+    private static async Task ExecuteAsync(
+        string operation,
+        Func<Task> action,
+        int resultCount,
+        CancellationToken cancellationToken)
+    {
+        await ExecuteAsync(
+            operation,
+            async () =>
+            {
+                await action();
+                return true;
+            },
+            _ => resultCount,
+            cancellationToken);
+    }
+
+    private static Task<T> ExecuteAsync<T>(
+        string operation,
+        Func<Task<T>> action,
+        int resultCount,
+        CancellationToken cancellationToken) =>
+        ExecuteAsync(operation, action, _ => resultCount, cancellationToken);
+
+    private static async Task<T> ExecuteAsync<T>(
+        string operation,
+        Func<Task<T>> action,
+        Func<T, int> resultCount,
+        CancellationToken cancellationToken)
+    {
+        long startedAt = Stopwatch.GetTimestamp();
+        using Activity? activity = ContractIqTelemetry.StartActivity(
+            $"contractiq.knowledge.index.{operation}");
+        activity?.SetTag("db.system.name", "azure_ai_search");
+        activity?.SetTag("db.operation.name", operation);
+
+        try
+        {
+            T result = await action();
+            int count = resultCount(result);
+            activity?.SetTag("contractiq.knowledge.result.count", count);
+            activity?.SetStatus(ActivityStatusCode.Ok);
+            ContractIqTelemetry.RecordKnowledgeIndexDependency(
+                ProviderName,
+                operation,
+                "succeeded",
+                Stopwatch.GetElapsedTime(startedAt),
+                count);
+            return result;
+        }
+        catch (OperationCanceledException exception) when (cancellationToken.IsCancellationRequested)
+        {
+            RecordFailure(activity, operation, "cancelled", exception, startedAt);
+            throw;
+        }
+        catch (OperationCanceledException exception)
+        {
+            RecordFailure(activity, operation, "unavailable", exception, startedAt);
+            throw CreateUnavailableException(exception);
+        }
+        catch (Exception exception) when (IsUnavailable(exception))
+        {
+            RecordFailure(activity, operation, "unavailable", exception, startedAt);
+            throw CreateUnavailableException(exception);
+        }
+        catch (Exception exception)
+        {
+            RecordFailure(activity, operation, "failed", exception, startedAt);
+            throw;
+        }
+    }
+
+    private static bool IsUnavailable(Exception exception) =>
+        exception is RequestFailedException or
+            AuthenticationFailedException or
+            CredentialUnavailableException or
+            HttpRequestException;
+
+    private static ExternalDependencyUnavailableException CreateUnavailableException(
+        Exception exception) =>
+        new(
+            "azure-ai-search",
+            "Azure AI Search is unavailable or the configured index cannot be accessed.",
+            exception);
+
+    private static void RecordFailure(
+        Activity? activity,
+        string operation,
+        string outcome,
+        Exception exception,
+        long startedAt)
+    {
+        ContractIqTelemetry.MarkError(activity, exception);
+        ContractIqTelemetry.RecordKnowledgeIndexDependency(
+            ProviderName,
+            operation,
+            outcome,
+            Stopwatch.GetElapsedTime(startedAt),
+            resultCount: 0);
+    }
+}

--- a/src/ContractIQ.Infrastructure/Knowledge/AzureSearch/AzureSearchGateway.cs
+++ b/src/ContractIQ.Infrastructure/Knowledge/AzureSearch/AzureSearchGateway.cs
@@ -1,0 +1,289 @@
+using Azure;
+using Azure.Core;
+using Azure.Search.Documents;
+using Azure.Search.Documents.Indexes;
+using Azure.Search.Documents.Indexes.Models;
+using Azure.Search.Documents.Models;
+
+namespace ContractIQ.Infrastructure.Knowledge.AzureSearch;
+
+internal sealed class AzureSearchGateway : IAzureSearchGateway, IDisposable
+{
+    internal const int SchemaVersion = 1;
+    internal const string VectorAlgorithmName = "contractiq-hnsw";
+    internal const string VectorProfileName = "contractiq-vector-profile";
+
+    private readonly SearchClient _searchClient;
+    private readonly SearchIndexClient _indexClient;
+    private readonly KnowledgeIndexOptions _options;
+    private readonly SemaphoreSlim _indexInitialization = new(1, 1);
+    private bool _indexReady;
+
+    public AzureSearchGateway(
+        KnowledgeIndexOptions options,
+        TokenCredential credential)
+    {
+        _options = options;
+        Uri endpoint = options.AzureSearchEndpoint
+            ?? throw new InvalidOperationException(
+                "Azure AI Search endpoint is required by the selected index provider.");
+        _indexClient = new SearchIndexClient(endpoint, credential);
+        _searchClient = new SearchClient(
+            endpoint,
+            options.AzureSearchIndexName,
+            credential);
+    }
+
+    public async Task<bool> IsCurrentAsync(
+        AzureSearchDocumentVersion version,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureIndexAsync(cancellationToken);
+
+        var options = new SearchOptions
+        {
+            Filter = CreateCurrentVersionFilter(version),
+            Size = 1,
+        };
+        options.Select.Add(nameof(AzureSearchKnowledgeChunkDocument.Id));
+
+        Response<SearchResults<AzureSearchKnowledgeChunkDocument>> response =
+            await _searchClient.SearchAsync<AzureSearchKnowledgeChunkDocument>(
+                "*",
+                options,
+                cancellationToken);
+
+        await foreach (SearchResult<AzureSearchKnowledgeChunkDocument> _ in
+            response.Value.GetResultsAsync())
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    public async Task ReplaceAsync(
+        string documentKey,
+        string version,
+        IReadOnlyList<AzureSearchKnowledgeChunkDocument> chunks,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureIndexAsync(cancellationToken);
+
+        IReadOnlyList<string> existingKeys = await FindVersionKeysAsync(
+            documentKey,
+            version,
+            cancellationToken);
+        HashSet<string> currentKeys = chunks
+            .Select(chunk => chunk.Id)
+            .ToHashSet(StringComparer.Ordinal);
+        string[] staleKeys = existingKeys
+            .Where(key => !currentKeys.Contains(key))
+            .ToArray();
+        var indexingOptions = new IndexDocumentsOptions
+        {
+            ThrowOnAnyError = true,
+        };
+
+        if (staleKeys.Length > 0)
+        {
+            await _searchClient.DeleteDocumentsAsync(
+                nameof(AzureSearchKnowledgeChunkDocument.Id),
+                staleKeys,
+                indexingOptions,
+                cancellationToken);
+        }
+
+        if (chunks.Count > 0)
+        {
+            await _searchClient.MergeOrUploadDocumentsAsync(
+                chunks,
+                indexingOptions,
+                cancellationToken);
+        }
+    }
+
+    public async Task<IReadOnlyList<AzureSearchHit>> HybridSearchAsync(
+        AzureSearchHybridQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureIndexAsync(cancellationToken);
+
+        SearchOptions options = CreateHybridSearchOptions(query);
+        Response<SearchResults<AzureSearchKnowledgeChunkDocument>> response =
+            await _searchClient.SearchAsync<AzureSearchKnowledgeChunkDocument>(
+                query.Text,
+                options,
+                cancellationToken);
+
+        var hits = new List<AzureSearchHit>();
+        await foreach (SearchResult<AzureSearchKnowledgeChunkDocument> result in
+            response.Value.GetResultsAsync())
+        {
+            hits.Add(new AzureSearchHit(result.Document, result.Score ?? 0d));
+        }
+
+        return hits;
+    }
+
+    public void Dispose() => _indexInitialization.Dispose();
+
+    internal static SearchIndex CreateIndexDefinition(
+        string indexName,
+        int embeddingDimensions)
+    {
+        if (embeddingDimensions != KnowledgeOptions.StoredEmbeddingDimensions)
+        {
+            throw new InvalidOperationException(
+                $"Azure AI Search schema v{SchemaVersion} requires " +
+                $"{KnowledgeOptions.StoredEmbeddingDimensions}-dimension embeddings.");
+        }
+
+        var fields = new FieldBuilder().Build(
+            typeof(AzureSearchKnowledgeChunkDocument));
+        var index = new SearchIndex(indexName, fields)
+        {
+            VectorSearch = new VectorSearch(),
+        };
+        index.VectorSearch.Algorithms.Add(
+            new HnswAlgorithmConfiguration(VectorAlgorithmName));
+        index.VectorSearch.Profiles.Add(
+            new VectorSearchProfile(VectorProfileName, VectorAlgorithmName));
+
+        return index;
+    }
+
+    internal static SearchOptions CreateHybridSearchOptions(
+        AzureSearchHybridQuery query)
+    {
+        var vectorQuery = new VectorizedQuery(query.Vector)
+        {
+            KNearestNeighborsCount = query.CandidateCount,
+        };
+        vectorQuery.Fields.Add(nameof(AzureSearchKnowledgeChunkDocument.Embedding));
+
+        var options = new SearchOptions
+        {
+            Filter = CreateScopeFilter(query),
+            Size = query.CandidateCount,
+            VectorSearch = new VectorSearchOptions
+            {
+                FilterMode = VectorFilterMode.PreFilter,
+            },
+        };
+        options.VectorSearch.Queries.Add(vectorQuery);
+        AddEvidenceFields(options.Select);
+
+        return options;
+    }
+
+    private async Task EnsureIndexAsync(CancellationToken cancellationToken)
+    {
+        if (_indexReady)
+        {
+            return;
+        }
+
+        await _indexInitialization.WaitAsync(cancellationToken);
+        try
+        {
+            if (_indexReady)
+            {
+                return;
+            }
+
+            SearchIndex definition = CreateIndexDefinition(
+                _options.AzureSearchIndexName,
+                KnowledgeOptions.StoredEmbeddingDimensions);
+            await _indexClient.CreateOrUpdateIndexAsync(
+                definition,
+                cancellationToken: cancellationToken);
+            _indexReady = true;
+        }
+        finally
+        {
+            _indexInitialization.Release();
+        }
+    }
+
+    private async Task<IReadOnlyList<string>> FindVersionKeysAsync(
+        string documentKey,
+        string version,
+        CancellationToken cancellationToken)
+    {
+        FormattableString versionFilter = $"""
+            SchemaVersion eq {SchemaVersion} and
+            DocumentKey eq {documentKey} and Version eq {version}
+            """;
+        var options = new SearchOptions
+        {
+            Filter = SearchFilter.Create(versionFilter),
+            Size = 1_000,
+        };
+        options.Select.Add(nameof(AzureSearchKnowledgeChunkDocument.Id));
+
+        Response<SearchResults<AzureSearchKnowledgeChunkDocument>> response =
+            await _searchClient.SearchAsync<AzureSearchKnowledgeChunkDocument>(
+                "*",
+                options,
+                cancellationToken);
+        var keys = new List<string>();
+
+        await foreach (SearchResult<AzureSearchKnowledgeChunkDocument> result in
+            response.Value.GetResultsAsync())
+        {
+            keys.Add(result.Document.Id);
+        }
+
+        return keys;
+    }
+
+    private static string CreateCurrentVersionFilter(
+        AzureSearchDocumentVersion version)
+    {
+        FormattableString filter = $"""
+            SchemaVersion eq {SchemaVersion} and
+            DocumentKey eq {version.DocumentKey} and
+            Version eq {version.Version} and
+            ContentChecksum eq {version.ContentChecksum} and
+            EmbeddingModel eq {version.EmbeddingModel}
+            """;
+        return SearchFilter.Create(filter);
+    }
+
+    private static string CreateScopeFilter(AzureSearchHybridQuery query)
+    {
+        DateTimeOffset asOf = new(
+            query.AsOf.ToDateTime(TimeOnly.MinValue),
+            TimeSpan.Zero);
+        string customerId = query.CustomerId.ToString("D");
+        string contractId = query.ContractId.ToString("D");
+
+        FormattableString filter = $"""
+            SchemaVersion eq {SchemaVersion} and
+            EffectiveFrom le {asOf} and
+            (EffectiveTo eq null or EffectiveTo ge {asOf}) and
+            (CustomerId eq null or CustomerId eq {customerId}) and
+            (ContractId eq null or ContractId eq {contractId})
+            """;
+        return SearchFilter.Create(filter);
+    }
+
+    private static void AddEvidenceFields(IList<string> select)
+    {
+        select.Add(nameof(AzureSearchKnowledgeChunkDocument.Id));
+        select.Add(nameof(AzureSearchKnowledgeChunkDocument.DocumentKey));
+        select.Add(nameof(AzureSearchKnowledgeChunkDocument.Title));
+        select.Add(nameof(AzureSearchKnowledgeChunkDocument.DocumentType));
+        select.Add(nameof(AzureSearchKnowledgeChunkDocument.Version));
+        select.Add(nameof(AzureSearchKnowledgeChunkDocument.Language));
+        select.Add(nameof(AzureSearchKnowledgeChunkDocument.CustomerId));
+        select.Add(nameof(AzureSearchKnowledgeChunkDocument.ContractId));
+        select.Add(nameof(AzureSearchKnowledgeChunkDocument.EffectiveFrom));
+        select.Add(nameof(AzureSearchKnowledgeChunkDocument.SourcePath));
+        select.Add(nameof(AzureSearchKnowledgeChunkDocument.Section));
+        select.Add(nameof(AzureSearchKnowledgeChunkDocument.Page));
+        select.Add(nameof(AzureSearchKnowledgeChunkDocument.Content));
+        select.Add(nameof(AzureSearchKnowledgeChunkDocument.ChunkIndex));
+    }
+}

--- a/src/ContractIQ.Infrastructure/Knowledge/AzureSearch/AzureSearchKnowledgeChunkDocument.cs
+++ b/src/ContractIQ.Infrastructure/Knowledge/AzureSearch/AzureSearchKnowledgeChunkDocument.cs
@@ -1,0 +1,70 @@
+using Azure.Search.Documents.Indexes;
+
+namespace ContractIQ.Infrastructure.Knowledge.AzureSearch;
+
+internal sealed class AzureSearchKnowledgeChunkDocument
+{
+    [SimpleField(IsKey = true, IsFilterable = true)]
+    public string Id { get; init; } = string.Empty;
+
+    [SimpleField(IsFilterable = true)]
+    public int SchemaVersion { get; init; }
+
+    [SimpleField(IsFilterable = true)]
+    public string DocumentKey { get; init; } = string.Empty;
+
+    [SearchableField]
+    public string Title { get; init; } = string.Empty;
+
+    [SimpleField(IsFilterable = true)]
+    public string DocumentType { get; init; } = string.Empty;
+
+    [SimpleField(IsFilterable = true)]
+    public string Version { get; init; } = string.Empty;
+
+    [SimpleField(IsFilterable = true)]
+    public string Language { get; init; } = string.Empty;
+
+    [SimpleField(IsFilterable = true)]
+    public string? CustomerId { get; init; }
+
+    [SimpleField(IsFilterable = true)]
+    public string? ContractId { get; init; }
+
+    [SimpleField(IsFilterable = true, IsSortable = true)]
+    public DateTimeOffset EffectiveFrom { get; init; }
+
+    [SimpleField(IsFilterable = true)]
+    public DateTimeOffset? EffectiveTo { get; init; }
+
+    [SimpleField]
+    public string SourcePath { get; init; } = string.Empty;
+
+    [SimpleField(IsFilterable = true)]
+    public string ContentChecksum { get; init; } = string.Empty;
+
+    [SimpleField(IsFilterable = true)]
+    public string EmbeddingModel { get; init; } = string.Empty;
+
+    [SimpleField(IsSortable = true)]
+    public int ChunkIndex { get; init; }
+
+    [SearchableField]
+    public string Section { get; init; } = string.Empty;
+
+    [SimpleField]
+    public int Page { get; init; }
+
+    [SearchableField]
+    public string Content { get; init; } = string.Empty;
+
+    [SimpleField]
+    public string ChunkChecksum { get; init; } = string.Empty;
+
+    [VectorSearchField(
+        VectorSearchDimensions = KnowledgeOptions.StoredEmbeddingDimensions,
+        VectorSearchProfileName = AzureSearchGateway.VectorProfileName,
+        IsStored = false,
+        IsHidden = true)]
+    public float[] Embedding { get; init; } = [];
+}

--- a/src/ContractIQ.Infrastructure/Knowledge/AzureSearch/IAzureSearchGateway.cs
+++ b/src/ContractIQ.Infrastructure/Knowledge/AzureSearch/IAzureSearchGateway.cs
@@ -1,0 +1,36 @@
+namespace ContractIQ.Infrastructure.Knowledge.AzureSearch;
+
+internal interface IAzureSearchGateway
+{
+    Task<bool> IsCurrentAsync(
+        AzureSearchDocumentVersion version,
+        CancellationToken cancellationToken = default);
+
+    Task ReplaceAsync(
+        string documentKey,
+        string version,
+        IReadOnlyList<AzureSearchKnowledgeChunkDocument> chunks,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<AzureSearchHit>> HybridSearchAsync(
+        AzureSearchHybridQuery query,
+        CancellationToken cancellationToken = default);
+}
+
+internal sealed record AzureSearchDocumentVersion(
+    string DocumentKey,
+    string Version,
+    string ContentChecksum,
+    string EmbeddingModel);
+
+internal sealed record AzureSearchHybridQuery(
+    string Text,
+    float[] Vector,
+    Guid CustomerId,
+    Guid ContractId,
+    DateOnly AsOf,
+    int CandidateCount);
+
+internal sealed record AzureSearchHit(
+    AzureSearchKnowledgeChunkDocument Document,
+    double Score);

--- a/src/ContractIQ.Infrastructure/Knowledge/KnowledgeIndexOptions.cs
+++ b/src/ContractIQ.Infrastructure/Knowledge/KnowledgeIndexOptions.cs
@@ -1,0 +1,80 @@
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Configuration;
+
+namespace ContractIQ.Infrastructure.Knowledge;
+
+public enum KnowledgeIndexProvider
+{
+    PostgreSql,
+    AzureAiSearch,
+}
+
+public sealed partial record KnowledgeIndexOptions(
+    KnowledgeIndexProvider Provider,
+    Uri? AzureSearchEndpoint,
+    string AzureSearchIndexName)
+{
+    public const string DefaultAzureSearchIndexName = "contractiq-knowledge-v1";
+
+    public static KnowledgeIndexOptions Local =>
+        new(KnowledgeIndexProvider.PostgreSql, null, DefaultAzureSearchIndexName);
+
+    public static KnowledgeIndexOptions FromConfiguration(IConfiguration configuration)
+    {
+        string providerValue = configuration["Knowledge:IndexProvider"] ?? "PostgreSql";
+        if (!Enum.TryParse(
+            providerValue,
+            ignoreCase: true,
+            out KnowledgeIndexProvider provider))
+        {
+            throw new InvalidOperationException(
+                $"Knowledge index provider '{providerValue}' is not supported. " +
+                "Use 'PostgreSql' or 'AzureAiSearch'.");
+        }
+
+        if (provider == KnowledgeIndexProvider.PostgreSql)
+        {
+            return Local;
+        }
+
+        string endpoint = GetRequiredSetting(
+            configuration,
+            "AzureSearch:Endpoint",
+            "Azure AI Search is selected, but no endpoint is configured.");
+        string indexName = configuration["AzureSearch:IndexName"]?.Trim()
+            ?? DefaultAzureSearchIndexName;
+        var endpointUri = new Uri(endpoint, UriKind.Absolute);
+
+        if (endpointUri.Scheme != Uri.UriSchemeHttps)
+        {
+            throw new InvalidOperationException(
+                "Azure AI Search endpoint must use HTTPS.");
+        }
+
+        if (!AzureSearchIndexNamePattern().IsMatch(indexName))
+        {
+            throw new InvalidOperationException(
+                "Azure AI Search index name must contain 2 to 128 lowercase letters, " +
+                "digits, hyphens, or underscores and start and end with a letter or digit.");
+        }
+
+        return new KnowledgeIndexOptions(provider, endpointUri, indexName);
+    }
+
+    private static string GetRequiredSetting(
+        IConfiguration configuration,
+        string key,
+        string errorMessage)
+    {
+        string? value = configuration[key];
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new InvalidOperationException(errorMessage);
+        }
+
+        return value.Trim();
+    }
+
+    [GeneratedRegex("^[a-z0-9][a-z0-9_-]{0,126}[a-z0-9]$", RegexOptions.CultureInvariant)]
+    private static partial Regex AzureSearchIndexNamePattern();
+}

--- a/src/ContractIQ.Infrastructure/Knowledge/KnowledgeOptions.cs
+++ b/src/ContractIQ.Infrastructure/Knowledge/KnowledgeOptions.cs
@@ -65,7 +65,8 @@ public sealed record KnowledgeOptions(
         if (dimensions != StoredEmbeddingDimensions)
         {
             throw new InvalidOperationException(
-                $"The current pgvector schema requires {StoredEmbeddingDimensions}-dimension embeddings.");
+                $"The current knowledge index schema requires " +
+                $"{StoredEmbeddingDimensions}-dimension embeddings.");
         }
 
         var endpointUri = new Uri(endpoint, UriKind.Absolute);

--- a/src/ContractIQ.Infrastructure/packages.lock.json
+++ b/src/ContractIQ.Infrastructure/packages.lock.json
@@ -11,6 +11,15 @@
           "Azure.Core": "1.53.0"
         }
       },
+      "Azure.Search.Documents": {
+        "type": "Direct",
+        "requested": "[12.0.0, )",
+        "resolved": "12.0.0",
+        "contentHash": "HziwTmbadPNT/Q0Bau3n7ubQQJde5AWGi2LpzA30JwDasJiY5ogyrp7pALpvUy5HYcgSMRrRdLtahgTT5TPyrA==",
+        "dependencies": {
+          "Azure.Core": "1.54.0"
+        }
+      },
       "Microsoft.EntityFrameworkCore": {
         "type": "Direct",
         "requested": "[10.0.11, )",
@@ -137,8 +146,8 @@
       },
       "Azure.Core": {
         "type": "Transitive",
-        "resolved": "1.53.0",
-        "contentHash": "x9c/toFMOtRrlTdFuE7rlGCVAduQzWVfKmLz5juj41zJAXEhYD5hluiUyyAEzJ6OxpBnKtiaBztzwpZITAVjtg==",
+        "resolved": "1.54.0",
+        "contentHash": "m6hHbx1q9+GCBZ5A9ykzFylPdTwscX2APH7PlnqV+yu+DH3RRtuIDJMRqdU17cMyinv0hCPofpegoyQ6qWPW7g==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "10.0.3",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",

--- a/tests/ContractIQ.IntegrationTests/AzureAiSearchKnowledgeIndexTests.cs
+++ b/tests/ContractIQ.IntegrationTests/AzureAiSearchKnowledgeIndexTests.cs
@@ -1,0 +1,305 @@
+using Azure;
+using Azure.Search.Documents;
+using Azure.Search.Documents.Indexes.Models;
+using Azure.Search.Documents.Models;
+using ContractIQ.Application.Common.Exceptions;
+using ContractIQ.Application.Knowledge;
+using ContractIQ.Application.Knowledge.Indexing;
+using ContractIQ.Infrastructure.Knowledge;
+using ContractIQ.Infrastructure.Knowledge.AzureSearch;
+using Xunit;
+
+namespace ContractIQ.IntegrationTests;
+
+public sealed class AzureAiSearchKnowledgeIndexTests
+{
+    private static readonly Guid CustomerId =
+        Guid.Parse("11111111-1111-4111-8111-111111111111");
+    private static readonly Guid ContractId =
+        Guid.Parse("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa");
+
+    [Fact]
+    public void Creates_a_versioned_vector_index_schema()
+    {
+        SearchIndex index = AzureSearchGateway.CreateIndexDefinition(
+            "contractiq-knowledge-v1",
+            768);
+
+        SearchField schemaVersion = Assert.Single(
+            index.Fields,
+            field => field.Name == nameof(AzureSearchKnowledgeChunkDocument.SchemaVersion));
+        SearchField customerId = Assert.Single(
+            index.Fields,
+            field => field.Name == nameof(AzureSearchKnowledgeChunkDocument.CustomerId));
+        SearchField content = Assert.Single(
+            index.Fields,
+            field => field.Name == nameof(AzureSearchKnowledgeChunkDocument.Content));
+        SearchField embedding = Assert.Single(
+            index.Fields,
+            field => field.Name == nameof(AzureSearchKnowledgeChunkDocument.Embedding));
+
+        Assert.True(schemaVersion.IsFilterable);
+        Assert.True(customerId.IsFilterable);
+        Assert.True(content.IsSearchable);
+        Assert.Equal(768, embedding.VectorSearchDimensions);
+        Assert.Equal(AzureSearchGateway.VectorProfileName, embedding.VectorSearchProfileName);
+        Assert.Single(index.VectorSearch.Algorithms);
+        Assert.Single(index.VectorSearch.Profiles);
+    }
+
+    [Fact]
+    public void Builds_one_prefiltered_keyword_and_vector_query()
+    {
+        var query = new AzureSearchHybridQuery(
+            "Can ACME cancel without a penalty?",
+            Enumerable.Repeat(0.25f, 768).ToArray(),
+            CustomerId,
+            ContractId,
+            new DateOnly(2026, 8, 28),
+            50);
+
+        SearchOptions options = AzureSearchGateway.CreateHybridSearchOptions(query);
+
+        Assert.Equal(50, options.Size);
+        Assert.Contains("CustomerId", options.Filter, StringComparison.Ordinal);
+        Assert.Contains(CustomerId.ToString("D"), options.Filter, StringComparison.Ordinal);
+        Assert.Contains("ContractId", options.Filter, StringComparison.Ordinal);
+        Assert.Contains(ContractId.ToString("D"), options.Filter, StringComparison.Ordinal);
+        Assert.Contains("EffectiveFrom", options.Filter, StringComparison.Ordinal);
+        Assert.Equal(VectorFilterMode.PreFilter, options.VectorSearch.FilterMode);
+        VectorizedQuery vectorQuery = Assert.IsType<VectorizedQuery>(
+            Assert.Single(options.VectorSearch.Queries));
+        Assert.Equal(50, vectorQuery.KNearestNeighborsCount);
+        Assert.Contains(
+            nameof(AzureSearchKnowledgeChunkDocument.Embedding),
+            vectorQuery.Fields);
+    }
+
+    [Fact]
+    public async Task Replacing_the_same_version_keeps_stable_chunk_keys_and_state()
+    {
+        var gateway = new InMemoryAzureSearchGateway();
+        var index = new AzureAiSearchKnowledgeIndex(gateway);
+        KnowledgeDocumentSource source = CreateSource();
+        KnowledgeChunk[] chunks = CreateChunks();
+
+        Assert.False(await index.IsCurrentAsync(
+            source.DocumentKey,
+            source.Version,
+            "document-checksum",
+            "embeddinggemma"));
+
+        await index.ReplaceAsync(
+            source,
+            "document-checksum",
+            "embeddinggemma",
+            chunks);
+        string[] firstKeys = gateway.Documents.Select(document => document.Id).ToArray();
+        await index.ReplaceAsync(
+            source,
+            "document-checksum",
+            "embeddinggemma",
+            chunks);
+
+        Assert.True(await index.IsCurrentAsync(
+            source.DocumentKey,
+            source.Version,
+            "document-checksum",
+            "embeddinggemma"));
+        Assert.Equal(chunks.Length, gateway.Documents.Count);
+        Assert.Equal(firstKeys, gateway.Documents.Select(document => document.Id));
+    }
+
+    [Fact]
+    public async Task Document_indexer_skips_an_unchanged_azure_search_version()
+    {
+        KnowledgeDocumentSource source = CreateSource();
+        var gateway = new InMemoryAzureSearchGateway();
+        var handler = new IndexKnowledgeDocumentsHandler(
+            new SingleDocumentCatalog(source),
+            new DeterministicEmbeddings(),
+            new AzureAiSearchKnowledgeIndex(gateway),
+            new MarkdownKnowledgeChunker());
+
+        IndexKnowledgeDocumentsResult first = await handler.HandleAsync();
+        IndexKnowledgeDocumentsResult second = await handler.HandleAsync();
+
+        Assert.Equal(1, first.IndexedDocuments);
+        Assert.Equal(1, second.SkippedDocuments);
+        Assert.Equal(1, gateway.ReplaceCount);
+    }
+
+    [Fact]
+    public async Task Hybrid_results_map_to_application_evidence_and_preserve_citations()
+    {
+        var gateway = new InMemoryAzureSearchGateway();
+        var index = new AzureAiSearchKnowledgeIndex(gateway);
+        KnowledgeDocumentSource source = CreateSource();
+        await index.ReplaceAsync(
+            source,
+            "document-checksum",
+            "embeddinggemma",
+            CreateChunks());
+        gateway.SearchScore = 0.0325d;
+
+        IReadOnlyList<KnowledgeEvidence> evidence = await index.SearchAsync(
+            "Can ACME cancel without a penalty?",
+            Enumerable.Repeat(0.25f, 768).ToArray(),
+            CustomerId,
+            ContractId,
+            new DateOnly(2026, 8, 28),
+            1);
+
+        KnowledgeEvidence result = Assert.Single(evidence);
+        Assert.Equal(source.DocumentKey, result.DocumentKey);
+        Assert.Equal(source.SourcePath, result.SourcePath);
+        Assert.Equal("Termination", result.Section);
+        Assert.Equal(1, result.Page);
+        Assert.Equal(0.0325d, result.Score);
+        Assert.Null(result.LexicalScore);
+        Assert.Null(result.VectorScore);
+        Assert.NotEqual(Guid.Empty, result.ChunkId);
+        Assert.NotNull(gateway.LastQuery);
+        Assert.Equal(CustomerId, gateway.LastQuery.CustomerId);
+        Assert.Equal(ContractId, gateway.LastQuery.ContractId);
+        Assert.Equal(20, gateway.LastQuery.CandidateCount);
+    }
+
+    [Fact]
+    public async Task Provider_failure_maps_to_the_safe_dependency_exception()
+    {
+        var gateway = new InMemoryAzureSearchGateway
+        {
+            SearchException = new RequestFailedException(503, "service unavailable"),
+        };
+        var index = new AzureAiSearchKnowledgeIndex(gateway);
+
+        ExternalDependencyUnavailableException exception =
+            await Assert.ThrowsAsync<ExternalDependencyUnavailableException>(
+                () => index.SearchAsync(
+                    "Can ACME cancel?",
+                    Enumerable.Repeat(0.25f, 768).ToArray(),
+                    CustomerId,
+                    ContractId,
+                    new DateOnly(2026, 8, 28),
+                    5));
+
+        Assert.Equal("azure-ai-search", exception.Dependency);
+        Assert.DoesNotContain(
+            "service unavailable",
+            exception.Message,
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static KnowledgeDocumentSource CreateSource() => new(
+        "contract-acme",
+        "ACME Agreement",
+        KnowledgeDocumentType.Contract,
+        "1.0",
+        "en",
+        CustomerId,
+        ContractId,
+        new DateOnly(2026, 1, 1),
+        null,
+        "contracts/acme.md",
+        "## Termination\n\nThirty days notice is required.");
+
+    private static KnowledgeChunk[] CreateChunks() =>
+    [
+        new KnowledgeChunk(
+            0,
+            "Termination",
+            1,
+            "Thirty days notice is required.",
+            "chunk-checksum-1",
+            Enumerable.Repeat(0.25f, 768).ToArray()),
+        new KnowledgeChunk(
+            1,
+            "Penalty",
+            2,
+            "A deterministic penalty may apply.",
+            "chunk-checksum-2",
+            Enumerable.Repeat(0.5f, 768).ToArray()),
+    ];
+
+    private sealed class InMemoryAzureSearchGateway : IAzureSearchGateway
+    {
+        public List<AzureSearchKnowledgeChunkDocument> Documents { get; } = [];
+
+        public AzureSearchHybridQuery? LastQuery { get; private set; }
+
+        public double SearchScore { get; set; } = 1d;
+
+        public Exception? SearchException { get; init; }
+
+        public int ReplaceCount { get; private set; }
+
+        public Task<bool> IsCurrentAsync(
+            AzureSearchDocumentVersion version,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(Documents.Any(document =>
+                document.DocumentKey == version.DocumentKey &&
+                document.Version == version.Version &&
+                document.ContentChecksum == version.ContentChecksum &&
+                document.EmbeddingModel == version.EmbeddingModel));
+
+        public Task ReplaceAsync(
+            string documentKey,
+            string version,
+            IReadOnlyList<AzureSearchKnowledgeChunkDocument> chunks,
+            CancellationToken cancellationToken = default)
+        {
+            Documents.RemoveAll(document =>
+                document.DocumentKey == documentKey && document.Version == version);
+            Documents.AddRange(chunks);
+            ReplaceCount++;
+            return Task.CompletedTask;
+        }
+
+        public Task<IReadOnlyList<AzureSearchHit>> HybridSearchAsync(
+            AzureSearchHybridQuery query,
+            CancellationToken cancellationToken = default)
+        {
+            LastQuery = query;
+            if (SearchException is not null)
+            {
+                return Task.FromException<IReadOnlyList<AzureSearchHit>>(SearchException);
+            }
+
+            IReadOnlyList<AzureSearchHit> hits = Documents
+                .Where(document =>
+                    document.CustomerId is null ||
+                    document.CustomerId == query.CustomerId.ToString("D"))
+                .Where(document =>
+                    document.ContractId is null ||
+                    document.ContractId == query.ContractId.ToString("D"))
+                .Take(query.CandidateCount)
+                .Select(document => new AzureSearchHit(document, SearchScore))
+                .ToArray();
+            return Task.FromResult(hits);
+        }
+    }
+
+    private sealed class SingleDocumentCatalog(KnowledgeDocumentSource source)
+        : IKnowledgeDocumentCatalog
+    {
+        public Task<IReadOnlyList<KnowledgeDocumentSource>> ReadAllAsync(
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<KnowledgeDocumentSource>>([source]);
+    }
+
+    private sealed class DeterministicEmbeddings : IKnowledgeEmbeddingGenerator
+    {
+        public string ModelId => "embeddinggemma";
+
+        public int Dimensions => 768;
+
+        public Task<IReadOnlyList<float[]>> GenerateAsync(
+            IReadOnlyList<string> values,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<float[]>>(
+                values
+                    .Select(_ => Enumerable.Repeat(0.25f, Dimensions).ToArray())
+                    .ToArray());
+    }
+}

--- a/tests/ContractIQ.IntegrationTests/KnowledgeIndexOptionsTests.cs
+++ b/tests/ContractIQ.IntegrationTests/KnowledgeIndexOptionsTests.cs
@@ -1,0 +1,116 @@
+using ContractIQ.Application.Knowledge;
+using ContractIQ.Infrastructure;
+using ContractIQ.Infrastructure.Assistant;
+using ContractIQ.Infrastructure.Knowledge;
+using ContractIQ.Infrastructure.Knowledge.AzureSearch;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace ContractIQ.IntegrationTests;
+
+public sealed class KnowledgeIndexOptionsTests
+{
+    [Fact]
+    public void Defaults_to_local_postgresql_index()
+    {
+        IConfiguration configuration = BuildConfiguration([]);
+
+        KnowledgeIndexOptions options = KnowledgeIndexOptions.FromConfiguration(configuration);
+
+        Assert.Equal(KnowledgeIndexProvider.PostgreSql, options.Provider);
+        Assert.Null(options.AzureSearchEndpoint);
+    }
+
+    [Fact]
+    public void Configures_keyless_azure_ai_search()
+    {
+        IConfiguration configuration = BuildConfiguration(
+            new Dictionary<string, string?>
+            {
+                ["Knowledge:IndexProvider"] = "AzureAiSearch",
+                ["AzureSearch:Endpoint"] =
+                    "https://srch-contractiq-dev.example.search.windows.net",
+                ["AzureSearch:IndexName"] = "contractiq-knowledge-v1",
+            });
+
+        KnowledgeIndexOptions options = KnowledgeIndexOptions.FromConfiguration(configuration);
+
+        Assert.Equal(KnowledgeIndexProvider.AzureAiSearch, options.Provider);
+        Assert.Equal(
+            new Uri("https://srch-contractiq-dev.example.search.windows.net"),
+            options.AzureSearchEndpoint);
+        Assert.Equal("contractiq-knowledge-v1", options.AzureSearchIndexName);
+    }
+
+    [Fact]
+    public void Rejects_azure_ai_search_without_an_endpoint()
+    {
+        IConfiguration configuration = BuildConfiguration(
+            new Dictionary<string, string?>
+            {
+                ["Knowledge:IndexProvider"] = "AzureAiSearch",
+            });
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+            () => KnowledgeIndexOptions.FromConfiguration(configuration));
+
+        Assert.Contains("endpoint", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("http://srch-contractiq-dev.example.search.windows.net", "contractiq-knowledge-v1")]
+    [InlineData("https://srch-contractiq-dev.example.search.windows.net", "ContractIQ-Knowledge")]
+    public void Rejects_unsafe_endpoint_or_invalid_index_name(
+        string endpoint,
+        string indexName)
+    {
+        IConfiguration configuration = BuildConfiguration(
+            new Dictionary<string, string?>
+            {
+                ["Knowledge:IndexProvider"] = "AzureAiSearch",
+                ["AzureSearch:Endpoint"] = endpoint,
+                ["AzureSearch:IndexName"] = indexName,
+            });
+
+        Assert.Throws<InvalidOperationException>(
+            () => KnowledgeIndexOptions.FromConfiguration(configuration));
+    }
+
+    [Fact]
+    public void Dependency_injection_selects_azure_search_without_a_network_call()
+    {
+        var services = new ServiceCollection();
+        services.AddInfrastructure(
+            "Host=localhost;Database=contractiq;Username=test;Password=test",
+            new KnowledgeOptions(
+                "sample-data/knowledge",
+                KnowledgeEmbeddingProvider.Ollama,
+                new Uri("http://localhost:11434"),
+                "embeddinggemma",
+                768),
+            new AssistantOptions(
+                AssistantProvider.Ollama,
+                new Uri("http://localhost:11434"),
+                "qwen3:4b",
+                null,
+                600,
+                0.1f),
+            new KnowledgeIndexOptions(
+                KnowledgeIndexProvider.AzureAiSearch,
+                new Uri("https://srch-contractiq-dev.example.search.windows.net"),
+                "contractiq-knowledge-v1"));
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        using IServiceScope scope = provider.CreateScope();
+        IKnowledgeIndex index = scope.ServiceProvider.GetRequiredService<IKnowledgeIndex>();
+
+        Assert.IsType<AzureAiSearchKnowledgeIndex>(index);
+    }
+
+    private static IConfiguration BuildConfiguration(
+        IEnumerable<KeyValuePair<string, string?>> values) =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(values)
+            .Build();
+}

--- a/tests/ContractIQ.IntegrationTests/packages.lock.json
+++ b/tests/ContractIQ.IntegrationTests/packages.lock.json
@@ -63,8 +63,8 @@
       },
       "Azure.Core": {
         "type": "Transitive",
-        "resolved": "1.53.0",
-        "contentHash": "x9c/toFMOtRrlTdFuE7rlGCVAduQzWVfKmLz5juj41zJAXEhYD5hluiUyyAEzJ6OxpBnKtiaBztzwpZITAVjtg==",
+        "resolved": "1.54.0",
+        "contentHash": "m6hHbx1q9+GCBZ5A9ykzFylPdTwscX2APH7PlnqV+yu+DH3RRtuIDJMRqdU17cMyinv0hCPofpegoyQ6qWPW7g==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "10.0.3",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
@@ -664,6 +664,7 @@
         "type": "Project",
         "dependencies": {
           "Azure.Identity": "[1.21.0, )",
+          "Azure.Search.Documents": "[12.0.0, )",
           "ContractIQ.Application": "[1.0.0, )",
           "Microsoft.EntityFrameworkCore": "[10.0.11, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.11, )",
@@ -684,6 +685,15 @@
         "contentHash": "GeFv8sGwRKvDKwI2WFy8r0mhmlxEVZg24Sit2NogTjiSO8RVjllWM65OT6e1sKjOvG8V74y7hAbaELUUPjZQSw==",
         "dependencies": {
           "Azure.Core": "1.53.0"
+        }
+      },
+      "Azure.Search.Documents": {
+        "type": "CentralTransitive",
+        "requested": "[12.0.0, )",
+        "resolved": "12.0.0",
+        "contentHash": "HziwTmbadPNT/Q0Bau3n7ubQQJde5AWGi2LpzA30JwDasJiY5ogyrp7pALpvUy5HYcgSMRrRdLtahgTT5TPyrA==",
+        "dependencies": {
+          "Azure.Core": "1.54.0"
         }
       },
       "Microsoft.AspNetCore.OpenApi": {

--- a/tools/ContractIQ.DocumentIndexer/appsettings.json
+++ b/tools/ContractIQ.DocumentIndexer/appsettings.json
@@ -4,10 +4,21 @@
   },
   "Knowledge": {
     "ContentRoot": "sample-data/knowledge",
+    "EmbeddingProvider": "Ollama",
+    "IndexProvider": "PostgreSql",
     "Ollama": {
       "Endpoint": "http://localhost:11434",
       "EmbeddingModel": "embeddinggemma",
       "Dimensions": 768
     }
+  },
+  "Foundry": {
+    "OpenAIEndpoint": "",
+    "EmbeddingDeployment": "",
+    "EmbeddingDimensions": 768
+  },
+  "AzureSearch": {
+    "Endpoint": "",
+    "IndexName": "contractiq-knowledge-v1"
   }
 }

--- a/tools/ContractIQ.DocumentIndexer/packages.lock.json
+++ b/tools/ContractIQ.DocumentIndexer/packages.lock.json
@@ -34,8 +34,8 @@
       },
       "Azure.Core": {
         "type": "Transitive",
-        "resolved": "1.53.0",
-        "contentHash": "x9c/toFMOtRrlTdFuE7rlGCVAduQzWVfKmLz5juj41zJAXEhYD5hluiUyyAEzJ6OxpBnKtiaBztzwpZITAVjtg==",
+        "resolved": "1.54.0",
+        "contentHash": "m6hHbx1q9+GCBZ5A9ykzFylPdTwscX2APH7PlnqV+yu+DH3RRtuIDJMRqdU17cMyinv0hCPofpegoyQ6qWPW7g==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "10.0.3",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
@@ -429,6 +429,7 @@
         "type": "Project",
         "dependencies": {
           "Azure.Identity": "[1.21.0, )",
+          "Azure.Search.Documents": "[12.0.0, )",
           "ContractIQ.Application": "[1.0.0, )",
           "Microsoft.EntityFrameworkCore": "[10.0.11, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.11, )",
@@ -449,6 +450,15 @@
         "contentHash": "GeFv8sGwRKvDKwI2WFy8r0mhmlxEVZg24Sit2NogTjiSO8RVjllWM65OT6e1sKjOvG8V74y7hAbaELUUPjZQSw==",
         "dependencies": {
           "Azure.Core": "1.53.0"
+        }
+      },
+      "Azure.Search.Documents": {
+        "type": "CentralTransitive",
+        "requested": "[12.0.0, )",
+        "resolved": "12.0.0",
+        "contentHash": "HziwTmbadPNT/Q0Bau3n7ubQQJde5AWGi2LpzA30JwDasJiY5ogyrp7pALpvUy5HYcgSMRrRdLtahgTT5TPyrA==",
+        "dependencies": {
+          "Azure.Core": "1.54.0"
         }
       },
       "Microsoft.EntityFrameworkCore": {


### PR DESCRIPTION
## Summary

- adds a configuration-selected Azure AI Search implementation of the existing `IKnowledgeIndex` port while keeping PostgreSQL/pgvector as the local default
- defines a versioned `contractiq-knowledge-v1` schema with document scope, effective dates, checksums, citation metadata, searchable text, and 768-dimension vectors
- makes replacement idempotent through current-version checks, deterministic chunk keys, stale-key deletion, and merge-or-upload indexing
- executes keyword BM25 and HNSW vector retrieval in one hybrid request with customer, contract, effective-date, and schema filters applied before vector ranking
- maps fused Azure results back to application-owned `KnowledgeEvidence` citations
- uses keyless `TokenCredential` authentication and translates provider failures to the existing safe dependency exception
- records provider, operation, duration, item count, and outcome without queries, document bodies, identifiers, endpoints, credentials, or vectors

## Validation

- `dotnet format ContractIQ.slnx --verify-no-changes --no-restore`
- `dotnet build ContractIQ.slnx --configuration Release --no-restore -m:1 -nr:false` — 0 warnings, 0 errors
- 89/89 domain, application, and deterministic AI evaluation tests passed
- 29/29 provider/options and Azure AI Search simulated integration tests passed
- Azure-specific tests cover schema, prefiltering, one hybrid request, idempotence, citations, DI selection, and safe failures without an Azure resource
- Bicep validation passed
- all NuGet projects report no known vulnerable packages

## Cost and safety boundary

This PR creates no Azure resource, requests no Azure token during tests, indexes no live document, and performs no billable call. PostgreSQL/pgvector and Ollama remain the committed defaults. Live keyless validation is deliberately deferred to the separately approved manual smoke-test slice.

Closes #51
Part of #13