### PR TITLE
fix: use GPT-5 completion token parameter in Foundry

### DIFF
--- a/docs/azure/foundry-model-adapters.md
+++ b/docs/azure/foundry-model-adapters.md
@@ -54,6 +54,12 @@ to three transient retries; the bounded manual smoke test overrides
 `Foundry:MaximumRetries` to `0` so a failed run cannot repeat model consumption
 automatically.
 
+The provider-neutral chat options normally map the output limit to the legacy
+`max_tokens` field. GPT-5 deployments reject that field, so the Foundry adapter
+omits it and sends the same configured limit as `max_completion_tokens` through
+the official OpenAI client options. Ollama and Kimi keep their existing option
+mapping.
+
 Changing the embedding deployment changes the stored embedding model identity.
 Run the document indexer again so document chunks are regenerated consistently.
 

--- a/src/ContractIQ.Infrastructure/Assistant/ChatClientAssistantAnswerGenerator.cs
+++ b/src/ContractIQ.Infrastructure/Assistant/ChatClientAssistantAnswerGenerator.cs
@@ -91,7 +91,12 @@ internal sealed class ChatClientAssistantAnswerGenerator : IAssistantAnswerGener
             var chatOptions = new ChatOptions
             {
                 ModelId = _options.ChatModel,
-                MaxOutputTokens = _options.MaximumOutputTokens,
+                // GPT-5 deployments reject the legacy max_tokens field produced
+                // by the provider-neutral mapping. Foundry receives the same
+                // limit through max_completion_tokens in its raw options.
+                MaxOutputTokens = _options.Provider == AssistantProvider.Foundry
+                    ? null
+                    : _options.MaximumOutputTokens,
                 // Kimi models have provider-defined fixed temperatures and reject
                 // the 0.1 value used by the local deterministic demo profile.
                 Temperature = _options.Provider == AssistantProvider.Ollama
@@ -110,6 +115,11 @@ internal sealed class ChatClientAssistantAnswerGenerator : IAssistantAnswerGener
             if (_options.Provider == AssistantProvider.Kimi)
             {
                 chatOptions.RawRepresentationFactory = _ => CreateKimiChatOptions();
+            }
+            else if (_options.Provider == AssistantProvider.Foundry)
+            {
+                chatOptions.RawRepresentationFactory = _ =>
+                    CreateFoundryChatOptions(_options.MaximumOutputTokens);
             }
 
             ChatResponse response = await _chatClient.GetResponseAsync(
@@ -206,6 +216,13 @@ internal sealed class ChatClientAssistantAnswerGenerator : IAssistantAnswerGener
         return options;
     }
 #pragma warning restore SCME0001
+
+    internal static OpenAIChatCompletionOptions CreateFoundryChatOptions(
+        int maximumOutputTokens) =>
+        new()
+        {
+            MaxOutputTokenCount = maximumOutputTokens,
+        };
 
     private ExternalDependencyUnavailableException CreateUnavailableException(
         Exception exception)

--- a/tests/ContractIQ.IntegrationTests/FoundryChatCompatibilityTests.cs
+++ b/tests/ContractIQ.IntegrationTests/FoundryChatCompatibilityTests.cs
@@ -1,0 +1,16 @@
+using ContractIQ.Infrastructure.Assistant;
+using Xunit;
+
+namespace ContractIQ.IntegrationTests;
+
+public sealed class FoundryChatCompatibilityTests
+{
+    [Fact]
+    public void Uses_the_gpt5_compatible_completion_token_limit()
+    {
+        OpenAI.Chat.ChatCompletionOptions options =
+            ChatClientAssistantAnswerGenerator.CreateFoundryChatOptions(350);
+
+        Assert.Equal(350, options.MaxOutputTokenCount);
+    }
+}


### PR DESCRIPTION
## Outcome

Adds the GPT-5-compatible completion token parameter to the Foundry chat adapter.

## Live finding

The deployed gpt-5-mini endpoint and Entra authentication were healthy, but the provider-neutral Microsoft.Extensions.AI mapping sent max_tokens. GPT-5 rejected it and requires max_completion_tokens.

## Fix

- Omit generic MaxOutputTokens for the Foundry provider.
- Apply the same configured limit through OpenAI ChatCompletionOptions.MaxOutputTokenCount.
- Keep the Ollama and Kimi mappings unchanged.
- Document the provider compatibility boundary.

## Tests

- Foundry compatibility and configuration selection: 14 passed.
- The rejected live request generated no model answer.

Refs #53