### PR TITLE
feat: prepare opt-in Foundry model deployments

### DIFF
--- a/docs/azure/implementation-plan.md
+++ b/docs/azure/implementation-plan.md
@@ -38,16 +38,19 @@ ContractIQ does not deploy a second hosted agent in Foundry for this increment. 
 
 Status on 2026-08-31: the Azure foundation definitions, Foundry model adapters,
 Azure AI Search adapter, and bounded manual OIDC smoke-test workflow are
-implemented and validated without provisioning resources. Live execution still
-requires separately approved infrastructure, model deployment, and GitHub
-environment configuration.
+implemented and validated without provisioning resources. Brazil South has
+live catalog capacity and subscription quota for `gpt-5-mini` version
+`2025-08-07` and `text-embedding-3-small` version `1` on `GlobalStandard`.
+Their Bicep deployments remain disabled by default and live execution still
+requires explicitly approved provisioning and GitHub environment configuration.
 
 ### 1. Azure foundation — implemented, not deployed
 
 - validate the subscription, ownership, quota, and provider availability;
 - review Bicep with a subscription budget, one resource group, a Foundry account/project, free Azure AI Search, and RBAC;
 - run `what-if` and stop for explicit provisioning approval;
-- provision no model until its live SKU and quota are verified.
+- keep model resources behind `deployModels=false` until their live SKU, quota,
+  cost boundary, and provisioning are explicitly approved.
 
 ### 2. Foundry adapters — implemented, not invoked live
 
@@ -91,7 +94,8 @@ environment configuration.
 - Azure configuration contains no committed key or secret.
 - Azure AI Search uses the free SKU for the portfolio environment.
 - Search Free receives application calls through Entra RBAC but does not use a Search-managed identity, integrated vectorization, or semantic ranking.
-- Model deployments are selected from live catalog and quota data rather than hardcoded assumptions.
+- Model deployment defaults record a dated live selection and remain opt-in;
+  catalog and quota are checked again before a later deployment.
 - Hybrid results are scoped, grounded, and mapped to citations.
 - A hosted model cannot bypass confirmation or deterministic domain rules.
 - Normal PR CI performs no billable call.

--- a/docs/operations/cost-and-resources.md
+++ b/docs/operations/cost-and-resources.md
@@ -121,7 +121,8 @@ ContractIQ v1 remains locally runnable without Azure credentials or automatic pr
 - Search-managed outbound identity, integrated vectorization, semantic ranking, and dedicated capacity remain a documented Basic-or-higher production evolution;
 - issue #13 records resource assumptions, budgets, keyless authentication, infrastructure as code, and the exact teardown boundary before deployment;
 - the USD 10 budget is an alerting target, not a hard spending cap;
-- model deployment stays out of the foundation template until live region, SKU, version, and quota checks are reviewed.
+- model deployments remain disabled by default until live region, SKU, version,
+  quota, and cost checks are reviewed and provisioning is explicitly approved.
 
 The optional Azure smoke workflow also remains inert until a person selects the
 `azure-dev` environment in GitHub Actions. One run makes one Foundry embedding

--- a/infra/azure/README.md
+++ b/infra/azure/README.md
@@ -8,11 +8,15 @@ This folder contains the reviewed infrastructure boundary for ContractIQ's optio
 | --- | --- | --- |
 | Resource group | One isolated development group | No charge |
 | Subscription budget | USD 10 planning target with 50%, 80%, and 100% alerts | No charge; alerts do not stop spend |
-| Microsoft Foundry account and project | `AIServices`, public development endpoint, local authentication disabled | Account/project have no committed throughput; model inference is usage-based |
+| Microsoft Foundry account and project | `AIServices`, public development endpoint, local authentication disabled | Account/project have no committed throughput |
+| Optional model deployments | `gpt-5-mini` and `text-embedding-3-small`, `GlobalStandard`, 1K TPM each | No fixed deployment charge; inference is usage-based |
 | Azure AI Search | Free tier, one shared service with a 50 MB limit | No charge while the free tier remains available and its limits are respected |
 | Role assignments | Least-privilege roles for the local developer and optional GitHub OIDC service principal | No charge |
 
-No model deployment is declared yet. Model name, version, SKU, capacity, and region must be resolved against the live catalog and subscription quota immediately before a separate approved deployment.
+Model deployments are declared but disabled by default through `deployModels=false`.
+The selected names, versions, SKU, capacity, and region were resolved against
+the live catalog and subscription quota on 2026-08-31. They must be checked
+again if the deployment is executed later or in another subscription.
 
 The template outputs `foundryOpenAIEndpoint` in the form expected by the .NET
 chat and embedding adapters: `https://<resource-name>.openai.azure.com/openai/v1/`.
@@ -51,7 +55,10 @@ Before anyone runs a subscription deployment, record all of the following in the
 7. The exact `what-if` output.
 8. Explicit approval to provision.
 
-After provisioning and model deployment are separately approved, follow the [manual keyless smoke-test guide](../../docs/azure/manual-smoke-test.md). The live workflow is never triggered by a push or pull request and performs only one bounded indexing/query scenario.
+Set `deployModels=true` only in an explicitly reviewed deployment. After
+provisioning is approved, follow the [manual keyless smoke-test guide](../../docs/azure/manual-smoke-test.md).
+The live workflow is never triggered by a push or pull request and performs
+only one bounded indexing/query scenario.
 
 ## Teardown boundary
 

--- a/infra/azure/main.bicep
+++ b/infra/azure/main.bicep
@@ -26,6 +26,25 @@ param developerPrincipalId string = ''
 @description('Optional service principal object ID used by the manual GitHub OIDC smoke test.')
 param smokeTestPrincipalId string = ''
 
+@description('Creates the validated pay-as-you-go chat and embedding model deployments. Keep false for foundation-only validation.')
+param deployModels bool = false
+
+@description('Chat model selected from the live Foundry catalog.')
+param chatModelName string = 'gpt-5-mini'
+
+@description('Pinned chat model version selected from the live Foundry catalog.')
+param chatModelVersion string = '2025-08-07'
+
+@description('Embedding model selected from the live Foundry catalog.')
+param embeddingModelName string = 'text-embedding-3-small'
+
+@description('Pinned embedding model version selected from the live Foundry catalog.')
+param embeddingModelVersion string = '1'
+
+@description('GlobalStandard deployment capacity in thousands of tokens per minute. Capacity reserves quota, not prepaid spend.')
+@minValue(1)
+param modelCapacity int = 1
+
 @description('Additional tags applied to every provisioned resource.')
 param tags object = {}
 
@@ -95,9 +114,15 @@ module aiPlatform 'modules/ai-platform.bicep' = {
   name: 'contractiq-ai-platform-${environmentName}'
   scope: resourceGroup
   params: {
+    chatModelName: chatModelName
+    chatModelVersion: chatModelVersion
     developerPrincipalId: developerPrincipalId
+    deployModels: deployModels
+    embeddingModelName: embeddingModelName
+    embeddingModelVersion: embeddingModelVersion
     environmentName: environmentName
     location: location
+    modelCapacity: modelCapacity
     smokeTestPrincipalId: smokeTestPrincipalId
     tags: commonTags
     uniqueSuffix: uniqueSuffix
@@ -109,5 +134,7 @@ output foundryAccountName string = aiPlatform.outputs.foundryAccountName
 output foundryProjectName string = aiPlatform.outputs.foundryProjectName
 output foundryEndpoint string = aiPlatform.outputs.foundryEndpoint
 output foundryOpenAIEndpoint string = aiPlatform.outputs.foundryOpenAIEndpoint
+output chatDeploymentName string = aiPlatform.outputs.chatDeploymentName
+output embeddingDeploymentName string = aiPlatform.outputs.embeddingDeploymentName
 output searchServiceName string = aiPlatform.outputs.searchServiceName
 output searchEndpoint string = aiPlatform.outputs.searchEndpoint

--- a/infra/azure/modules/ai-platform.bicep
+++ b/infra/azure/modules/ai-platform.bicep
@@ -16,9 +16,29 @@ param developerPrincipalId string = ''
 @description('Optional service principal object ID for the manual GitHub OIDC smoke test.')
 param smokeTestPrincipalId string = ''
 
+@description('Whether the validated pay-as-you-go model deployments are included.')
+param deployModels bool = false
+
+@description('Chat model name selected from the live catalog.')
+param chatModelName string
+
+@description('Pinned chat model version selected from the live catalog.')
+param chatModelVersion string
+
+@description('Embedding model name selected from the live catalog.')
+param embeddingModelName string
+
+@description('Pinned embedding model version selected from the live catalog.')
+param embeddingModelVersion string
+
+@description('GlobalStandard capacity in thousands of tokens per minute.')
+param modelCapacity int
+
 var foundryAccountName = 'aif-contractiq-${environmentName}-${uniqueSuffix}'
 var foundryProjectName = 'contractiq-${environmentName}'
 var searchServiceName = 'srch-contractiq-${environmentName}-${uniqueSuffix}'
+var chatDeploymentName = 'contractiq-chat'
+var embeddingDeploymentName = 'contractiq-embeddings'
 
 var cognitiveServicesOpenAiUserRoleId = subscriptionResourceId(
   'Microsoft.Authorization/roleDefinitions',
@@ -66,6 +86,38 @@ resource foundryProject 'Microsoft.CognitiveServices/accounts/projects@2025-06-0
     description: 'Optional Microsoft Foundry project for the ContractIQ portfolio application.'
   }
   tags: tags
+}
+
+resource chatDeployment 'Microsoft.CognitiveServices/accounts/deployments@2024-10-01' = if (deployModels) {
+  name: chatDeploymentName
+  parent: foundryAccount
+  sku: {
+    name: 'GlobalStandard'
+    capacity: modelCapacity
+  }
+  properties: {
+    model: {
+      format: 'OpenAI'
+      name: chatModelName
+      version: chatModelVersion
+    }
+  }
+}
+
+resource embeddingDeployment 'Microsoft.CognitiveServices/accounts/deployments@2024-10-01' = if (deployModels) {
+  name: embeddingDeploymentName
+  parent: foundryAccount
+  sku: {
+    name: 'GlobalStandard'
+    capacity: modelCapacity
+  }
+  properties: {
+    model: {
+      format: 'OpenAI'
+      name: embeddingModelName
+      version: embeddingModelVersion
+    }
+  }
 }
 
 resource searchService 'Microsoft.Search/searchServices@2025-05-01' = {
@@ -156,5 +208,7 @@ output foundryAccountName string = foundryAccount.name
 output foundryProjectName string = foundryProject.name
 output foundryEndpoint string = foundryAccount.properties.endpoint
 output foundryOpenAIEndpoint string = 'https://${foundryAccount.name}.openai.azure.com/openai/v1/'
+output chatDeploymentName string = chatDeploymentName
+output embeddingDeploymentName string = embeddingDeploymentName
 output searchServiceName string = searchService.name
 output searchEndpoint string = 'https://${searchService.name}.search.windows.net'


### PR DESCRIPTION
## Outcome

Adds opt-in Microsoft Foundry model deployments selected from the live Azure catalog and subscription quota. No Azure resource is provisioned by this PR.

## Selected profile

- Region: Brazil South
- Chat: gpt-5-mini, version 2025-08-07, GlobalStandard, 1K TPM
- Embeddings: text-embedding-3-small, version 1, GlobalStandard, 1K TPM
- Default safety switch: deployModels=false
- Azure AI Search: Free tier
- Authentication: Entra ID and RBAC; local keys remain disabled

## Live preflight evidence

- Microsoft.Search and Microsoft.CognitiveServices providers are Registered.
- Both model deployments have catalog capacity and subscription quota in Brazil South.
- Bicep compilation passed.
- Foundation-only what-if: 8 resources to create.
- Opt-in model what-if: 10 resources to create.
- Post-validation inventory: 0 Azure resources and 0 budgets.

## Tests

- Bicep build: passed
- Offline/unit suites: 133 passed
- Integration suite: 34 Docker-backed cases could not start because Docker Desktop was not running locally; 44 cases in the assembly passed. CI will rerun with Docker.
- No residual test processes remain.

## Cost boundary

Foundry model deployments are pay-as-you-go and have no fixed deployment charge. They remain disabled unless an approved deployment explicitly sets deployModels=true. The USD 10 budget is an alert, not a hard cap.

Refs #53 and #13