### PR TITLE
fix: serialize Foundry child deployments

### DIFF
--- a/infra/azure/modules/ai-platform.bicep
+++ b/infra/azure/modules/ai-platform.bicep
@@ -91,6 +91,11 @@ resource foundryProject 'Microsoft.CognitiveServices/accounts/projects@2025-06-0
 resource chatDeployment 'Microsoft.CognitiveServices/accounts/deployments@2024-10-01' = if (deployModels) {
   name: chatDeploymentName
   parent: foundryAccount
+  // Cognitive Services can reject concurrent child writes on a newly created
+  // account. Keep project -> embeddings -> chat deterministic and idempotent.
+  dependsOn: [
+    embeddingDeployment
+  ]
   sku: {
     name: 'GlobalStandard'
     capacity: modelCapacity
@@ -107,6 +112,9 @@ resource chatDeployment 'Microsoft.CognitiveServices/accounts/deployments@2024-1
 resource embeddingDeployment 'Microsoft.CognitiveServices/accounts/deployments@2024-10-01' = if (deployModels) {
   name: embeddingDeploymentName
   parent: foundryAccount
+  dependsOn: [
+    foundryProject
+  ]
   sku: {
     name: 'GlobalStandard'
     capacity: modelCapacity


### PR DESCRIPTION
## Outcome

Serializes Foundry child resource creation after the first live deployment exposed an Azure parent-resource write conflict.

## Root cause

The project, embedding deployment, and chat deployment were submitted concurrently against a newly created Cognitive Services account. Azure accepted the project and embedding model but rejected the chat deployment with RequestConflict.

## Fix

- Create the Foundry project first.
- Create the embedding deployment after the project.
- Create the chat deployment after embeddings.
- Preserve idempotency for the already-created resources.

## Validation

- Bicep build passed.
- Live What-If against the partial deployment shows only the budget and chat deployment to create.
- No hosted model invocation was made.

Refs #53