### PR TITLE
fix: await Azure Search visibility in smoke test

### DIFF
--- a/docs/azure/manual-smoke-test.md
+++ b/docs/azure/manual-smoke-test.md
@@ -12,6 +12,9 @@ The workflow is safe by construction:
 - no Azure client secret or service key is stored in GitHub;
 - the tool sends one embedding request containing exactly two short fictional inputs;
 - it indexes exactly one fictional chunk and performs one hybrid search query;
+- it performs bounded Search-only readiness checks until the uploaded version is
+  visible, accounting for Azure AI Search eventual consistency without repeating
+  the embedding request or the hybrid query;
 - Foundry and Azure AI Search SDK retries are set to zero for this run;
 - the tool times out after 90 seconds and the job after five minutes;
 - concurrent runs for the same environment are serialized;

--- a/tests/ContractIQ.IntegrationTests/AzureSmokeTestRunnerTests.cs
+++ b/tests/ContractIQ.IntegrationTests/AzureSmokeTestRunnerTests.cs
@@ -30,6 +30,7 @@ public sealed class AzureSmokeTestRunnerTests
         Assert.Equal(1, embeddings.RequestCount);
         Assert.Equal(2, embeddings.LastValues.Count);
         Assert.Equal(1, index.ReplaceCount);
+        Assert.Equal(1, index.IsCurrentCount);
         Assert.Equal(1, index.SearchCount);
         Assert.Equal(1, index.LastChunkCount);
         Assert.Equal(1, index.LastLimit);
@@ -52,6 +53,7 @@ public sealed class AzureSmokeTestRunnerTests
 
         Assert.Contains("no evidence", exception.Message, StringComparison.OrdinalIgnoreCase);
         Assert.Equal(1, index.ReplaceCount);
+        Assert.Equal(1, index.IsCurrentCount);
         Assert.Equal(1, index.SearchCount);
     }
 
@@ -86,6 +88,8 @@ public sealed class AzureSmokeTestRunnerTests
 
         public int ReplaceCount { get; private set; }
 
+        public int IsCurrentCount { get; private set; }
+
         public int SearchCount { get; private set; }
 
         public int LastChunkCount { get; private set; }
@@ -101,8 +105,11 @@ public sealed class AzureSmokeTestRunnerTests
             string version,
             string contentChecksum,
             string embeddingModel,
-            CancellationToken cancellationToken = default) =>
-            Task.FromResult(false);
+            CancellationToken cancellationToken = default)
+        {
+            IsCurrentCount++;
+            return Task.FromResult(_source is not null);
+        }
 
         public Task ReplaceAsync(
             KnowledgeDocumentSource source,

--- a/tools/ContractIQ.AzureSmokeTest/AzureSmokeTestRunner.cs
+++ b/tools/ContractIQ.AzureSmokeTest/AzureSmokeTestRunner.cs
@@ -22,6 +22,9 @@ internal sealed class AzureSmokeTestRunner(
         "A cancellation request requires 30 days written notice before termination.";
     private const string Query =
         "How much written notice is required for cancellation?";
+    private const int IndexReadinessAttempts = 20;
+    private static readonly TimeSpan IndexReadinessDelay =
+        TimeSpan.FromMilliseconds(250);
 
     public async Task<AzureSmokeTestReport> RunAsync(
         CancellationToken cancellationToken = default)
@@ -61,6 +64,10 @@ internal sealed class AzureSmokeTestRunner(
             embeddingGenerator.ModelId,
             [chunk],
             cancellationToken);
+        await WaitUntilIndexedAsync(
+            source,
+            ComputeChecksum(source.Content),
+            cancellationToken);
 
         IReadOnlyList<KnowledgeEvidence> evidence = await knowledgeIndex.SearchAsync(
             Query,
@@ -96,6 +103,36 @@ internal sealed class AzureSmokeTestRunner(
             SearchResultCount: evidence.Count,
             SearchProvider: "azure-ai-search",
             IndexName: indexName);
+    }
+
+    private async Task WaitUntilIndexedAsync(
+        KnowledgeDocumentSource source,
+        string contentChecksum,
+        CancellationToken cancellationToken)
+    {
+        for (int attempt = 1; attempt <= IndexReadinessAttempts; attempt++)
+        {
+            if (await knowledgeIndex.IsCurrentAsync(
+                    source.DocumentKey,
+                    source.Version,
+                    contentChecksum,
+                    embeddingGenerator.ModelId,
+                    cancellationToken))
+            {
+                return;
+            }
+
+            if (attempt < IndexReadinessAttempts)
+            {
+                await Task.Delay(
+                    IndexReadinessDelay,
+                    timeProvider,
+                    cancellationToken);
+            }
+        }
+
+        throw new InvalidOperationException(
+            "The indexed smoke-test document did not become searchable in time.");
     }
 
     private void ValidateEmbeddings(IReadOnlyList<float[]> embeddings)


### PR DESCRIPTION
## Outcome

Makes the bounded Azure AI smoke test reliable against Azure AI Search eventual consistency.

## Live finding

The Foundry embedding request and document upload succeeded, but the immediate hybrid query ran before the newly uploaded version became searchable. A later Search-only read confirmed the document was present and searchable.

## Fix

- Poll the application-owned IsCurrentAsync boundary for at most five seconds.
- Keep provider SDK retries at zero.
- Do not repeat the embedding request.
- Execute exactly one hybrid search query after index visibility.
- Document the readiness behavior.

## Tests

- Targeted AzureSmokeTestRunnerTests: 2 passed.
- No Docker dependency required for the targeted tests.

Refs #53