### PR TITLE
feat: add keyless manual Azure AI smoke test

### DIFF
--- a/.github/workflows/azure-ai-smoke-test.yml
+++ b/.github/workflows/azure-ai-smoke-test.yml
@@ -1,0 +1,134 @@
+name: Azure AI smoke test
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: GitHub environment authorized for the Azure development profile
+        required: true
+        type: choice
+        options:
+          - azure-dev
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: azure-ai-smoke-${{ inputs.environment }}
+  cancel-in-progress: false
+
+jobs:
+  smoke-test:
+    name: One bounded indexing and query scenario
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    timeout-minutes: 5
+    env:
+      DOTNET_CLI_TELEMETRY_OPTOUT: true
+      DOTNET_NOLOGO: true
+      NUGET_XMLDOC_MODE: skip
+      AZURE_CORE_COLLECT_TELEMETRY: false
+      AZURE_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+      ConnectionStrings__ContractIQ: Host=unused;Database=unused;Username=unused;Password=unused
+      Knowledge__EmbeddingProvider: Foundry
+      Knowledge__IndexProvider: AzureAiSearch
+      Foundry__OpenAIEndpoint: ${{ vars.FOUNDRY_OPENAI_ENDPOINT }}
+      Foundry__EmbeddingDeployment: ${{ vars.FOUNDRY_EMBEDDING_DEPLOYMENT }}
+      Foundry__EmbeddingDimensions: '768'
+      Foundry__MaximumRetries: '0'
+      AzureSearch__Endpoint: ${{ vars.AZURE_SEARCH_ENDPOINT }}
+      AzureSearch__IndexName: ${{ vars.AZURE_SEARCH_INDEX_NAME }}
+      AzureSearch__MaximumRetries: '0'
+      AzureSmoke__TimeoutSeconds: '90'
+      AzureSmoke__ReportPath: TestResults/azure-smoke-test.json
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+
+      - name: Validate environment configuration
+        shell: bash
+        run: |
+          required_variables=(
+            AZURE_CLIENT_ID
+            AZURE_TENANT_ID
+            AZURE_SUBSCRIPTION_ID
+            Foundry__OpenAIEndpoint
+            Foundry__EmbeddingDeployment
+            AzureSearch__Endpoint
+            AzureSearch__IndexName
+          )
+
+          for variable_name in "${required_variables[@]}"; do
+            if [[ -z "${!variable_name}" ]]; then
+              echo "Required environment variable is missing: ${variable_name}" >&2
+              exit 1
+            fi
+          done
+
+      - name: Sign in to Azure through GitHub OIDC
+        uses: Azure/login@7ddb5af1ef8758cf1353cf3b42f940aee27ba21c # v3.0.2
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+        with:
+          dotnet-version: 10.0.400
+
+      - name: Restore smoke-test tool
+        run: >-
+          dotnet restore tools/ContractIQ.AzureSmokeTest/ContractIQ.AzureSmokeTest.csproj
+          --locked-mode
+          -p:NuGetAudit=true
+          -p:NuGetAuditMode=all
+          -p:NuGetAuditLevel=moderate
+          -p:TreatWarningsAsErrors=true
+
+      - name: Build smoke-test tool
+        run: >-
+          dotnet build tools/ContractIQ.AzureSmokeTest/ContractIQ.AzureSmokeTest.csproj
+          --configuration Release
+          --no-restore
+
+      - name: Run one bounded Azure AI scenario
+        run: >-
+          dotnet tools/ContractIQ.AzureSmokeTest/bin/Release/net10.0/ContractIQ.AzureSmokeTest.dll
+
+      - name: Add cost-relevant usage to the run summary
+        if: success()
+        shell: bash
+        run: |
+          report="TestResults/azure-smoke-test.json"
+          {
+            echo "## Azure AI smoke-test usage"
+            echo
+            echo "| Measurement | Value |"
+            echo "| --- | ---: |"
+            echo "| Embedding requests | $(jq -r '.EmbeddingRequests' "$report") |"
+            echo "| Embedding inputs | $(jq -r '.EmbeddingInputs' "$report") |"
+            echo "| Input characters | $(jq -r '.EmbeddingInputCharacters' "$report") |"
+            echo "| Indexed chunks | $(jq -r '.IndexedChunks' "$report") |"
+            echo "| Search queries | $(jq -r '.SearchQueries' "$report") |"
+            echo "| Search results | $(jq -r '.SearchResultCount' "$report") |"
+            echo "| Duration (ms) | $(jq -r '.DurationMilliseconds | round' "$report") |"
+            echo
+            echo "SDK retries were configured to zero for this run."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload bounded usage report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: azure-ai-smoke-test-report
+          path: TestResults/azure-smoke-test.json
+          if-no-files-found: ignore
+          retention-days: 7

--- a/ContractIQ.slnx
+++ b/ContractIQ.slnx
@@ -13,6 +13,7 @@
   </Folder>
   <Folder Name="/tools/">
     <Project Path="tools/ContractIQ.AiEvaluator/ContractIQ.AiEvaluator.csproj" />
+    <Project Path="tools/ContractIQ.AzureSmokeTest/ContractIQ.AzureSmokeTest.csproj" />
     <Project Path="tools/ContractIQ.DocumentIndexer/ContractIQ.DocumentIndexer.csproj" />
   </Folder>
 </Solution>

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The model does not calculate penalties, authorize users, write to the database, 
 - provider-neutral chat, embeddings, and tool calling through `Microsoft.Extensions.AI`, using local Ollama, optional hosted Kimi, or keyless Microsoft Foundry;
 - explicit human confirmation, idempotency, transactions, and domain revalidation for AI-prepared writes;
 - OpenTelemetry traces, metrics, and structured logs with an optional local Aspire Dashboard;
-- automated domain, application, integration, frontend, security, and deterministic AI evaluation gates;
+- automated domain, application, integration, frontend, security, and deterministic AI evaluation gates, plus an isolated manual keyless Azure smoke test;
 - GitHub Issues, short-lived branches, protected pull requests, Dependabot, and reproducible dependency locks.
 
 ## How it works
@@ -132,7 +132,7 @@ The required GitHub Actions workflow restores locked dependencies, audits NuGet 
 
 Current release-candidate coverage includes:
 
-- 156 backend tests across domain, application, integration, and AI evaluation projects;
+- 167 backend tests across domain, application, integration, and AI evaluation projects;
 - 15 React component and workflow tests;
 - 12 deterministic AI safety scenarios covering grounding, citation integrity, bilingual behavior, refusal, and tool routing.
 
@@ -175,7 +175,7 @@ src/
   ContractIQ.Api/             HTTP composition root, security and telemetry
   ContractIQ.Web/             React and TypeScript product workspace
 tests/                        Domain, application, integration and AI evaluations
-tools/                        Document indexer and deterministic AI evaluator
+tools/                        Document indexer, Azure smoke test and deterministic AI evaluator
 evaluations/                  Versioned evaluation scenarios
 sample-data/                  Fictional contracts and internal policies
 docs/                         Architecture, decisions, operations and demo material
@@ -197,6 +197,7 @@ docs/                         Architecture, decisions, operations and demo mater
 - [Optional Azure AI implementation plan](docs/azure/implementation-plan.md)
 - [Microsoft Foundry model adapters](docs/azure/foundry-model-adapters.md)
 - [Azure AI Search adapter](docs/azure/azure-ai-search-adapter.md)
+- [Manual keyless Azure AI smoke test](docs/azure/manual-smoke-test.md)
 - [Azure infrastructure validation](infra/azure/README.md)
 - [v1.0.0 release checklist](docs/release/v1.0.0-checklist.md)
 - [Architecture Decision Records](docs/adr)
@@ -204,6 +205,6 @@ docs/                         Architecture, decisions, operations and demo mater
 
 ## Project status
 
-The local portfolio MVP is feature-complete and validated for the first `v1.0.0` release. The optional Microsoft Foundry and Azure AI Search adapters plus the non-deploying Azure infrastructure foundation are implemented incrementally. Live Azure validation and Microsoft Entra ID for end users remain separate post-MVP items. None of these services is required to run or evaluate the local version.
+The local portfolio MVP is feature-complete and validated for the first `v1.0.0` release. The optional Microsoft Foundry and Azure AI Search adapters, non-deploying Azure infrastructure foundation, and manually dispatched OIDC smoke-test workflow are implemented incrementally. The workflow has not made a live call; provisioning and live Azure validation still require explicit approval. Microsoft Entra ID for end users remains a separate post-MVP item. None of these services is required to run or evaluate the local version.
 
 ContractIQ uses fictional companies, contracts, policies, and rules. It is a software engineering demonstration and does not provide legal advice.

--- a/docs/azure/azure-ai-search-adapter.md
+++ b/docs/azure/azure-ai-search-adapter.md
@@ -86,6 +86,10 @@ dotnet user-secrets set "AzureSearch:Endpoint" "https://<search-name>.search.win
 dotnet user-secrets set "AzureSearch:IndexName" "contractiq-knowledge-v1" --project src/ContractIQ.Api
 ```
 
+Normal runtime defaults to three transient Search SDK retries. The bounded
+manual smoke workflow sets `AzureSearch:MaximumRetries` to `0`; accepted values
+are zero through five.
+
 The document indexer is a separate process. Configure its current PowerShell
 session without saving a key:
 

--- a/docs/azure/foundry-model-adapters.md
+++ b/docs/azure/foundry-model-adapters.md
@@ -49,7 +49,10 @@ dotnet user-secrets set "Foundry:EmbeddingDimensions" "768" --project src/Contra
 
 The endpoint must use HTTPS and end with `/openai/v1/`. Deployment names cannot
 be empty. Embedding dimensions must be explicitly configured and must equal 768
-while the local pgvector schema remains `vector(768)`.
+while the local pgvector schema remains `vector(768)`. Normal runtime defaults
+to three transient retries; the bounded manual smoke test overrides
+`Foundry:MaximumRetries` to `0` so a failed run cannot repeat model consumption
+automatically.
 
 Changing the embedding deployment changes the stored embedding model identity.
 Run the document indexer again so document chunks are regenerated consistently.

--- a/docs/azure/implementation-plan.md
+++ b/docs/azure/implementation-plan.md
@@ -37,8 +37,10 @@ ContractIQ does not deploy a second hosted agent in Foundry for this increment. 
 ## Delivery slices
 
 Status on 2026-08-31: the Azure foundation definitions, Foundry model adapters,
-and Azure AI Search adapter are implemented and validated without provisioning
-resources. Manual keyless smoke testing is the next delivery slice.
+Azure AI Search adapter, and bounded manual OIDC smoke-test workflow are
+implemented and validated without provisioning resources. Live execution still
+requires separately approved infrastructure, model deployment, and GitHub
+environment configuration.
 
 ### 1. Azure foundation — implemented, not deployed
 
@@ -64,13 +66,17 @@ resources. Manual keyless smoke testing is the next delivery slice.
 - preserve customer and contract filters before ranking;
 - map Azure results to application-owned `KnowledgeEvidence` citations.
 
-### 4. CI and live validation
+### 4. CI and live validation — implemented, not invoked live
 
 - compile Bicep on ordinary pull requests without Azure authentication;
 - run unit and simulated integration tests without hosted calls;
-- add a manually dispatched smoke test for a small, bounded Azure query;
-- use GitHub OIDC for future automated Azure access instead of a stored client secret;
+- add a manually dispatched smoke test that sends one two-input embedding batch,
+  indexes one fictional chunk, and runs one hybrid query;
+- use GitHub OIDC through the explicitly selected `azure-dev` environment instead
+  of a stored client secret;
 - never provision or invoke a model automatically on every push.
+- disable provider SDK retries for the bounded live run and publish only
+  cost-relevant counts and duration.
 
 ### 5. Documentation and portfolio proof
 

--- a/docs/azure/manual-smoke-test.md
+++ b/docs/azure/manual-smoke-test.md
@@ -1,0 +1,149 @@
+# Manual keyless Azure AI smoke test
+
+## Purpose
+
+The `Azure AI smoke test` GitHub Actions workflow proves that the application-owned Foundry embedding adapter and Azure AI Search hybrid adapter can work together with Microsoft Entra authentication. It is deliberately separate from normal CI because it contacts live Azure resources.
+
+The workflow is safe by construction:
+
+- it runs only through `workflow_dispatch`;
+- the operator must explicitly select the `azure-dev` GitHub environment;
+- GitHub obtains a short-lived Azure token through OIDC workload identity federation;
+- no Azure client secret or service key is stored in GitHub;
+- the tool sends one embedding request containing exactly two short fictional inputs;
+- it indexes exactly one fictional chunk and performs one hybrid search query;
+- Foundry and Azure AI Search SDK retries are set to zero for this run;
+- the tool times out after 90 seconds and the job after five minutes;
+- concurrent runs for the same environment are serialized;
+- the usage report contains counts and duration, not document or query content.
+
+Normal `push` and `pull_request` CI remains offline and deterministic. Adding this workflow does not provision Azure resources or deploy a model.
+
+## What must exist first
+
+Do not configure or run the workflow until the separately reviewed Azure deployment has created:
+
+1. the Foundry account and project;
+2. one compatible 768-dimension embedding deployment;
+3. the Free Azure AI Search service;
+4. the GitHub OIDC application/service principal and its role assignments.
+
+The smoke tool creates or updates only the configured Search index. Use the dedicated name `contractiq-smoke-v1` so smoke data does not mix with the demo index.
+
+## 1. Create the GitHub environment
+
+In the GitHub repository:
+
+1. Open **Settings > Environments**.
+2. Create an environment named exactly `azure-dev`.
+3. Restrict deployment branches and tags to the protected `main` branch.
+4. Add yourself as a required reviewer if the GitHub plan supports it. This creates an additional human approval before a live run.
+5. Do not add an Azure client secret.
+
+The workflow's environment choice is intentionally limited to this exact name,
+and the job also refuses to run from a ref other than `main`.
+
+## 2. Create the federated identity
+
+In **Azure portal > Microsoft Entra ID > App registrations**:
+
+1. Create a single-tenant registration named `github-contractiq-azure-dev`.
+2. Open **Certificates & secrets > Federated credentials**.
+3. Choose the GitHub Actions deployment-environment scenario.
+4. Configure:
+   - organization: `andreluizleite`;
+   - repository: `ContractIQ`;
+   - entity type: `Environment`;
+   - environment: `azure-dev`;
+   - name: `github-contractiq-azure-dev`.
+5. Confirm that the generated subject is exactly:
+
+   ```text
+   repo:andreluizleite/ContractIQ:environment:azure-dev
+   ```
+
+The trusted issuer is `https://token.actions.githubusercontent.com` and the audience is `api://AzureADTokenExchange`. No password is created.
+
+Record these non-secret identifiers:
+
+- application (client) ID;
+- directory (tenant) ID;
+- service principal object ID from the corresponding Enterprise Application.
+
+The service principal object ID is the value passed to Bicep as `smokeTestPrincipalId`. Do not confuse it with the app-registration object ID.
+
+## 3. Assign least-privilege roles
+
+Pass the service principal object ID to the reviewed Bicep deployment:
+
+```powershell
+-smokeTestPrincipalId '<service-principal-object-id>'
+```
+
+The template scopes these roles to the individual resources:
+
+| Resource | Role | Why it is required |
+| --- | --- | --- |
+| Foundry account | Cognitive Services OpenAI User | Invoke the embedding deployment |
+| Azure AI Search service | Search Service Contributor | Create or update the versioned smoke index schema |
+| Azure AI Search service | Search Index Data Contributor | Upload one chunk and run one hybrid query |
+
+No Owner, Contributor, subscription-wide data role, or Microsoft Graph permission is required by the workflow.
+
+## 4. Configure non-secret GitHub variables
+
+Add the following variables to the `azure-dev` GitHub environment, not repository secrets:
+
+| Variable | Value |
+| --- | --- |
+| `AZURE_CLIENT_ID` | App registration application/client ID |
+| `AZURE_TENANT_ID` | Entra directory/tenant ID |
+| `AZURE_SUBSCRIPTION_ID` | Approved Azure subscription ID |
+| `FOUNDRY_OPENAI_ENDPOINT` | Bicep `foundryOpenAIEndpoint` output ending in `/openai/v1/` |
+| `FOUNDRY_EMBEDDING_DEPLOYMENT` | Approved 768-dimension embedding deployment name |
+| `AZURE_SEARCH_ENDPOINT` | Bicep `searchEndpoint` output |
+| `AZURE_SEARCH_INDEX_NAME` | `contractiq-smoke-v1` |
+
+These identifiers and endpoints are configuration, not authentication secrets. Authentication succeeds only when GitHub presents an OIDC token whose repository and environment claims match the federated credential.
+
+## 5. Run and review
+
+1. Open **Actions > Azure AI smoke test**.
+2. Select **Run workflow**.
+3. Keep the environment set to `azure-dev`.
+4. Approve the environment gate if one was configured.
+5. Review the job summary and the seven-day `azure-ai-smoke-test-report` artifact.
+
+A successful report must show:
+
+- embedding requests: `1`;
+- embedding inputs: `2`;
+- indexed chunks: `1`;
+- search queries: `1`;
+- search results: `1`.
+
+The input-character count, model name, index name, result count, and duration are reported because they help explain consumption. Exact provider cost is not estimated by the workflow.
+
+## Failure behavior
+
+The workflow does not retry the model or Search operation. A failure ends the run and requires a person to inspect configuration before manually starting another run. Common causes are:
+
+- the federated subject does not use the `azure-dev` environment;
+- the service principal object ID was not supplied to Bicep;
+- a role assignment has not finished propagating;
+- the Foundry endpoint does not end in `/openai/v1/`;
+- the embedding deployment name or 768-dimension configuration is wrong;
+- the Free Search service or dedicated index is unavailable.
+
+Error output names the failed area but does not print tokens, document content, or provider response bodies.
+
+## Revoke access
+
+To stop future workflow access without deleting Azure resources:
+
+1. Delete the `github-contractiq-azure-dev` federated credential from the Entra app registration, or disable/delete the corresponding Enterprise Application.
+2. Remove the seven GitHub environment variables from `azure-dev`.
+3. Remove the optional `smokeTestPrincipalId` from the next Bicep deployment so its three role assignments are deleted.
+4. Delete the `azure-dev` GitHub environment if it will not be reused.
+
+For complete project teardown, delete the isolated `rg-contractiq-ai-dev` resource group after preserving the required portfolio evidence, then remove the subscription-level budget separately. Resource deletion remains an explicit human action and is never performed by this workflow.

--- a/docs/operations/cost-and-resources.md
+++ b/docs/operations/cost-and-resources.md
@@ -123,4 +123,12 @@ ContractIQ v1 remains locally runnable without Azure credentials or automatic pr
 - the USD 10 budget is an alerting target, not a hard spending cap;
 - model deployment stays out of the foundation template until live region, SKU, version, and quota checks are reviewed.
 
+The optional Azure smoke workflow also remains inert until a person selects the
+`azure-dev` environment in GitHub Actions. One run makes one Foundry embedding
+request with two short fictional inputs, writes one Search chunk, and performs
+one hybrid query. SDK retries are disabled, concurrent runs are serialized, and
+the resulting count/duration report is retained for seven days. See the
+[manual keyless smoke-test guide](../azure/manual-smoke-test.md) for setup,
+execution, and revocation.
+
 This boundary prevents a documentation example from accidentally creating a chargeable cloud resource.

--- a/infra/azure/README.md
+++ b/infra/azure/README.md
@@ -10,7 +10,7 @@ This folder contains the reviewed infrastructure boundary for ContractIQ's optio
 | Subscription budget | USD 10 planning target with 50%, 80%, and 100% alerts | No charge; alerts do not stop spend |
 | Microsoft Foundry account and project | `AIServices`, public development endpoint, local authentication disabled | Account/project have no committed throughput; model inference is usage-based |
 | Azure AI Search | Free tier, one shared service with a 50 MB limit | No charge while the free tier remains available and its limits are respected |
-| Role assignments | Least-privilege roles for the local developer | No charge |
+| Role assignments | Least-privilege roles for the local developer and optional GitHub OIDC service principal | No charge |
 
 No model deployment is declared yet. Model name, version, SKU, capacity, and region must be resolved against the live catalog and subscription quota immediately before a separate approved deployment.
 
@@ -26,6 +26,7 @@ chat and embedding adapters: `https://<resource-name>.openai.azure.com/openai/v1
 - A production evolution can select Basic to add a Search-managed identity, integrated vectorization, semantic ranking, dedicated capacity, and stronger operational guarantees.
 - Public endpoints keep this portfolio environment small. Private endpoints, a VNet, and Key Vault would add cost and operational complexity without improving the local-only demo enough to justify them.
 - Only fictional sample contracts and policies may be indexed or sent to a hosted model.
+- The optional `smokeTestPrincipalId` receives only Foundry inference plus Search schema/data roles on the individual resources. GitHub exchanges OIDC claims for a short-lived Azure token; no client secret is stored.
 
 ## Validate without deploying
 
@@ -49,6 +50,8 @@ Before anyone runs a subscription deployment, record all of the following in the
 6. The budget email, budget start date, and USD 10 amount.
 7. The exact `what-if` output.
 8. Explicit approval to provision.
+
+After provisioning and model deployment are separately approved, follow the [manual keyless smoke-test guide](../../docs/azure/manual-smoke-test.md). The live workflow is never triggered by a push or pull request and performs only one bounded indexing/query scenario.
 
 ## Teardown boundary
 

--- a/infra/azure/main.bicep
+++ b/infra/azure/main.bicep
@@ -23,6 +23,9 @@ param budgetStartDate string = utcNow('yyyy-MM-01')
 @description('Optional Microsoft Entra object ID for the local developer. Leave empty during validation.')
 param developerPrincipalId string = ''
 
+@description('Optional service principal object ID used by the manual GitHub OIDC smoke test.')
+param smokeTestPrincipalId string = ''
+
 @description('Additional tags applied to every provisioned resource.')
 param tags object = {}
 
@@ -95,6 +98,7 @@ module aiPlatform 'modules/ai-platform.bicep' = {
     developerPrincipalId: developerPrincipalId
     environmentName: environmentName
     location: location
+    smokeTestPrincipalId: smokeTestPrincipalId
     tags: commonTags
     uniqueSuffix: uniqueSuffix
   }

--- a/infra/azure/modules/ai-platform.bicep
+++ b/infra/azure/modules/ai-platform.bicep
@@ -13,6 +13,9 @@ param tags object
 @description('Optional Microsoft Entra object ID for local keyless development.')
 param developerPrincipalId string = ''
 
+@description('Optional service principal object ID for the manual GitHub OIDC smoke test.')
+param smokeTestPrincipalId string = ''
+
 var foundryAccountName = 'aif-contractiq-${environmentName}-${uniqueSuffix}'
 var foundryProjectName = 'contractiq-${environmentName}'
 var searchServiceName = 'srch-contractiq-${environmentName}-${uniqueSuffix}'
@@ -115,6 +118,36 @@ resource searchDataRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = i
   properties: {
     principalId: developerPrincipalId
     principalType: 'User'
+    roleDefinitionId: searchIndexDataContributorRoleId
+  }
+}
+
+resource smokeFoundryInferenceRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (!empty(smokeTestPrincipalId)) {
+  name: guid(foundryAccount.id, smokeTestPrincipalId, cognitiveServicesOpenAiUserRoleId)
+  scope: foundryAccount
+  properties: {
+    principalId: smokeTestPrincipalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: cognitiveServicesOpenAiUserRoleId
+  }
+}
+
+resource smokeSearchManagementRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (!empty(smokeTestPrincipalId)) {
+  name: guid(searchService.id, smokeTestPrincipalId, searchServiceContributorRoleId)
+  scope: searchService
+  properties: {
+    principalId: smokeTestPrincipalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: searchServiceContributorRoleId
+  }
+}
+
+resource smokeSearchDataRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (!empty(smokeTestPrincipalId)) {
+  name: guid(searchService.id, smokeTestPrincipalId, searchIndexDataContributorRoleId)
+  scope: searchService
+  properties: {
+    principalId: smokeTestPrincipalId
+    principalType: 'ServicePrincipal'
     roleDefinitionId: searchIndexDataContributorRoleId
   }
 }

--- a/src/ContractIQ.Infrastructure/AI/FoundryClientOptions.cs
+++ b/src/ContractIQ.Infrastructure/AI/FoundryClientOptions.cs
@@ -1,0 +1,28 @@
+using Microsoft.Extensions.Configuration;
+
+namespace ContractIQ.Infrastructure.AI;
+
+public sealed record FoundryClientOptions(int MaximumRetries)
+{
+    public const int DefaultMaximumRetries = 3;
+
+    public static FoundryClientOptions Default => new(DefaultMaximumRetries);
+
+    public static FoundryClientOptions FromConfiguration(IConfiguration configuration)
+    {
+        string? value = configuration["Foundry:MaximumRetries"];
+        int maximumRetries = string.IsNullOrWhiteSpace(value)
+            ? DefaultMaximumRetries
+            : int.TryParse(value, out int configuredRetries)
+                ? configuredRetries
+                : -1;
+
+        if (maximumRetries is < 0 or > 5)
+        {
+            throw new InvalidOperationException(
+                "Foundry maximum retries must be an integer between 0 and 5.");
+        }
+
+        return new FoundryClientOptions(maximumRetries);
+    }
+}

--- a/src/ContractIQ.Infrastructure/AI/FoundryOpenAIClientFactory.cs
+++ b/src/ContractIQ.Infrastructure/AI/FoundryOpenAIClientFactory.cs
@@ -10,7 +10,9 @@ namespace ContractIQ.Infrastructure.AI;
 /// injection so local Azure CLI credentials and future managed identities use
 /// the same application code.
 /// </summary>
-internal sealed class FoundryOpenAIClientFactory(TokenCredential credential)
+internal sealed class FoundryOpenAIClientFactory(
+    TokenCredential credential,
+    FoundryClientOptions options)
 {
     private const string FoundryTokenScope = "https://ai.azure.com/.default";
 
@@ -20,6 +22,7 @@ internal sealed class FoundryOpenAIClientFactory(TokenCredential credential)
         var clientOptions = new OpenAIClientOptions
         {
             Endpoint = endpoint,
+            RetryPolicy = new ClientRetryPolicy(options.MaximumRetries),
         };
 
         // The official Foundry keyless .NET pattern currently exposes this

--- a/src/ContractIQ.Infrastructure/DependencyInjection.cs
+++ b/src/ContractIQ.Infrastructure/DependencyInjection.cs
@@ -34,11 +34,14 @@ public static class DependencyInjection
         KnowledgeIndexOptions knowledgeIndexOptions =
             KnowledgeIndexOptions.FromConfiguration(configuration);
         AssistantOptions assistantOptions = AssistantOptions.FromConfiguration(configuration);
+        FoundryClientOptions foundryClientOptions =
+            FoundryClientOptions.FromConfiguration(configuration);
         return services.AddInfrastructure(
             connectionString,
             knowledgeOptions,
             assistantOptions,
-            knowledgeIndexOptions);
+            knowledgeIndexOptions,
+            foundryClientOptions);
     }
 
     public static IServiceCollection AddInfrastructure(
@@ -86,11 +89,13 @@ public static class DependencyInjection
         string connectionString,
         KnowledgeOptions knowledgeOptions,
         AssistantOptions assistantOptions,
-        KnowledgeIndexOptions? knowledgeIndexOptions = null)
+        KnowledgeIndexOptions? knowledgeIndexOptions = null,
+        FoundryClientOptions? foundryClientOptions = null)
     {
         ArgumentNullException.ThrowIfNull(services);
         ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
         knowledgeIndexOptions ??= KnowledgeIndexOptions.Local;
+        foundryClientOptions ??= FoundryClientOptions.Default;
 
         services.AddDbContext<ContractIqDbContext>(options =>
             options.UseNpgsql(
@@ -111,6 +116,7 @@ public static class DependencyInjection
         services.AddScoped<ICancellationRequestStore, PostgresCancellationRequestStore>();
         services.AddSingleton(knowledgeOptions);
         services.AddSingleton(knowledgeIndexOptions);
+        services.AddSingleton(foundryClientOptions);
         services.AddSingleton<IKnowledgeDocumentCatalog, FileSystemKnowledgeDocumentCatalog>();
         services.AddSingleton<TokenCredential>(_ => new DefaultAzureCredential());
         if (knowledgeIndexOptions.Provider == KnowledgeIndexProvider.AzureAiSearch)

--- a/src/ContractIQ.Infrastructure/Knowledge/AzureSearch/AzureSearchGateway.cs
+++ b/src/ContractIQ.Infrastructure/Knowledge/AzureSearch/AzureSearchGateway.cs
@@ -27,11 +27,13 @@ internal sealed class AzureSearchGateway : IAzureSearchGateway, IDisposable
         Uri endpoint = options.AzureSearchEndpoint
             ?? throw new InvalidOperationException(
                 "Azure AI Search endpoint is required by the selected index provider.");
-        _indexClient = new SearchIndexClient(endpoint, credential);
+        SearchClientOptions clientOptions = CreateClientOptions(options.MaximumRetries);
+        _indexClient = new SearchIndexClient(endpoint, credential, clientOptions);
         _searchClient = new SearchClient(
             endpoint,
             options.AzureSearchIndexName,
-            credential);
+            credential,
+            CreateClientOptions(options.MaximumRetries));
     }
 
     public async Task<bool> IsCurrentAsync(
@@ -151,6 +153,13 @@ internal sealed class AzureSearchGateway : IAzureSearchGateway, IDisposable
             new VectorSearchProfile(VectorProfileName, VectorAlgorithmName));
 
         return index;
+    }
+
+    internal static SearchClientOptions CreateClientOptions(int maximumRetries)
+    {
+        var options = new SearchClientOptions();
+        options.Retry.MaxRetries = maximumRetries;
+        return options;
     }
 
     internal static SearchOptions CreateHybridSearchOptions(

--- a/src/ContractIQ.Infrastructure/Knowledge/KnowledgeIndexOptions.cs
+++ b/src/ContractIQ.Infrastructure/Knowledge/KnowledgeIndexOptions.cs
@@ -12,9 +12,11 @@ public enum KnowledgeIndexProvider
 public sealed partial record KnowledgeIndexOptions(
     KnowledgeIndexProvider Provider,
     Uri? AzureSearchEndpoint,
-    string AzureSearchIndexName)
+    string AzureSearchIndexName,
+    int MaximumRetries = 3)
 {
     public const string DefaultAzureSearchIndexName = "contractiq-knowledge-v1";
+    public const int DefaultMaximumRetries = 3;
 
     public static KnowledgeIndexOptions Local =>
         new(KnowledgeIndexProvider.PostgreSql, null, DefaultAzureSearchIndexName);
@@ -43,6 +45,8 @@ public sealed partial record KnowledgeIndexOptions(
             "Azure AI Search is selected, but no endpoint is configured.");
         string indexName = configuration["AzureSearch:IndexName"]?.Trim()
             ?? DefaultAzureSearchIndexName;
+        int maximumRetries = ParseMaximumRetries(
+            configuration["AzureSearch:MaximumRetries"]);
         var endpointUri = new Uri(endpoint, UriKind.Absolute);
 
         if (endpointUri.Scheme != Uri.UriSchemeHttps)
@@ -58,7 +62,28 @@ public sealed partial record KnowledgeIndexOptions(
                 "digits, hyphens, or underscores and start and end with a letter or digit.");
         }
 
-        return new KnowledgeIndexOptions(provider, endpointUri, indexName);
+        return new KnowledgeIndexOptions(
+            provider,
+            endpointUri,
+            indexName,
+            maximumRetries);
+    }
+
+    private static int ParseMaximumRetries(string? value)
+    {
+        int maximumRetries = string.IsNullOrWhiteSpace(value)
+            ? DefaultMaximumRetries
+            : int.TryParse(value, out int configuredRetries)
+                ? configuredRetries
+                : -1;
+
+        if (maximumRetries is < 0 or > 5)
+        {
+            throw new InvalidOperationException(
+                "Azure AI Search maximum retries must be an integer between 0 and 5.");
+        }
+
+        return maximumRetries;
     }
 
     private static string GetRequiredSetting(

--- a/tests/ContractIQ.IntegrationTests/AzureAiSearchKnowledgeIndexTests.cs
+++ b/tests/ContractIQ.IntegrationTests/AzureAiSearchKnowledgeIndexTests.cs
@@ -76,6 +76,14 @@ public sealed class AzureAiSearchKnowledgeIndexTests
     }
 
     [Fact]
+    public void Configures_zero_sdk_retries_for_a_bounded_smoke_test()
+    {
+        SearchClientOptions options = AzureSearchGateway.CreateClientOptions(0);
+
+        Assert.Equal(0, options.Retry.MaxRetries);
+    }
+
+    [Fact]
     public async Task Replacing_the_same_version_keeps_stable_chunk_keys_and_state()
     {
         var gateway = new InMemoryAzureSearchGateway();

--- a/tests/ContractIQ.IntegrationTests/AzureSmokeTestRunnerTests.cs
+++ b/tests/ContractIQ.IntegrationTests/AzureSmokeTestRunnerTests.cs
@@ -1,0 +1,162 @@
+using ContractIQ.Application.Knowledge;
+using ContractIQ.AzureSmokeTest;
+using Xunit;
+
+namespace ContractIQ.IntegrationTests;
+
+public sealed class AzureSmokeTestRunnerTests
+{
+    [Fact]
+    public async Task Runs_one_bounded_indexing_and_query_scenario()
+    {
+        var embeddings = new RecordingEmbeddingGenerator();
+        var index = new RecordingKnowledgeIndex();
+        var runner = new AzureSmokeTestRunner(
+            embeddings,
+            index,
+            TimeProvider.System,
+            "contractiq-smoke-v1");
+
+        AzureSmokeTestReport report = await runner.RunAsync();
+
+        Assert.Equal("succeeded", report.Outcome);
+        Assert.Equal(1, report.EmbeddingRequests);
+        Assert.Equal(2, report.EmbeddingInputs);
+        Assert.Equal(1, report.IndexedDocuments);
+        Assert.Equal(1, report.IndexedChunks);
+        Assert.Equal(1, report.SearchQueries);
+        Assert.Equal(1, report.SearchResultCount);
+        Assert.Equal("contractiq-smoke-v1", report.IndexName);
+        Assert.Equal(1, embeddings.RequestCount);
+        Assert.Equal(2, embeddings.LastValues.Count);
+        Assert.Equal(1, index.ReplaceCount);
+        Assert.Equal(1, index.SearchCount);
+        Assert.Equal(1, index.LastChunkCount);
+        Assert.Equal(1, index.LastLimit);
+        Assert.Equal(AzureSmokeTestRunner.CustomerId, index.LastCustomerId);
+        Assert.Equal(AzureSmokeTestRunner.ContractId, index.LastContractId);
+    }
+
+    [Fact]
+    public async Task Fails_when_the_bounded_query_returns_no_evidence()
+    {
+        var index = new RecordingKnowledgeIndex { ReturnEvidence = false };
+        var runner = new AzureSmokeTestRunner(
+            new RecordingEmbeddingGenerator(),
+            index,
+            TimeProvider.System,
+            "contractiq-smoke-v1");
+
+        InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => runner.RunAsync());
+
+        Assert.Contains("no evidence", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(1, index.ReplaceCount);
+        Assert.Equal(1, index.SearchCount);
+    }
+
+    private sealed class RecordingEmbeddingGenerator : IKnowledgeEmbeddingGenerator
+    {
+        public string ModelId => "contractiq-embeddings";
+
+        public int Dimensions => 768;
+
+        public int RequestCount { get; private set; }
+
+        public IReadOnlyList<string> LastValues { get; private set; } = [];
+
+        public Task<IReadOnlyList<float[]>> GenerateAsync(
+            IReadOnlyList<string> values,
+            CancellationToken cancellationToken = default)
+        {
+            RequestCount++;
+            LastValues = values;
+            return Task.FromResult<IReadOnlyList<float[]>>(
+                values
+                    .Select(_ => Enumerable.Repeat(0.25f, Dimensions).ToArray())
+                    .ToArray());
+        }
+    }
+
+    private sealed class RecordingKnowledgeIndex : IKnowledgeIndex
+    {
+        private KnowledgeDocumentSource? _source;
+
+        public bool ReturnEvidence { get; init; } = true;
+
+        public int ReplaceCount { get; private set; }
+
+        public int SearchCount { get; private set; }
+
+        public int LastChunkCount { get; private set; }
+
+        public int LastLimit { get; private set; }
+
+        public Guid LastCustomerId { get; private set; }
+
+        public Guid LastContractId { get; private set; }
+
+        public Task<bool> IsCurrentAsync(
+            string documentKey,
+            string version,
+            string contentChecksum,
+            string embeddingModel,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(false);
+
+        public Task ReplaceAsync(
+            KnowledgeDocumentSource source,
+            string contentChecksum,
+            string embeddingModel,
+            IReadOnlyList<KnowledgeChunk> chunks,
+            CancellationToken cancellationToken = default)
+        {
+            _source = source;
+            ReplaceCount++;
+            LastChunkCount = chunks.Count;
+            return Task.CompletedTask;
+        }
+
+        public Task<IReadOnlyList<KnowledgeEvidence>> SearchAsync(
+            string query,
+            float[] queryEmbedding,
+            Guid customerId,
+            Guid contractId,
+            DateOnly asOf,
+            int limit,
+            CancellationToken cancellationToken = default)
+        {
+            SearchCount++;
+            LastCustomerId = customerId;
+            LastContractId = contractId;
+            LastLimit = limit;
+
+            if (!ReturnEvidence || _source is null)
+            {
+                return Task.FromResult<IReadOnlyList<KnowledgeEvidence>>([]);
+            }
+
+            IReadOnlyList<KnowledgeEvidence> evidence =
+            [
+                new KnowledgeEvidence(
+                    Guid.Parse("99999999-9999-4999-8999-999999999999"),
+                    _source.DocumentKey,
+                    _source.Title,
+                    _source.DocumentType,
+                    _source.Version,
+                    _source.Language,
+                    _source.CustomerId,
+                    _source.ContractId,
+                    _source.EffectiveFrom,
+                    _source.SourcePath,
+                    "Cancellation notice",
+                    1,
+                    _source.Content,
+                    1d,
+                    null,
+                    null),
+            ];
+            return Task.FromResult(evidence);
+        }
+    }
+}

--- a/tests/ContractIQ.IntegrationTests/ContractIQ.IntegrationTests.csproj
+++ b/tests/ContractIQ.IntegrationTests/ContractIQ.IntegrationTests.csproj
@@ -16,5 +16,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\ContractIQ.Api\ContractIQ.Api.csproj" />
+    <ProjectReference Include="..\..\tools\ContractIQ.AzureSmokeTest\ContractIQ.AzureSmokeTest.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/ContractIQ.IntegrationTests/FoundryClientOptionsTests.cs
+++ b/tests/ContractIQ.IntegrationTests/FoundryClientOptionsTests.cs
@@ -1,0 +1,54 @@
+using ContractIQ.Infrastructure.AI;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace ContractIQ.IntegrationTests;
+
+public sealed class FoundryClientOptionsTests
+{
+    [Fact]
+    public void Uses_safe_default_retries_for_normal_runtime()
+    {
+        IConfiguration configuration = BuildConfiguration([]);
+
+        FoundryClientOptions options = FoundryClientOptions.FromConfiguration(configuration);
+
+        Assert.Equal(FoundryClientOptions.DefaultMaximumRetries, options.MaximumRetries);
+    }
+
+    [Fact]
+    public void Allows_zero_retries_for_the_bounded_smoke_test()
+    {
+        IConfiguration configuration = BuildConfiguration(
+            new Dictionary<string, string?>
+            {
+                ["Foundry:MaximumRetries"] = "0",
+            });
+
+        FoundryClientOptions options = FoundryClientOptions.FromConfiguration(configuration);
+
+        Assert.Equal(0, options.MaximumRetries);
+    }
+
+    [Theory]
+    [InlineData("-1")]
+    [InlineData("6")]
+    [InlineData("many")]
+    public void Rejects_unbounded_or_invalid_retry_configuration(string retries)
+    {
+        IConfiguration configuration = BuildConfiguration(
+            new Dictionary<string, string?>
+            {
+                ["Foundry:MaximumRetries"] = retries,
+            });
+
+        Assert.Throws<InvalidOperationException>(
+            () => FoundryClientOptions.FromConfiguration(configuration));
+    }
+
+    private static IConfiguration BuildConfiguration(
+        IEnumerable<KeyValuePair<string, string?>> values) =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(values)
+            .Build();
+}

--- a/tests/ContractIQ.IntegrationTests/KnowledgeIndexOptionsTests.cs
+++ b/tests/ContractIQ.IntegrationTests/KnowledgeIndexOptionsTests.cs
@@ -32,6 +32,7 @@ public sealed class KnowledgeIndexOptionsTests
                 ["AzureSearch:Endpoint"] =
                     "https://srch-contractiq-dev.example.search.windows.net",
                 ["AzureSearch:IndexName"] = "contractiq-knowledge-v1",
+                ["AzureSearch:MaximumRetries"] = "0",
             });
 
         KnowledgeIndexOptions options = KnowledgeIndexOptions.FromConfiguration(configuration);
@@ -41,6 +42,26 @@ public sealed class KnowledgeIndexOptionsTests
             new Uri("https://srch-contractiq-dev.example.search.windows.net"),
             options.AzureSearchEndpoint);
         Assert.Equal("contractiq-knowledge-v1", options.AzureSearchIndexName);
+        Assert.Equal(0, options.MaximumRetries);
+    }
+
+    [Theory]
+    [InlineData("-1")]
+    [InlineData("6")]
+    [InlineData("many")]
+    public void Rejects_unbounded_or_invalid_retry_configuration(string retries)
+    {
+        IConfiguration configuration = BuildConfiguration(
+            new Dictionary<string, string?>
+            {
+                ["Knowledge:IndexProvider"] = "AzureAiSearch",
+                ["AzureSearch:Endpoint"] =
+                    "https://srch-contractiq-dev.example.search.windows.net",
+                ["AzureSearch:MaximumRetries"] = retries,
+            });
+
+        Assert.Throws<InvalidOperationException>(
+            () => KnowledgeIndexOptions.FromConfiguration(configuration));
     }
 
     [Fact]

--- a/tools/ContractIQ.AzureSmokeTest/AzureSmokeTestReport.cs
+++ b/tools/ContractIQ.AzureSmokeTest/AzureSmokeTestReport.cs
@@ -1,0 +1,18 @@
+namespace ContractIQ.AzureSmokeTest;
+
+internal sealed record AzureSmokeTestReport(
+    string Outcome,
+    DateTimeOffset StartedAtUtc,
+    double DurationMilliseconds,
+    string EmbeddingProvider,
+    string EmbeddingModel,
+    int EmbeddingRequests,
+    int EmbeddingInputs,
+    int EmbeddingInputCharacters,
+    int EmbeddingDimensions,
+    int IndexedDocuments,
+    int IndexedChunks,
+    int SearchQueries,
+    int SearchResultCount,
+    string SearchProvider,
+    string IndexName);

--- a/tools/ContractIQ.AzureSmokeTest/AzureSmokeTestRunner.cs
+++ b/tools/ContractIQ.AzureSmokeTest/AzureSmokeTestRunner.cs
@@ -1,0 +1,114 @@
+using System.Diagnostics;
+using System.Security.Cryptography;
+using System.Text;
+using ContractIQ.Application.Knowledge;
+
+namespace ContractIQ.AzureSmokeTest;
+
+internal sealed class AzureSmokeTestRunner(
+    IKnowledgeEmbeddingGenerator embeddingGenerator,
+    IKnowledgeIndex knowledgeIndex,
+    TimeProvider timeProvider,
+    string indexName)
+{
+    internal static readonly Guid CustomerId =
+        Guid.Parse("11111111-1111-4111-8111-111111111111");
+    internal static readonly Guid ContractId =
+        Guid.Parse("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa");
+
+    private const string DocumentKey = "contractiq-azure-smoke-policy";
+    private const string DocumentVersion = "1";
+    private const string Content =
+        "A cancellation request requires 30 days written notice before termination.";
+    private const string Query =
+        "How much written notice is required for cancellation?";
+
+    public async Task<AzureSmokeTestReport> RunAsync(
+        CancellationToken cancellationToken = default)
+    {
+        DateTimeOffset startedAt = timeProvider.GetUtcNow();
+        long timestamp = Stopwatch.GetTimestamp();
+        string[] embeddingInputs = [Content, Query];
+
+        IReadOnlyList<float[]> embeddings = await embeddingGenerator.GenerateAsync(
+            embeddingInputs,
+            cancellationToken);
+        ValidateEmbeddings(embeddings);
+
+        var source = new KnowledgeDocumentSource(
+            DocumentKey,
+            "ContractIQ Azure smoke-test policy",
+            KnowledgeDocumentType.Policy,
+            DocumentVersion,
+            "en",
+            CustomerId,
+            ContractId,
+            new DateOnly(2026, 1, 1),
+            null,
+            "smoke/contractiq-azure-policy.md",
+            Content);
+        var chunk = new KnowledgeChunk(
+            0,
+            "Cancellation notice",
+            1,
+            Content,
+            ComputeChecksum(Content),
+            embeddings[0]);
+
+        await knowledgeIndex.ReplaceAsync(
+            source,
+            ComputeChecksum(source.Content),
+            embeddingGenerator.ModelId,
+            [chunk],
+            cancellationToken);
+
+        IReadOnlyList<KnowledgeEvidence> evidence = await knowledgeIndex.SearchAsync(
+            Query,
+            embeddings[1],
+            CustomerId,
+            ContractId,
+            new DateOnly(2026, 8, 31),
+            limit: 1,
+            cancellationToken);
+        KnowledgeEvidence result = evidence.SingleOrDefault()
+            ?? throw new InvalidOperationException(
+                "The bounded hybrid query returned no evidence.");
+
+        if (!string.Equals(result.DocumentKey, DocumentKey, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                "The bounded hybrid query returned unexpected evidence.");
+        }
+
+        return new AzureSmokeTestReport(
+            "succeeded",
+            startedAt,
+            Stopwatch.GetElapsedTime(timestamp).TotalMilliseconds,
+            "foundry",
+            embeddingGenerator.ModelId,
+            EmbeddingRequests: 1,
+            EmbeddingInputs: embeddingInputs.Length,
+            EmbeddingInputCharacters: embeddingInputs.Sum(value => value.Length),
+            EmbeddingDimensions: embeddingGenerator.Dimensions,
+            IndexedDocuments: 1,
+            IndexedChunks: 1,
+            SearchQueries: 1,
+            SearchResultCount: evidence.Count,
+            SearchProvider: "azure-ai-search",
+            IndexName: indexName);
+    }
+
+    private void ValidateEmbeddings(IReadOnlyList<float[]> embeddings)
+    {
+        if (embeddings.Count != 2 ||
+            embeddings.Any(value => value.Length != embeddingGenerator.Dimensions))
+        {
+            throw new InvalidOperationException(
+                "Foundry returned an unexpected embedding result shape.");
+        }
+    }
+
+    private static string ComputeChecksum(string value) =>
+        Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(value)))
+            .ToLowerInvariant();
+}

--- a/tools/ContractIQ.AzureSmokeTest/ContractIQ.AzureSmokeTest.csproj
+++ b/tools/ContractIQ.AzureSmokeTest/ContractIQ.AzureSmokeTest.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\ContractIQ.Application\ContractIQ.Application.csproj" />
+    <ProjectReference Include="..\..\src\ContractIQ.Infrastructure\ContractIQ.Infrastructure.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="ContractIQ.IntegrationTests" />
+  </ItemGroup>
+</Project>

--- a/tools/ContractIQ.AzureSmokeTest/Program.cs
+++ b/tools/ContractIQ.AzureSmokeTest/Program.cs
@@ -1,0 +1,84 @@
+using System.Text.Json;
+using ContractIQ.Application.Knowledge;
+using ContractIQ.Infrastructure;
+using ContractIQ.Infrastructure.Knowledge;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace ContractIQ.AzureSmokeTest;
+
+public static class Program
+{
+    public static async Task<int> Main(string[] args)
+    {
+        try
+        {
+            return await RunAsync(args);
+        }
+        catch (Exception exception)
+        {
+            Console.Error.WriteLine(
+                $"Azure AI smoke test failed ({exception.GetType().Name}). " +
+                "Review the Azure roles, endpoints, deployments, and workflow variables.");
+            return 1;
+        }
+    }
+
+    private static async Task<int> RunAsync(string[] args)
+    {
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
+        builder.Services.AddInfrastructure(builder.Configuration);
+        builder.Services.AddSingleton(TimeProvider.System);
+        builder.Services.AddScoped(serviceProvider =>
+        {
+            KnowledgeIndexOptions options = serviceProvider
+                .GetRequiredService<KnowledgeIndexOptions>();
+            return new AzureSmokeTestRunner(
+                serviceProvider.GetRequiredService<IKnowledgeEmbeddingGenerator>(),
+                serviceProvider.GetRequiredService<IKnowledgeIndex>(),
+                serviceProvider.GetRequiredService<TimeProvider>(),
+                options.AzureSearchIndexName);
+        });
+
+        using IHost host = builder.Build();
+        int timeoutSeconds = ReadTimeoutSeconds(
+            builder.Configuration["AzureSmoke:TimeoutSeconds"]);
+        string reportPath = builder.Configuration["AzureSmoke:ReportPath"]
+            ?? "TestResults/azure-smoke-test.json";
+        using var timeout = new CancellationTokenSource(
+            TimeSpan.FromSeconds(timeoutSeconds));
+
+        await using AsyncServiceScope scope = host.Services.CreateAsyncScope();
+        AzureSmokeTestReport report = await scope.ServiceProvider
+            .GetRequiredService<AzureSmokeTestRunner>()
+            .RunAsync(timeout.Token);
+        string json = JsonSerializer.Serialize(
+            report,
+            new JsonSerializerOptions { WriteIndented = true });
+
+        string? directory = Path.GetDirectoryName(reportPath);
+        if (!string.IsNullOrWhiteSpace(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        await File.WriteAllTextAsync(reportPath, json, timeout.Token);
+        Console.WriteLine(json);
+        return 0;
+    }
+
+    private static int ReadTimeoutSeconds(string? value)
+    {
+        int timeoutSeconds = int.TryParse(value, out int configuredTimeout)
+            ? configuredTimeout
+            : 90;
+
+        if (timeoutSeconds is < 30 or > 180)
+        {
+            throw new InvalidOperationException(
+                "Azure smoke-test timeout must be between 30 and 180 seconds.");
+        }
+
+        return timeoutSeconds;
+    }
+}

--- a/tools/ContractIQ.AzureSmokeTest/packages.lock.json
+++ b/tools/ContractIQ.AzureSmokeTest/packages.lock.json
@@ -2,64 +2,35 @@
   "version": 2,
   "dependencies": {
     "net10.0": {
-      "coverlet.collector": {
-        "type": "Direct",
-        "requested": "[6.0.4, )",
-        "resolved": "6.0.4",
-        "contentHash": "lkhqpF8Pu2Y7IiN7OntbsTtdbpR1syMsm2F3IgX6ootA4ffRqWL5jF7XipHuZQTdVuWG/gVAAcf8mjk8Tz0xPg=="
-      },
-      "Microsoft.AspNetCore.Mvc.Testing": {
+      "Microsoft.Extensions.Hosting": {
         "type": "Direct",
         "requested": "[10.0.11, )",
         "resolved": "10.0.11",
-        "contentHash": "BJi3rpYETlh0wd14Lg5Is9MWvEf55TAGd7yo+xGHuEZp7ololyvftbQZ1i7ZuITA7DgNPJED6EMhFSWycq7SBg==",
+        "contentHash": "eIDa/Rl+93aj17gMlFsJJx+LhBvb3CP0Mu1PeVYkDp2Y3S4Jock8UynfGQEcx7lrlq+gKW+ECQJHbro/LTPDEQ==",
         "dependencies": {
-          "Microsoft.AspNetCore.TestHost": "10.0.11",
-          "Microsoft.Extensions.DependencyModel": "10.0.11",
-          "Microsoft.Extensions.Hosting": "10.0.11"
+          "Microsoft.Extensions.Configuration": "10.0.11",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.11",
+          "Microsoft.Extensions.Configuration.CommandLine": "10.0.11",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.11",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.11",
+          "Microsoft.Extensions.Configuration.Json": "10.0.11",
+          "Microsoft.Extensions.Configuration.UserSecrets": "10.0.11",
+          "Microsoft.Extensions.DependencyInjection": "10.0.11",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Diagnostics": "10.0.11",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.11",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.11",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Logging": "10.0.11",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.11",
+          "Microsoft.Extensions.Logging.Console": "10.0.11",
+          "Microsoft.Extensions.Logging.Debug": "10.0.11",
+          "Microsoft.Extensions.Logging.EventLog": "10.0.11",
+          "Microsoft.Extensions.Logging.EventSource": "10.0.11",
+          "Microsoft.Extensions.Options": "10.0.11"
         }
-      },
-      "Microsoft.NET.Test.Sdk": {
-        "type": "Direct",
-        "requested": "[17.14.1, )",
-        "resolved": "17.14.1",
-        "contentHash": "HJKqKOE+vshXra2aEHpi2TlxYX7Z9VFYkr+E5rwEvHC8eIXiyO+K9kNm8vmNom3e2rA56WqxU+/N9NJlLGXsJQ==",
-        "dependencies": {
-          "Microsoft.CodeCoverage": "17.14.1",
-          "Microsoft.TestPlatform.TestHost": "17.14.1"
-        }
-      },
-      "Respawn": {
-        "type": "Direct",
-        "requested": "[7.0.0, )",
-        "resolved": "7.0.0",
-        "contentHash": "AyWlducZGOnmlEVz4PaL3Qv8wcY3ClPZS9CrlDnSVahGd/E9tTEgSFiC8yoV/F6o6P6IYm8xnHFa/vmWT8tfcw=="
-      },
-      "Testcontainers.PostgreSql": {
-        "type": "Direct",
-        "requested": "[4.14.0, )",
-        "resolved": "4.14.0",
-        "contentHash": "OPHWR9oCW89yuNxJjUo8Xtwrk0bcOdzFOE2Ryo01GAf/3WEzD+0j0gmdKSxx5kBprCdlbXurBJyaV7nSLPyWKQ==",
-        "dependencies": {
-          "Testcontainers": "4.14.0"
-        }
-      },
-      "xunit": {
-        "type": "Direct",
-        "requested": "[2.9.3, )",
-        "resolved": "2.9.3",
-        "contentHash": "TlXQBinK35LpOPKHAqbLY4xlEen9TBafjs0V5KnA4wZsoQLQJiirCR4CbIXvOH8NzkW4YeJKP5P/Bnrodm0h9Q==",
-        "dependencies": {
-          "xunit.analyzers": "1.18.0",
-          "xunit.assert": "2.9.3",
-          "xunit.core": "[2.9.3]"
-        }
-      },
-      "xunit.runner.visualstudio": {
-        "type": "Direct",
-        "requested": "[3.1.4, )",
-        "resolved": "3.1.4",
-        "contentHash": "5mj99LvCqrq3CNi06xYdyIAXOEh+5b33F2nErCzI5zWiDdLHXiPXEWFSUAF8zlIv0ZWqjZNCwHTQeAPYbF3pCg=="
       },
       "Azure.Core": {
         "type": "Transitive",
@@ -75,86 +46,10 @@
           "System.Memory.Data": "10.0.3"
         }
       },
-      "BouncyCastle.Cryptography": {
-        "type": "Transitive",
-        "resolved": "2.7.0",
-        "contentHash": "U+12df8UEWHgBi04YVf/Lgi2dy3SItlIYvHjjEVa/BngCQIzDCDRBk50DDByCfDvSbe5pRNFr3b7UrVK2kMcLw=="
-      },
-      "Docker.DotNet.Enhanced": {
-        "type": "Transitive",
-        "resolved": "4.3.3",
-        "contentHash": "nGicLwvd42FhRk+khY5uS6cx49ErNdwYKnYBg0F4m4BDKLp/R77AVmmN9xAiqI3W/wN5ZCHkdUhgxf5ORkZuFQ==",
-        "dependencies": {
-          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.3.3",
-          "Docker.DotNet.Enhanced.LegacyHttp": "4.3.3",
-          "Docker.DotNet.Enhanced.NPipe": "4.3.3",
-          "Docker.DotNet.Enhanced.NativeHttp": "4.3.3",
-          "Docker.DotNet.Enhanced.Unix": "4.3.3",
-          "Microsoft.Extensions.Logging.Abstractions": "8.0.3"
-        }
-      },
-      "Docker.DotNet.Enhanced.Handler.Abstractions": {
-        "type": "Transitive",
-        "resolved": "4.3.3",
-        "contentHash": "9Cp8hOgtynixcDoAs9lnEaQosluojSYmiW3fsLsLIVfZjlq/fznSIZNUhnmyT4Xo1Iyuok/y49WL/25O47u0Pw==",
-        "dependencies": {
-          "Microsoft.Extensions.Logging.Abstractions": "8.0.3"
-        }
-      },
-      "Docker.DotNet.Enhanced.LegacyHttp": {
-        "type": "Transitive",
-        "resolved": "4.3.3",
-        "contentHash": "7j3M16emv9PAQN7VwFn23xLYNj8GJmwPOcogveHkaWnOCqiC+anRaNKQwqIBNApM1AuwZKivehTKTPmmrjUUnw==",
-        "dependencies": {
-          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.3.3"
-        }
-      },
-      "Docker.DotNet.Enhanced.NativeHttp": {
-        "type": "Transitive",
-        "resolved": "4.3.3",
-        "contentHash": "iNzK+jRFeEMobSA7l/h4ARwCKOOefOWtVN5/RB0ft6/6H6IQXvVUuOgGyZAjYLBT7TsyClRYno2B904f3dtBuQ==",
-        "dependencies": {
-          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.3.3"
-        }
-      },
-      "Docker.DotNet.Enhanced.NPipe": {
-        "type": "Transitive",
-        "resolved": "4.3.3",
-        "contentHash": "ZTLYufuEfY0e6qLOgeH9QgXx2KYuoABRVaY5A8rsggyLgYqbDj9rCRfVAhHPCUv83S7pVxDHy+Tvm/BnxjWVpg==",
-        "dependencies": {
-          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.3.3"
-        }
-      },
-      "Docker.DotNet.Enhanced.Unix": {
-        "type": "Transitive",
-        "resolved": "4.3.3",
-        "contentHash": "ypo8qNbmvHw1t9VfpRTMogCw2vht6VjkXzlGYUUeP2H2bf83USURdla1maW1njn2oq2rfLUFOGMfmt+A37QU2w==",
-        "dependencies": {
-          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.3.3"
-        }
-      },
-      "Docker.DotNet.Enhanced.X509": {
-        "type": "Transitive",
-        "resolved": "4.3.3",
-        "contentHash": "oBDibWezEv4hgj3RIQxI3DVcxkNV1MdrD0d/jhjUu+h3DL+qc0wlkQva15kkwMatXmC/hWp1VP0DMoFXe+BmEw==",
-        "dependencies": {
-          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.3.3"
-        }
-      },
-      "Microsoft.AspNetCore.TestHost": {
-        "type": "Transitive",
-        "resolved": "10.0.11",
-        "contentHash": "IVGNbZVxLuL80y7cmXYfhIFoTGneHkp4D7xXarYe6V/wjo8/2qiSLUwWax1/h2eHtJ3Y5cuqmtpOyWMnXIsUMA=="
-      },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
         "resolved": "10.0.3",
         "contentHash": "TV62UsrJZPX6gbt3c4WrtXh7bmaDIcMqf9uft1cc4L6gJXOU07hDGEh+bFQh/L2Az0R1WVOkiT66lFqS6G2NmA=="
-      },
-      "Microsoft.CodeCoverage": {
-        "type": "Transitive",
-        "resolved": "17.14.1",
-        "contentHash": "pmTrhfFIoplzFVbhVwUquT+77CbGH+h4/3mBpdmIlYtBi9nAB+kKI6dN3A/nV4DFi3wLLx/BlHIPK+MkbQ6Tpg=="
       },
       "Microsoft.EntityFrameworkCore.Abstractions": {
         "type": "Transitive",
@@ -268,11 +163,6 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.11"
         }
-      },
-      "Microsoft.Extensions.DependencyModel": {
-        "type": "Transitive",
-        "resolved": "10.0.11",
-        "contentHash": "PJPtFYsZ+r+uz9qqXWUTEyKeJ1EiBGIJtqavkg9ZXijjGSFAk4Fgi5sqIxj+uAyLZwEKgexDUQXhWhvU6l3+og=="
       },
       "Microsoft.Extensions.Diagnostics": {
         "type": "Transitive",
@@ -471,25 +361,6 @@
         "resolved": "8.14.0",
         "contentHash": "iwbCpSjD3ehfTwBhtSNEtKPK0ICun6ov7Ibx6ISNA9bfwIyzI2Siwyi9eJFCJBwxowK9xcA1mj+jBWiigeqgcQ=="
       },
-      "Microsoft.TestPlatform.ObjectModel": {
-        "type": "Transitive",
-        "resolved": "17.14.1",
-        "contentHash": "xTP1W6Mi6SWmuxd3a+jj9G9UoC850WGwZUps1Wah9r1ZxgXhdJfj1QqDLJkFjHDCvN42qDL2Ps5KjQYWUU0zcQ=="
-      },
-      "Microsoft.TestPlatform.TestHost": {
-        "type": "Transitive",
-        "resolved": "17.14.1",
-        "contentHash": "d78LPzGKkJwsJXAQwsbJJ7LE7D1wB+rAyhHHAaODF+RDSQ0NgMjDFkSA1Djw18VrxO76GlKAjRUhl+H8NL8Z+Q==",
-        "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "17.14.1",
-          "Newtonsoft.Json": "13.0.3"
-        }
-      },
-      "Newtonsoft.Json": {
-        "type": "Transitive",
-        "resolved": "13.0.3",
-        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
-      },
       "Npgsql": {
         "type": "Transitive",
         "resolved": "10.0.3",
@@ -506,51 +377,12 @@
           "System.ClientModel": "1.14.0"
         }
       },
-      "OpenTelemetry": {
-        "type": "Transitive",
-        "resolved": "1.18.0",
-        "contentHash": "13AKxycK+olOLe061MjliPTNBR/DUkjyRr0b9zwUhKyMjFS8lXS7G31R85rkbM55up2YFmdykWdAw2giBDJpiQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.0",
-          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Logging.Configuration": "10.0.0",
-          "OpenTelemetry.Api.ProviderBuilderExtensions": "1.18.0"
-        }
-      },
-      "OpenTelemetry.Api": {
-        "type": "Transitive",
-        "resolved": "1.18.0",
-        "contentHash": "Dhzm5oughIY9EWckt2J1yXcEbXpki5WCL2q7prJoYxzH6C7jdkfGtPMTkUVZZ4AhjJKzQnlC+kLSIlmIVwC4Vw=="
-      },
-      "OpenTelemetry.Api.ProviderBuilderExtensions": {
-        "type": "Transitive",
-        "resolved": "1.18.0",
-        "contentHash": "io6A6PJFp3vIObRGf6oPjdHsdglkinXt/0SpTDJHrVnsLxUtOzwh/QwTsnhBJ43wJ6QcGMkyNzsSSY8XEB1Q5Q==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
-          "OpenTelemetry.Api": "1.18.0"
-        }
-      },
       "Pgvector": {
         "type": "Transitive",
         "resolved": "0.3.2",
         "contentHash": "n7M5LuNejHUmtWky3zCbNO+tP1Gnjiuv9Qtu4LyvB1602dD8RiBxxCQp9jEjM0ZFDxAZF1oOWkNIkXw46KT00Q==",
         "dependencies": {
           "Npgsql": "8.0.5"
-        }
-      },
-      "SharpZipLib": {
-        "type": "Transitive",
-        "resolved": "1.4.2",
-        "contentHash": "yjj+3zgz8zgXpiiC3ZdF/iyTBbz2fFvMxZFEBPUcwZjIvXOf37Ylm+K58hqMfIBt5JgU/Z2uoUS67JmTLe973A=="
-      },
-      "SSH.NET": {
-        "type": "Transitive",
-        "resolved": "2026.0.0",
-        "contentHash": "Yu9dirPq8l3oaat0+OQ7K0nUf5MmYltpia5UGqsApTG4zTPvBC1cxbNnC3NERij26dUST0A3Ef1QdHSn5ArbWQ==",
-        "dependencies": {
-          "BouncyCastle.Cryptography": "2.7.0",
-          "Microsoft.Extensions.Logging.Abstractions": "8.0.3"
         }
       },
       "System.ClientModel": {
@@ -584,85 +416,10 @@
         "resolved": "4.5.0",
         "contentHash": "wLBKzFnDCxP12VL9ANydSYhk59fC4cvOr9ypYQLPnAj48NQIhqnjdD2yhP8yEKyBJEjERWS9DisKL7rX5eU25Q=="
       },
-      "Testcontainers": {
-        "type": "Transitive",
-        "resolved": "4.14.0",
-        "contentHash": "ojuBi91xcMsR6vnFuNsQDWU9tlZlrtmqy95VPNWVVnh24GiwFL/WMnVmb6bRv8LqovtnKPJN9cpmH1k02Z4ZoA==",
-        "dependencies": {
-          "Docker.DotNet.Enhanced": "4.3.3",
-          "Docker.DotNet.Enhanced.X509": "4.3.3",
-          "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
-          "SSH.NET": "2026.0.0",
-          "SharpZipLib": "1.4.2"
-        }
-      },
-      "xunit.abstractions": {
-        "type": "Transitive",
-        "resolved": "2.0.3",
-        "contentHash": "pot1I4YOxlWjIb5jmwvvQNbTrZ3lJQ+jUGkGjWE3hEFM0l5gOnBWS+H3qsex68s5cO52g+44vpGzhAt+42vwKg=="
-      },
-      "xunit.analyzers": {
-        "type": "Transitive",
-        "resolved": "1.18.0",
-        "contentHash": "OtFMHN8yqIcYP9wcVIgJrq01AfTxijjAqVDy/WeQVSyrDC1RzBWeQPztL49DN2syXRah8TYnfvk035s7L95EZQ=="
-      },
-      "xunit.assert": {
-        "type": "Transitive",
-        "resolved": "2.9.3",
-        "contentHash": "/Kq28fCE7MjOV42YLVRAJzRF0WmEqsmflm0cfpMjGtzQ2lR5mYVj1/i0Y8uDAOLczkL3/jArrwehfMD0YogMAA=="
-      },
-      "xunit.core": {
-        "type": "Transitive",
-        "resolved": "2.9.3",
-        "contentHash": "BiAEvqGvyme19wE0wTKdADH+NloYqikiU0mcnmiNyXaF9HyHmE6sr/3DC5vnBkgsWaE6yPyWszKSPSApWdRVeQ==",
-        "dependencies": {
-          "xunit.extensibility.core": "[2.9.3]",
-          "xunit.extensibility.execution": "[2.9.3]"
-        }
-      },
-      "xunit.extensibility.core": {
-        "type": "Transitive",
-        "resolved": "2.9.3",
-        "contentHash": "kf3si0YTn2a8J8eZNb+zFpwfoyvIrQ7ivNk5ZYA5yuYk1bEtMe4DxJ2CF/qsRgmEnDr7MnW1mxylBaHTZ4qErA==",
-        "dependencies": {
-          "xunit.abstractions": "2.0.3"
-        }
-      },
-      "xunit.extensibility.execution": {
-        "type": "Transitive",
-        "resolved": "2.9.3",
-        "contentHash": "yMb6vMESlSrE3Wfj7V6cjQ3S4TXdXpRqYeNEI3zsX31uTsGMJjEw6oD5F5u1cHnMptjhEECnmZSsPxB6ChZHDQ==",
-        "dependencies": {
-          "xunit.extensibility.core": "[2.9.3]"
-        }
-      },
-      "contractiq.api": {
-        "type": "Project",
-        "dependencies": {
-          "ContractIQ.Application": "[1.0.0, )",
-          "ContractIQ.Infrastructure": "[1.0.0, )",
-          "Microsoft.AspNetCore.OpenApi": "[10.0.11, )",
-          "Microsoft.OpenApi": "[2.12.2, )",
-          "Npgsql.OpenTelemetry": "[10.0.3, )",
-          "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.18.0, )",
-          "OpenTelemetry.Extensions.Hosting": "[1.18.0, )",
-          "OpenTelemetry.Instrumentation.AspNetCore": "[1.18.0, )",
-          "OpenTelemetry.Instrumentation.Http": "[1.18.0, )",
-          "OpenTelemetry.Instrumentation.Runtime": "[1.18.0, )"
-        }
-      },
       "contractiq.application": {
         "type": "Project",
         "dependencies": {
           "ContractIQ.Domain": "[1.0.0, )"
-        }
-      },
-      "contractiq.azuresmoketest": {
-        "type": "Project",
-        "dependencies": {
-          "ContractIQ.Application": "[1.0.0, )",
-          "ContractIQ.Infrastructure": "[1.0.0, )",
-          "Microsoft.Extensions.Hosting": "[10.0.11, )"
         }
       },
       "contractiq.domain": {
@@ -702,15 +459,6 @@
         "contentHash": "HziwTmbadPNT/Q0Bau3n7ubQQJde5AWGi2LpzA30JwDasJiY5ogyrp7pALpvUy5HYcgSMRrRdLtahgTT5TPyrA==",
         "dependencies": {
           "Azure.Core": "1.54.0"
-        }
-      },
-      "Microsoft.AspNetCore.OpenApi": {
-        "type": "CentralTransitive",
-        "requested": "[10.0.11, )",
-        "resolved": "10.0.11",
-        "contentHash": "R/1EATnPLU+gRfB6lwVkMcymmyAY5ppBBdRN/5lhNEiT3xP1sWccuSFkU/f1lQvN/WgRq5Vn8AhCdE3fqgsL/w==",
-        "dependencies": {
-          "Microsoft.OpenApi": "[2.7.5, 3.0.0)"
         }
       },
       "Microsoft.EntityFrameworkCore": {
@@ -786,42 +534,6 @@
           "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.11"
         }
       },
-      "Microsoft.Extensions.Hosting": {
-        "type": "CentralTransitive",
-        "requested": "[10.0.11, )",
-        "resolved": "10.0.11",
-        "contentHash": "eIDa/Rl+93aj17gMlFsJJx+LhBvb3CP0Mu1PeVYkDp2Y3S4Jock8UynfGQEcx7lrlq+gKW+ECQJHbro/LTPDEQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.11",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.11",
-          "Microsoft.Extensions.Configuration.Binder": "10.0.11",
-          "Microsoft.Extensions.Configuration.CommandLine": "10.0.11",
-          "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.11",
-          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.11",
-          "Microsoft.Extensions.Configuration.Json": "10.0.11",
-          "Microsoft.Extensions.Configuration.UserSecrets": "10.0.11",
-          "Microsoft.Extensions.DependencyInjection": "10.0.11",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.11",
-          "Microsoft.Extensions.Diagnostics": "10.0.11",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.11",
-          "Microsoft.Extensions.FileProviders.Physical": "10.0.11",
-          "Microsoft.Extensions.Hosting.Abstractions": "10.0.11",
-          "Microsoft.Extensions.Logging": "10.0.11",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.11",
-          "Microsoft.Extensions.Logging.Configuration": "10.0.11",
-          "Microsoft.Extensions.Logging.Console": "10.0.11",
-          "Microsoft.Extensions.Logging.Debug": "10.0.11",
-          "Microsoft.Extensions.Logging.EventLog": "10.0.11",
-          "Microsoft.Extensions.Logging.EventSource": "10.0.11",
-          "Microsoft.Extensions.Options": "10.0.11"
-        }
-      },
-      "Microsoft.OpenApi": {
-        "type": "CentralTransitive",
-        "requested": "[2.12.2, )",
-        "resolved": "2.12.2",
-        "contentHash": "ZkT7qiJe0Kj0+DTZOZo+xrDy1kNmdsWFQVPIQLNx9ZJ0T9cB2LG7r+Bi60so8/+yg1nkS7QCPadrzsTG4VPKrA=="
-      },
       "Npgsql.EntityFrameworkCore.PostgreSQL": {
         "type": "CentralTransitive",
         "requested": "[10.0.3, )",
@@ -833,16 +545,6 @@
           "Npgsql": "10.0.3"
         }
       },
-      "Npgsql.OpenTelemetry": {
-        "type": "CentralTransitive",
-        "requested": "[10.0.3, )",
-        "resolved": "10.0.3",
-        "contentHash": "ShsdG/FHxJ2VuWM6tebJL/mCWkcxymmvtENN59c85EsJdT4TStWwwtgZoBu/9UvC0qi1jpFZ6bOfl9ijiWD+vA==",
-        "dependencies": {
-          "Npgsql": "10.0.3",
-          "OpenTelemetry.API": "1.15.3"
-        }
-      },
       "OllamaSharp": {
         "type": "CentralTransitive",
         "requested": "[5.4.30, )",
@@ -851,54 +553,6 @@
         "dependencies": {
           "Microsoft.Extensions.AI": "10.8.0",
           "Microsoft.Extensions.AI.Abstractions": "10.8.0"
-        }
-      },
-      "OpenTelemetry.Exporter.OpenTelemetryProtocol": {
-        "type": "CentralTransitive",
-        "requested": "[1.18.0, )",
-        "resolved": "1.18.0",
-        "contentHash": "Et3WAviooKGObZjUZN8d6eTsdJs1YM3ZoN+KlWSAHksTmHG1nyGi9XGo2wb0fkFMWK0g80FOPdR1njg52Dm+aw==",
-        "dependencies": {
-          "OpenTelemetry": "1.18.0"
-        }
-      },
-      "OpenTelemetry.Extensions.Hosting": {
-        "type": "CentralTransitive",
-        "requested": "[1.18.0, )",
-        "resolved": "1.18.0",
-        "contentHash": "u+JMA82H65MKwMvd2qUpL8C2qE4Jux2nvX9hmy036UK/Apv2YyIRYCttF/vlX6nMPcAKI8BXkscmL4QG3C69fw==",
-        "dependencies": {
-          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
-          "OpenTelemetry": "1.18.0"
-        }
-      },
-      "OpenTelemetry.Instrumentation.AspNetCore": {
-        "type": "CentralTransitive",
-        "requested": "[1.18.0, )",
-        "resolved": "1.18.0",
-        "contentHash": "hBiMXE/CGIAHUOpi0gScNkjHB0L9XbCin5lZObL+dMBl4OmpndnHgxP3JZDnnGtU6qOzdeh8TYUV9f6Jgmmhlw==",
-        "dependencies": {
-          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.18.0, 2.0.0)"
-        }
-      },
-      "OpenTelemetry.Instrumentation.Http": {
-        "type": "CentralTransitive",
-        "requested": "[1.18.0, )",
-        "resolved": "1.18.0",
-        "contentHash": "/X57peOOa4a+9V4DSVXbuIWdsAxmU5gsxw8lu+gJU0zuewsYhC9f6qdm8GEW0VvqG9e+gxn0HdVR5G3YHcWDTw==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.0",
-          "Microsoft.Extensions.Options": "10.0.0",
-          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.18.0, 2.0.0)"
-        }
-      },
-      "OpenTelemetry.Instrumentation.Runtime": {
-        "type": "CentralTransitive",
-        "requested": "[1.18.0, )",
-        "resolved": "1.18.0",
-        "contentHash": "McuXGjBJDL/Cown2PxfUQysK98MZG7ZDjO/IKUtaAx8t1m0PB0d+QtJC79RFTVipMhRIwjJiULNOp0OGfZbvwg==",
-        "dependencies": {
-          "OpenTelemetry.Api": "[1.18.0, 2.0.0)"
         }
       },
       "Pgvector.EntityFrameworkCore": {


### PR DESCRIPTION
## Summary

- add a manually dispatched `azure-dev` GitHub Actions workflow that authenticates to Azure with OIDC and no stored client secret
- add a bounded .NET smoke-test tool that sends one two-input Foundry embedding request, indexes one fictional chunk, and runs one Azure AI Search hybrid query
- disable Foundry and Search SDK retries for the live smoke profile and publish cost-relevant counts without prompt or document content
- add least-privilege Bicep role assignments for the optional GitHub service principal
- document setup, execution, troubleshooting, cost boundaries, and complete revocation

Normal push and pull-request CI remains deterministic and does not authenticate to or call Azure. This PR provisions no resource, deploys no model, and makes no live Azure request.

## Validation

- `dotnet restore ContractIQ.slnx --locked-mode` with NuGet audit
- `dotnet format ContractIQ.slnx --verify-no-changes --no-restore`
- Release build: 0 warnings, 0 errors
- 40 domain + 34 application + 15 AI evaluation + 44 non-Docker integration tests passed
- full integration suite deferred to GitHub CI because Docker Desktop is stopped locally
- Bicep compilation passed
- all GitHub workflows passed actionlint
- no vulnerable NuGet packages found
- safe missing-configuration failure path verified without contacting Azure

Closes #52
Part of #13
