### PR TITLE
feat(observability): correlate Azure AI workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,9 +130,9 @@ See [safe tool calling](docs/assistant/safe-tool-calling.md), [grounded answers]
 
 The required GitHub Actions workflow restores locked dependencies, audits NuGet and npm packages, verifies formatting, builds the solution, runs all tests, and executes the deterministic AI evaluator without hosted credentials or paid services.
 
-Current release-candidate coverage includes:
+Current coverage includes:
 
-- 167 backend tests across domain, application, integration, and AI evaluation projects;
+- 170 backend tests across domain, application, integration, and AI evaluation projects;
 - 15 React component and workflow tests;
 - 12 deterministic AI safety scenarios covering grounding, citation integrity, bilingual behavior, refusal, and tool routing.
 
@@ -161,7 +161,7 @@ npm run build
 | Fully local assistant | None                                                            | Adds approximately 2.5 GB for `qwen3:4b` and local CPU/RAM usage |
 | Kimi assistant        | Provider API credits only when a grounded question is submitted | Local PostgreSQL and embeddings remain required                  |
 | Aspire observability  | None                                                            | Optional local container and telemetry storage                   |
-| Optional Azure AI     | No cost until explicitly provisioned; Search Free has no hourly charge and Foundry inference consumes credit only when invoked | Local application and PostgreSQL remain available |
+| Optional Azure AI     | The development profile is provisioned; Search Free has no hourly charge and Foundry inference consumes credit only when invoked | Local application and PostgreSQL remain available |
 
 See [cost and resource management](docs/operations/cost-and-resources.md) for startup, storage, cleanup, credential removal, and the future Azure boundary.
 
@@ -198,6 +198,7 @@ docs/                         Architecture, decisions, operations and demo mater
 - [Microsoft Foundry model adapters](docs/azure/foundry-model-adapters.md)
 - [Azure AI Search adapter](docs/azure/azure-ai-search-adapter.md)
 - [Manual keyless Azure AI smoke test](docs/azure/manual-smoke-test.md)
+- [Azure AI live validation evidence](docs/azure/live-validation-2026-09-02.md)
 - [Azure infrastructure validation](infra/azure/README.md)
 - [v1.0.0 release checklist](docs/release/v1.0.0-checklist.md)
 - [Architecture Decision Records](docs/adr)
@@ -205,6 +206,6 @@ docs/                         Architecture, decisions, operations and demo mater
 
 ## Project status
 
-The local portfolio MVP is feature-complete and validated for the first `v1.0.0` release. The optional Microsoft Foundry and Azure AI Search adapters, non-deploying Azure infrastructure foundation, and manually dispatched OIDC smoke-test workflow are implemented incrementally. The workflow has not made a live call; provisioning and live Azure validation still require explicit approval. Microsoft Entra ID for end users remains a separate post-MVP item. None of these services is required to run or evaluate the local version.
+The local portfolio MVP is feature-complete and validated for the first `v1.0.0` release. The optional Microsoft Foundry and Azure AI Search development profile has also been provisioned and validated with bilingual grounded answers, keyless hybrid retrieval, correlated Aspire traces, and a separately confirmed CQRS action. Normal CI remains offline and non-billable; the manually dispatched GitHub OIDC workflow has not been required for ordinary pull requests. Microsoft Entra ID for end users remains a separate post-MVP item. None of the Azure services is required to run or evaluate the local version.
 
 ContractIQ uses fictional companies, contracts, policies, and rules. It is a software engineering demonstration and does not provide legal advice.

--- a/docs/azure/implementation-plan.md
+++ b/docs/azure/implementation-plan.md
@@ -36,15 +36,13 @@ ContractIQ does not deploy a second hosted agent in Foundry for this increment. 
 
 ## Delivery slices
 
-Status on 2026-08-31: the Azure foundation definitions, Foundry model adapters,
-Azure AI Search adapter, and bounded manual OIDC smoke-test workflow are
-implemented and validated without provisioning resources. Brazil South has
-live catalog capacity and subscription quota for `gpt-5-mini` version
-`2025-08-07` and `text-embedding-3-small` version `1` on `GlobalStandard`.
-Their Bicep deployments remain disabled by default and live execution still
-requires explicitly approved provisioning and GitHub environment configuration.
+Status on 2026-09-02: the cost-controlled foundation was provisioned in Brazil
+South and the Foundry chat/embedding adapters plus Azure AI Search hybrid adapter
+were validated end to end. Bicep model deployment remains opt-in for a fresh
+environment, normal CI makes no hosted call, and the local profile remains the
+default. See the [dated live evidence](live-validation-2026-09-02.md).
 
-### 1. Azure foundation — implemented, not deployed
+### 1. Azure foundation — deployed and verified
 
 - validate the subscription, ownership, quota, and provider availability;
 - review Bicep with a subscription budget, one resource group, a Foundry account/project, free Azure AI Search, and RBAC;
@@ -52,7 +50,7 @@ requires explicitly approved provisioning and GitHub environment configuration.
 - keep model resources behind `deployModels=false` until their live SKU, quota,
   cost boundary, and provisioning are explicitly approved.
 
-### 2. Foundry adapters — implemented, not invoked live
+### 2. Foundry adapters — implemented and invoked live
 
 - add a `Foundry` assistant provider without changing the local default;
 - authenticate with `DefaultAzureCredential` and the developer's Azure CLI session;
@@ -60,7 +58,7 @@ requires explicitly approved provisioning and GitHub environment configuration.
 - translate external failures to the existing safe application exceptions;
 - record dependency duration and result without prompt or document bodies.
 
-### 3. Azure AI Search adapters — implemented, not invoked live
+### 3. Azure AI Search adapters — implemented and invoked live
 
 - define a versioned index schema for document identity, scope, version, chunk text, citation metadata, and vectors;
 - generate embeddings through the application-owned Foundry adapter and push vectors to Search;
@@ -69,7 +67,7 @@ requires explicitly approved provisioning and GitHub environment configuration.
 - preserve customer and contract filters before ranking;
 - map Azure results to application-owned `KnowledgeEvidence` citations.
 
-### 4. CI and live validation — implemented, not invoked live
+### 4. CI and live validation — bounded local Azure run completed
 
 - compile Bicep on ordinary pull requests without Azure authentication;
 - run unit and simulated integration tests without hosted calls;
@@ -81,12 +79,21 @@ requires explicitly approved provisioning and GitHub environment configuration.
 - disable provider SDK retries for the bounded live run and publish only
   cost-relevant counts and duration.
 
+The local keyless smoke test, bilingual grounded chat, correlated indexing and
+assistant traces, and idempotent CQRS confirmation are complete. The manually
+dispatched GitHub OIDC workflow remains available as a separate CI identity
+demonstration and is never triggered by an ordinary push or pull request.
+
 ### 5. Documentation and portfolio proof
 
 - document local and Azure setup, indexing, querying, troubleshooting, cost inspection, and teardown;
 - capture a cited ACME answer and correlated Aspire trace;
 - demonstrate that the confirmed cancellation request still executes CQRS/domain logic;
 - update the interview guide, architecture diagram, release notes, and CV only after the live flow is verified.
+
+Live technical validation is complete. The remaining portfolio slice is the
+dated evaluation report, final interview material, CV wording, and teardown
+decision before the promotional-credit deadline.
 
 ## Acceptance criteria
 

--- a/docs/azure/live-validation-2026-09-02.md
+++ b/docs/azure/live-validation-2026-09-02.md
@@ -1,0 +1,126 @@
+# Azure AI live validation — 2026-09-02
+
+## Outcome
+
+The optional Azure profile was exercised end to end from the local ASP.NET Core
+application. Microsoft Foundry generated embeddings and the assistant answer,
+Azure AI Search performed scoped hybrid retrieval, and PostgreSQL remained the
+system of record for structured data and cancellation requests.
+
+The validation did not host the API, React application, or PostgreSQL in Azure.
+The default local profile remains independent from Azure.
+
+## Environment
+
+- Foundry chat deployment: `contractiq-chat`, `gpt-5-mini` 2025-08-07,
+  GlobalStandard, 10K TPM;
+- Foundry embedding deployment: `contractiq-embeddings`,
+  `text-embedding-3-small` v1, GlobalStandard, 1K TPM;
+- Azure AI Search: `srch-contractiq-dev-7ip435`, Free;
+- primary knowledge index: `contractiq-knowledge-v1`, 22 fictional chunks;
+- authentication: Microsoft Entra through `AzureCliCredential`, with no local
+  service key;
+- Foundry and Search SDK retries: zero for the bounded validation;
+- telemetry backend: local .NET Aspire Dashboard through OTLP.
+
+## Correlated evidence
+
+### Indexing
+
+Trace `cb0b47f9f3871283e98b69e0d900712f` contains 57 spans in one tree:
+
+```text
+contractiq.knowledge.index
+└── contractiq.knowledge.document.index (five documents)
+    ├── contractiq.knowledge.index.check
+    │   └── Azure AI Search version check
+    ├── contractiq.knowledge.embedding.generate
+    │   └── contractiq.ai.embedding.request
+    │       └── Foundry HTTP request
+    └── contractiq.knowledge.index.replace
+        └── Azure AI Search upload requests
+```
+
+The successful captured run indexed five fictional documents as 22 chunks in
+12.11 seconds.
+
+### Retrieval, model, and read tools
+
+Trace `61e6e509e764ceec1b42e43753247477` contains the complete action-preparation
+request:
+
+```text
+POST /api/v1/assistant/answers
+└── contractiq.assistant.ask
+    ├── PostgreSQL contract query
+    ├── contractiq.knowledge.search
+    │   ├── Foundry query embedding
+    │   └── Azure AI Search hybrid retrieval
+    └── contractiq.ai.model.generate
+        ├── Foundry chat request
+        ├── deterministic cancellation assessment tool
+        └── cancellation preparation tool
+```
+
+The response used deployment `contractiq-chat`, returned eight application-owned
+citations, and proposed `create_cancellation_request` with explicit confirmation
+required. No write occurred during model invocation.
+
+### Confirmed CQRS boundary
+
+Trace `be497206ffbea6234130fdbb46fd224c` contains:
+
+```text
+POST /api/v1/assistant/actions/cancellation-requests
+└── contractiq.assistant.tool.execute
+    └── contractiq.cancellation.create
+        └── PostgreSQL idempotency lookup
+```
+
+The local database already contained an open ACME request. The validation reused
+its original idempotency key and returned HTTP 200 with outcome `replayed`; it did
+not create or alter a row. This proves that the confirmed agent action still
+crosses the application-owned CQRS handler and idempotency boundary. Automated
+tests cover both the initial `created` outcome and the subsequent `replayed`
+outcome.
+
+## Telemetry privacy inspection
+
+The Aspire span detail was inspected for the read tool and state-changing tool.
+Exported attributes contained operation name, allow-listed tool name, outcome,
+provider/model metadata, counts, and state-changing classification.
+
+They did not contain:
+
+- user question, system prompt, answer, or retrieved chunk text;
+- document key, title, source path, or document content;
+- customer, contract, cancellation-request, or chunk identifiers;
+- idempotency key, access token, API key, connection string, or authorization
+  header.
+
+Automated activity-listener tests enforce the indexing and confirmed-command
+correlation and assert that representative business content and identifiers are
+absent from application-owned tags.
+
+## Cost and cleanup record
+
+The first indexing attempt exposed that the console host had not been started,
+so logs arrived but activities were not exported. It still completed five
+bounded embedding batches covering 22 short fictional chunks. After fixing the
+host lifecycle, the temporary Search index was removed and one equivalent run
+was made to capture the trace. Total indexing diagnostics therefore used ten
+embedding requests and 44 chunk inputs, with zero automatic retries.
+
+The agent evidence added one query embedding and one bounded chat request. The
+confirmation replay was local and made no model or Search request. A mistaken
+local endpoint path returned HTTP 404 before application execution and made no
+Azure call.
+
+Temporary index `contractiq-telemetry-v1` was deleted after capture. A direct
+read returned `No index with the name ... was found`, confirming cleanup. The
+primary `contractiq-knowledge-v1` index and the reviewed portfolio resources
+remain available for the next evaluation slice.
+
+Review the paid-capable resources by 2026-09-27 and delete the development
+resource group before the assumed 2026-09-30 promotional-credit expiry when it
+is no longer required.

--- a/docs/observability/local-telemetry.md
+++ b/docs/observability/local-telemetry.md
@@ -48,6 +48,32 @@ A confirmed cancellation adds `contractiq.assistant.tool.execute` and
 `contractiq.cancellation.create` spans. PostgreSQL command spans are emitted by
 Npgsql and remain children of the same request trace.
 
+The document indexer can export its own short-lived trace to the same dashboard.
+Set the telemetry variables in the terminal that runs the indexer:
+
+```powershell
+$env:OpenTelemetry__Enabled = 'true'
+$env:OpenTelemetry__OtlpEndpoint = 'http://localhost:4317'
+dotnet run --project tools/ContractIQ.DocumentIndexer
+```
+
+The indexer starts and stops its .NET host explicitly so the OpenTelemetry
+providers are activated and flushed before the console process exits. A changed
+document produces this correlated tree:
+
+```text
+contractiq.knowledge.index
+└── contractiq.knowledge.document.index
+    ├── contractiq.knowledge.index.check
+    ├── contractiq.knowledge.embedding.generate
+    │   └── provider embedding request
+    └── contractiq.knowledge.index.replace
+        └── PostgreSQL or Azure AI Search dependency request
+```
+
+An unchanged document ends after the check span with outcome `skipped`; it does
+not generate embeddings or replace index data.
+
 ## Correlation
 
 Every HTTP response includes `X-Correlation-ID`. The value is the W3C trace ID
@@ -69,6 +95,8 @@ addition to these application-owned measurements:
 - `contractiq.assistant.requests` and `contractiq.assistant.request.duration`;
 - `contractiq.assistant.evidence.count` and `contractiq.assistant.citation.count`;
 - `contractiq.knowledge.searches`, duration, and result count;
+- `contractiq.knowledge.indexing.runs`, duration, indexed document count, and
+  indexed chunk count;
 - `contractiq.ai.model.requests`, duration, and provider-reported token counts;
 - `contractiq.assistant.tool.calls` by tool, outcome, and state-changing class;
 - `contractiq.cancellation.commands` and command duration.
@@ -90,9 +118,11 @@ Standard ASP.NET Core server spans keep the matched route template, such as
 path/full-URL attributes before export so route values cannot carry contract IDs.
 
 Safe dimensions include operation name, provider and model name, language,
-outcome, duration, counts, and whether a tool is state-changing. The model HTTP
-instrumentation uses standard request metadata and does not capture request or
-response bodies. EF Core parameter value logging is not enabled.
+document type, outcome, duration, counts, and whether a tool is state-changing.
+Document titles, keys, paths, checksums, and business identifiers are not span
+attributes. The model HTTP instrumentation uses standard request metadata and
+does not capture request or response bodies. EF Core parameter value logging is
+not enabled.
 
 Tool audit events retain business identifiers inside the application boundary so
 a future authorized audit store can enforce access controls. The current exported

--- a/docs/operations/cost-and-resources.md
+++ b/docs/operations/cost-and-resources.md
@@ -112,17 +112,23 @@ Build outputs can be recreated and are excluded from Git. Use the standard IDE o
 
 ## Azure boundary and teardown
 
-ContractIQ v1 remains locally runnable without Azure credentials or automatic provisioning. The post-v1 roadmap now contains reviewed Bicep under `infra/azure`, but merely cloning, building, or testing it does not create resources. Therefore:
+ContractIQ v1 remains locally runnable without Azure credentials or automatic
+provisioning. The optional development resources were provisioned on 2026-09-01
+after an explicit review, but merely cloning, building, or testing the repository
+still does not create or invoke them. Therefore:
 
 - cloning, building, testing, and demonstrating v1 creates no Azure resource;
-- no Azure resource group exists until an explicit subscription deployment is approved;
-- Microsoft Foundry and Azure AI Search adapters are implemented but remain optional and are not local runtime dependencies;
+- `rg-contractiq-ai-dev` exists only for the explicitly approved portfolio
+  validation and must not be treated as a prerequisite;
+- Microsoft Foundry and Azure AI Search adapters remain optional and are not
+  local runtime dependencies;
 - the free Search profile stays keyless for inbound application calls through Entra RBAC, while application-owned code generates and uploads embeddings;
 - Search-managed outbound identity, integrated vectorization, semantic ranking, and dedicated capacity remain a documented Basic-or-higher production evolution;
 - issue #13 records resource assumptions, budgets, keyless authentication, infrastructure as code, and the exact teardown boundary before deployment;
 - the USD 10 budget is an alerting target, not a hard spending cap;
-- model deployments remain disabled by default until live region, SKU, version,
-  quota, and cost checks are reviewed and provisioning is explicitly approved.
+- model deployments remain disabled by default for a new deployment even though
+  the reviewed development environment currently has `contractiq-chat` and
+  `contractiq-embeddings` available.
 
 The optional Azure smoke workflow also remains inert until a person selects the
 `azure-dev` environment in GitHub Actions. One run makes one Foundry embedding
@@ -132,4 +138,7 @@ the resulting count/duration report is retained for seven days. See the
 [manual keyless smoke-test guide](../azure/manual-smoke-test.md) for setup,
 execution, and revocation.
 
-This boundary prevents a documentation example from accidentally creating a chargeable cloud resource.
+The dated [Azure live-validation record](../azure/live-validation-2026-09-02.md)
+lists the exact bounded calls, trace evidence, temporary-index cleanup, and
+remaining review dates. This boundary prevents a documentation example or
+ordinary CI run from accidentally creating a chargeable cloud resource.

--- a/infra/azure/README.md
+++ b/infra/azure/README.md
@@ -73,3 +73,49 @@ only one bounded indexing/query scenario.
 All billable-capable resources are kept in the exact resource group `rg-contractiq-ai-dev`. After preserving any required screenshots and validation evidence, delete that resource group from the Azure portal or with an explicitly reviewed CLI command. The subscription-level budget can then be removed separately.
 
 Deletion is intentionally not automated from a pull request or a normal CI run.
+
+### Exact reviewed teardown procedure
+
+Do not run these deletion commands until the portfolio evidence has been
+preserved and the owner has explicitly approved teardown. First verify the
+active subscription and exact targets:
+
+```powershell
+az account show --query "{Name:name, SubscriptionId:id, TenantId:tenantId}" --output table
+az resource list --resource-group rg-contractiq-ai-dev `
+  --query "[].{Name:name, Type:type, Location:location}" `
+  --output table
+az consumption budget show `
+  --budget-name budget-contractiq-ai-dev `
+  --output table
+```
+
+The expected resource group contains only the ContractIQ Foundry account and
+project, its two model deployments, Azure AI Search, and their role assignments.
+The budget is subscription-scoped and therefore is not removed with the group.
+
+After explicit approval, delete the isolated resource group and wait for Azure
+to report that it no longer exists:
+
+```powershell
+az group delete --name rg-contractiq-ai-dev --yes --no-wait
+az group wait --name rg-contractiq-ai-dev --deleted
+```
+
+Then remove the separate alert budget:
+
+```powershell
+az consumption budget delete --budget-name budget-contractiq-ai-dev
+```
+
+Finally verify both cleanup boundaries:
+
+```powershell
+az group exists --name rg-contractiq-ai-dev
+az consumption budget show --budget-name budget-contractiq-ai-dev
+```
+
+The expected group result is `false`; the budget lookup should report that the
+budget is not found. Record the UTC deletion date in issue #53. Deleting this
+Azure group does not remove the local repository, PostgreSQL volume, Aspire
+dashboard, GitHub repository, or local user secrets.

--- a/src/ContractIQ.Application/Common/Observability/ContractIqTelemetry.cs
+++ b/src/ContractIQ.Application/Common/Observability/ContractIqTelemetry.cs
@@ -42,6 +42,21 @@ public static class ContractIqTelemetry
         "contractiq.knowledge.search.result.count",
         unit: "{item}",
         description: "Evidence items returned by hybrid search.");
+    private static readonly Counter<long> KnowledgeIndexingRuns = Meter.CreateCounter<long>(
+        "contractiq.knowledge.indexing.runs",
+        description: "Number of knowledge indexing runs.");
+    private static readonly Histogram<double> KnowledgeIndexingDuration = Meter.CreateHistogram<double>(
+        "contractiq.knowledge.indexing.duration",
+        unit: "s",
+        description: "End-to-end knowledge indexing duration.");
+    private static readonly Histogram<long> KnowledgeIndexedDocumentCount = Meter.CreateHistogram<long>(
+        "contractiq.knowledge.indexing.document.count",
+        unit: "{item}",
+        description: "Documents indexed by a knowledge indexing run.");
+    private static readonly Histogram<long> KnowledgeIndexedChunkCount = Meter.CreateHistogram<long>(
+        "contractiq.knowledge.indexing.chunk.count",
+        unit: "{item}",
+        description: "Chunks indexed by a knowledge indexing run.");
     private static readonly Counter<long> KnowledgeIndexDependencyRequests = Meter.CreateCounter<long>(
         "contractiq.knowledge.index.dependency.requests",
         description: "Number of knowledge-index dependency operations.");
@@ -123,6 +138,23 @@ public static class ContractIqTelemetry
         KnowledgeSearches.Add(1, tags);
         KnowledgeSearchDuration.Record(duration.TotalSeconds, tags);
         KnowledgeSearchResultCount.Record(resultCount, tags);
+    }
+
+    public static void RecordKnowledgeIndexing(
+        string outcome,
+        TimeSpan duration,
+        int indexedDocuments,
+        int indexedChunks)
+    {
+        var tags = new TagList
+        {
+            { "contractiq.outcome", outcome },
+        };
+
+        KnowledgeIndexingRuns.Add(1, tags);
+        KnowledgeIndexingDuration.Record(duration.TotalSeconds, tags);
+        KnowledgeIndexedDocumentCount.Record(indexedDocuments, tags);
+        KnowledgeIndexedChunkCount.Record(indexedChunks, tags);
     }
 
     public static void RecordKnowledgeIndexDependency(

--- a/src/ContractIQ.Application/Knowledge/Indexing/IndexKnowledgeDocumentsHandler.cs
+++ b/src/ContractIQ.Application/Knowledge/Indexing/IndexKnowledgeDocumentsHandler.cs
@@ -1,4 +1,6 @@
+using System.Diagnostics;
 using System.Text;
+using ContractIQ.Application.Common.Observability;
 
 namespace ContractIQ.Application.Knowledge.Indexing;
 
@@ -11,16 +13,132 @@ public sealed class IndexKnowledgeDocumentsHandler(
     public async Task<IndexKnowledgeDocumentsResult> HandleAsync(
         CancellationToken cancellationToken = default)
     {
-        IReadOnlyList<KnowledgeDocumentSource> documents =
-            await catalog.ReadAllAsync(cancellationToken);
-
+        long startedAt = Stopwatch.GetTimestamp();
         int indexedDocuments = 0;
         int skippedDocuments = 0;
         int indexedChunks = 0;
+        using Activity? activity = ContractIqTelemetry.StartActivity(
+            "contractiq.knowledge.index");
 
-        foreach (KnowledgeDocumentSource document in documents)
+        try
         {
-            string checksum = ComputeDocumentChecksum(document);
+            IReadOnlyList<KnowledgeDocumentSource> documents =
+                await catalog.ReadAllAsync(cancellationToken);
+            activity?.SetTag("contractiq.knowledge.document.discovered.count", documents.Count);
+
+            foreach (KnowledgeDocumentSource document in documents)
+            {
+                using Activity? documentActivity = ContractIqTelemetry.StartActivity(
+                    "contractiq.knowledge.document.index");
+                documentActivity?.SetTag(
+                    "contractiq.knowledge.document.type",
+                    document.DocumentType.ToString().ToLowerInvariant());
+                documentActivity?.SetTag(
+                    "contractiq.knowledge.document.language",
+                    document.Language);
+
+                try
+                {
+                    string checksum = ComputeDocumentChecksum(document);
+                    bool isCurrent = await IsCurrentAsync(
+                        document,
+                        checksum,
+                        cancellationToken);
+
+                    if (isCurrent)
+                    {
+                        skippedDocuments++;
+                        documentActivity?.SetTag("contractiq.outcome", "skipped");
+                        documentActivity?.SetStatus(ActivityStatusCode.Ok);
+                        continue;
+                    }
+
+                    IReadOnlyList<KnowledgeChunkDraft> drafts = chunker.Chunk(document.Content);
+                    IReadOnlyList<float[]> embeddings = await GenerateEmbeddingsAsync(
+                        drafts,
+                        cancellationToken);
+
+                    if (embeddings.Count != drafts.Count ||
+                        embeddings.Any(embedding => embedding.Length != embeddingGenerator.Dimensions))
+                    {
+                        throw new InvalidOperationException(
+                            $"Embedding model '{embeddingGenerator.ModelId}' returned an unexpected shape.");
+                    }
+
+                    KnowledgeChunk[] chunks = drafts
+                        .Select((draft, index) => new KnowledgeChunk(
+                            draft.Index,
+                            draft.Section,
+                            draft.Page,
+                            draft.Content,
+                            draft.Checksum,
+                            embeddings[index]))
+                        .ToArray();
+
+                    await ReplaceAsync(
+                        document,
+                        checksum,
+                        chunks,
+                        cancellationToken);
+
+                    indexedDocuments++;
+                    indexedChunks += chunks.Length;
+                    documentActivity?.SetTag("contractiq.outcome", "indexed");
+                    documentActivity?.SetTag(
+                        "contractiq.knowledge.chunk.count",
+                        chunks.Length);
+                    documentActivity?.SetStatus(ActivityStatusCode.Ok);
+                }
+                catch (Exception exception)
+                {
+                    ContractIqTelemetry.MarkError(documentActivity, exception);
+                    throw;
+                }
+            }
+
+            activity?.SetTag("contractiq.knowledge.document.indexed.count", indexedDocuments);
+            activity?.SetTag("contractiq.knowledge.document.skipped.count", skippedDocuments);
+            activity?.SetTag("contractiq.knowledge.chunk.indexed.count", indexedChunks);
+            activity?.SetTag("contractiq.outcome", "succeeded");
+            activity?.SetStatus(ActivityStatusCode.Ok);
+            ContractIqTelemetry.RecordKnowledgeIndexing(
+                "succeeded",
+                Stopwatch.GetElapsedTime(startedAt),
+                indexedDocuments,
+                indexedChunks);
+
+            return new IndexKnowledgeDocumentsResult(
+                indexedDocuments,
+                skippedDocuments,
+                indexedChunks);
+        }
+        catch (Exception exception)
+        {
+            string outcome = exception is OperationCanceledException
+                ? "cancelled"
+                : "failed";
+
+            ContractIqTelemetry.MarkError(activity, exception);
+            ContractIqTelemetry.RecordKnowledgeIndexing(
+                outcome,
+                Stopwatch.GetElapsedTime(startedAt),
+                indexedDocuments,
+                indexedChunks);
+            throw;
+        }
+    }
+
+    private async Task<bool> IsCurrentAsync(
+        KnowledgeDocumentSource document,
+        string checksum,
+        CancellationToken cancellationToken)
+    {
+        using Activity? activity = ContractIqTelemetry.StartActivity(
+            "contractiq.knowledge.index.check");
+        activity?.SetTag("gen_ai.request.model", embeddingGenerator.ModelId);
+
+        try
+        {
             bool isCurrent = await knowledgeIndex.IsCurrentAsync(
                 document.DocumentKey,
                 document.Version,
@@ -28,49 +146,67 @@ public sealed class IndexKnowledgeDocumentsHandler(
                 embeddingGenerator.ModelId,
                 cancellationToken);
 
-            if (isCurrent)
-            {
-                skippedDocuments++;
-                continue;
-            }
+            activity?.SetTag("contractiq.knowledge.index.current", isCurrent);
+            activity?.SetStatus(ActivityStatusCode.Ok);
+            return isCurrent;
+        }
+        catch (Exception exception)
+        {
+            ContractIqTelemetry.MarkError(activity, exception);
+            throw;
+        }
+    }
 
-            IReadOnlyList<KnowledgeChunkDraft> drafts = chunker.Chunk(document.Content);
+    private async Task<IReadOnlyList<float[]>> GenerateEmbeddingsAsync(
+        IReadOnlyList<KnowledgeChunkDraft> drafts,
+        CancellationToken cancellationToken)
+    {
+        using Activity? activity = ContractIqTelemetry.StartActivity(
+            "contractiq.knowledge.embedding.generate");
+        activity?.SetTag("gen_ai.request.model", embeddingGenerator.ModelId);
+        activity?.SetTag("contractiq.knowledge.embedding.input.count", drafts.Count);
+
+        try
+        {
             IReadOnlyList<float[]> embeddings = await embeddingGenerator.GenerateAsync(
                 drafts.Select(chunk => chunk.Content).ToArray(),
                 cancellationToken);
 
-            if (embeddings.Count != drafts.Count ||
-                embeddings.Any(embedding => embedding.Length != embeddingGenerator.Dimensions))
-            {
-                throw new InvalidOperationException(
-                    $"Embedding model '{embeddingGenerator.ModelId}' returned an unexpected shape.");
-            }
+            activity?.SetStatus(ActivityStatusCode.Ok);
+            return embeddings;
+        }
+        catch (Exception exception)
+        {
+            ContractIqTelemetry.MarkError(activity, exception);
+            throw;
+        }
+    }
 
-            KnowledgeChunk[] chunks = drafts
-                .Select((draft, index) => new KnowledgeChunk(
-                    draft.Index,
-                    draft.Section,
-                    draft.Page,
-                    draft.Content,
-                    draft.Checksum,
-                    embeddings[index]))
-                .ToArray();
+    private async Task ReplaceAsync(
+        KnowledgeDocumentSource document,
+        string checksum,
+        IReadOnlyList<KnowledgeChunk> chunks,
+        CancellationToken cancellationToken)
+    {
+        using Activity? activity = ContractIqTelemetry.StartActivity(
+            "contractiq.knowledge.index.replace");
+        activity?.SetTag("contractiq.knowledge.chunk.count", chunks.Count);
 
+        try
+        {
             await knowledgeIndex.ReplaceAsync(
                 document,
                 checksum,
                 embeddingGenerator.ModelId,
                 chunks,
                 cancellationToken);
-
-            indexedDocuments++;
-            indexedChunks += chunks.Length;
+            activity?.SetStatus(ActivityStatusCode.Ok);
         }
-
-        return new IndexKnowledgeDocumentsResult(
-            indexedDocuments,
-            skippedDocuments,
-            indexedChunks);
+        catch (Exception exception)
+        {
+            ContractIqTelemetry.MarkError(activity, exception);
+            throw;
+        }
     }
 
     private static string ComputeDocumentChecksum(KnowledgeDocumentSource document)

--- a/tests/ContractIQ.Application.Tests/Assistant/CancellationAssistantToolsTests.cs
+++ b/tests/ContractIQ.Application.Tests/Assistant/CancellationAssistantToolsTests.cs
@@ -1,6 +1,8 @@
+using System.Diagnostics;
 using ContractIQ.Application.Assistant.Tools;
 using ContractIQ.Application.Cancellations.CreateCancellationRequest;
 using ContractIQ.Application.Common.Exceptions;
+using ContractIQ.Application.Common.Observability;
 using ContractIQ.Application.Contracts.AssessCancellation;
 using ContractIQ.Application.Contracts.GetContractDetails;
 using ContractIQ.Application.Knowledge;
@@ -108,6 +110,77 @@ public sealed class CancellationAssistantToolsTests
         Assert.Single(store.Requests);
         Assert.Contains(audit.Events, item => item.Outcome == "created");
         Assert.Contains(audit.Events, item => item.Outcome == "replayed");
+    }
+
+    [Fact]
+    public async Task Write_tool_correlates_confirmation_and_command_without_business_identifiers()
+    {
+        var contract = ApplicationTestData.CreateContract();
+        var repository = new FakeContractRepository(contract);
+        var store = new FakeCancellationRequestStore();
+        var audit = new FakeAssistantToolAudit();
+        var handler = CreateWriteHandler(repository, store, audit);
+        const string idempotencyKey = "telemetry-request-001";
+        ConfirmCancellationActionCommand command = Command(
+            contract,
+            confirmed: true,
+            idempotencyKey);
+        var completedActivities = new List<Activity>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = activitySource =>
+                activitySource.Name is ContractIqTelemetry.ActivitySourceName or
+                    "ContractIQ.Application.Tests",
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) =>
+                ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStopped = completedActivities.Add,
+        };
+        ActivitySource.AddActivityListener(listener);
+        using var testSource = new ActivitySource("ContractIQ.Application.Tests");
+
+        Activity root = testSource.StartActivity("test.confirmation.request")!;
+        ActivityTraceId expectedTraceId = root.TraceId;
+        await handler.HandleAsync(command);
+        await handler.HandleAsync(command);
+        root.Stop();
+
+        Activity[] toolActivities = completedActivities
+            .Where(activity =>
+                activity.Source.Name == ContractIqTelemetry.ActivitySourceName &&
+                activity.TraceId == expectedTraceId &&
+                activity.OperationName == "contractiq.assistant.tool.execute")
+            .OrderBy(activity => activity.StartTimeUtc)
+            .ToArray();
+        Activity[] commandActivities = completedActivities
+            .Where(activity =>
+                activity.Source.Name == ContractIqTelemetry.ActivitySourceName &&
+                activity.TraceId == expectedTraceId &&
+                activity.OperationName == "contractiq.cancellation.create")
+            .OrderBy(activity => activity.StartTimeUtc)
+            .ToArray();
+
+        Assert.Equal(2, toolActivities.Length);
+        Assert.Equal(2, commandActivities.Length);
+        Assert.Equal("created", toolActivities[0].GetTagItem("contractiq.outcome"));
+        Assert.Equal("replayed", toolActivities[1].GetTagItem("contractiq.outcome"));
+        Assert.Equal(false, commandActivities[0].GetTagItem("contractiq.command.is_replay"));
+        Assert.Equal(true, commandActivities[1].GetTagItem("contractiq.command.is_replay"));
+        Assert.Equal(toolActivities[0].SpanId, commandActivities[0].ParentSpanId);
+        Assert.Equal(toolActivities[1].SpanId, commandActivities[1].ParentSpanId);
+        Assert.All(toolActivities, activity => Assert.Equal(root.SpanId, activity.ParentSpanId));
+        Assert.All(
+            toolActivities.Concat(commandActivities),
+            activity => Assert.Equal(ActivityStatusCode.Ok, activity.Status));
+
+        string exportedTags = string.Join(
+            '|',
+            toolActivities.Concat(commandActivities)
+                .SelectMany(activity => activity.TagObjects)
+                .Select(tag => $"{tag.Key}={tag.Value}"));
+
+        Assert.DoesNotContain(idempotencyKey, exportedTags, StringComparison.Ordinal);
+        Assert.DoesNotContain(contract.CustomerId.ToString(), exportedTags, StringComparison.Ordinal);
+        Assert.DoesNotContain(contract.Id.ToString(), exportedTags, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/ContractIQ.Application.Tests/Knowledge/IndexKnowledgeDocumentsHandlerTests.cs
+++ b/tests/ContractIQ.Application.Tests/Knowledge/IndexKnowledgeDocumentsHandlerTests.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+using ContractIQ.Application.Common.Observability;
 using ContractIQ.Application.Knowledge;
 using ContractIQ.Application.Knowledge.Indexing;
 using Xunit;
@@ -26,6 +28,77 @@ public sealed class IndexKnowledgeDocumentsHandlerTests
         Assert.Equal(0, second.IndexedDocuments);
         Assert.Equal(1, second.SkippedDocuments);
         Assert.Equal(1, index.ReplaceCount);
+    }
+
+    [Fact]
+    public async Task HandleAsync_correlates_indexing_spans_without_document_content_or_identifiers()
+    {
+        KnowledgeDocumentSource source = CreateSource();
+        var completedActivities = new List<Activity>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = activitySource =>
+                activitySource.Name is ContractIqTelemetry.ActivitySourceName or
+                    "ContractIQ.Application.Tests",
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) =>
+                ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStopped = completedActivities.Add,
+        };
+        ActivitySource.AddActivityListener(listener);
+        using var testSource = new ActivitySource("ContractIQ.Application.Tests");
+
+        var handler = new IndexKnowledgeDocumentsHandler(
+            new Catalog(source),
+            new Embeddings(),
+            new InMemoryKnowledgeIndex(),
+            new MarkdownKnowledgeChunker());
+
+        Activity root = testSource.StartActivity("test.indexing.request")!;
+        ActivityTraceId expectedTraceId = root.TraceId;
+        await handler.HandleAsync();
+        root.Stop();
+
+        Activity[] indexingActivities = completedActivities
+            .Where(activity =>
+                activity.Source.Name == ContractIqTelemetry.ActivitySourceName &&
+                activity.TraceId == expectedTraceId)
+            .ToArray();
+
+        Activity indexing = Assert.Single(
+            indexingActivities,
+            activity => activity.OperationName == "contractiq.knowledge.index");
+        Activity document = Assert.Single(
+            indexingActivities,
+            activity => activity.OperationName == "contractiq.knowledge.document.index");
+        Activity check = Assert.Single(
+            indexingActivities,
+            activity => activity.OperationName == "contractiq.knowledge.index.check");
+        Activity embeddings = Assert.Single(
+            indexingActivities,
+            activity => activity.OperationName == "contractiq.knowledge.embedding.generate");
+        Activity replace = Assert.Single(
+            indexingActivities,
+            activity => activity.OperationName == "contractiq.knowledge.index.replace");
+
+        Assert.Equal(root.SpanId, indexing.ParentSpanId);
+        Assert.Equal(indexing.SpanId, document.ParentSpanId);
+        Assert.Equal(document.SpanId, check.ParentSpanId);
+        Assert.Equal(document.SpanId, embeddings.ParentSpanId);
+        Assert.Equal(document.SpanId, replace.ParentSpanId);
+        Assert.All(indexingActivities, activity =>
+            Assert.Equal(ActivityStatusCode.Ok, activity.Status));
+
+        string exportedTags = string.Join(
+            '|',
+            indexingActivities.SelectMany(activity => activity.TagObjects)
+                .Select(tag => $"{tag.Key}={tag.Value}"));
+
+        Assert.DoesNotContain(source.DocumentKey, exportedTags, StringComparison.Ordinal);
+        Assert.DoesNotContain(source.Title, exportedTags, StringComparison.Ordinal);
+        Assert.DoesNotContain(source.SourcePath, exportedTags, StringComparison.Ordinal);
+        Assert.DoesNotContain(source.Content, exportedTags, StringComparison.Ordinal);
+        Assert.DoesNotContain(source.CustomerId!.Value.ToString(), exportedTags, StringComparison.Ordinal);
+        Assert.DoesNotContain(source.ContractId!.Value.ToString(), exportedTags, StringComparison.Ordinal);
     }
 
     private static KnowledgeDocumentSource CreateSource() => new(

--- a/tools/ContractIQ.DocumentIndexer/ContractIQ.DocumentIndexer.csproj
+++ b/tools/ContractIQ.DocumentIndexer/ContractIQ.DocumentIndexer.csproj
@@ -10,6 +10,11 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Npgsql.OpenTelemetry" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/ContractIQ.DocumentIndexer/DocumentIndexerOpenTelemetryExtensions.cs
+++ b/tools/ContractIQ.DocumentIndexer/DocumentIndexerOpenTelemetryExtensions.cs
@@ -1,0 +1,81 @@
+using ContractIQ.Application.Common.Observability;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Npgsql;
+using OpenTelemetry.Logs;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+
+internal static class DocumentIndexerOpenTelemetryExtensions
+{
+    public static HostApplicationBuilder AddDocumentIndexerOpenTelemetry(
+        this HostApplicationBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        IConfigurationSection section = builder.Configuration.GetSection("OpenTelemetry");
+        bool enabled = bool.TryParse(section["Enabled"], out bool configuredEnabled) &&
+            configuredEnabled;
+
+        if (!enabled)
+        {
+            return builder;
+        }
+
+        string serviceName = section["ServiceName"]?.Trim() ??
+            "ContractIQ.DocumentIndexer";
+        string endpointValue = section["OtlpEndpoint"]?.Trim() ??
+            "http://localhost:4317";
+
+        if (string.IsNullOrWhiteSpace(serviceName))
+        {
+            throw new InvalidOperationException(
+                "OpenTelemetry:ServiceName must not be empty.");
+        }
+
+        if (!Uri.TryCreate(endpointValue, UriKind.Absolute, out Uri? endpoint) ||
+            endpoint.Scheme is not ("http" or "https"))
+        {
+            throw new InvalidOperationException(
+                "OpenTelemetry:OtlpEndpoint must be an absolute HTTP or HTTPS URI.");
+        }
+
+        string serviceVersion = typeof(Program).Assembly
+            .GetName()
+            .Version?
+            .ToString() ?? "unknown";
+        ResourceBuilder resource = ResourceBuilder
+            .CreateDefault()
+            .AddService(serviceName, serviceVersion: serviceVersion);
+
+        builder.Services
+            .AddOpenTelemetry()
+            .ConfigureResource(resourceBuilder =>
+                resourceBuilder.AddService(serviceName, serviceVersion: serviceVersion))
+            .WithTracing(tracing => tracing
+                .AddSource(ContractIqTelemetry.ActivitySourceName)
+                .AddHttpClientInstrumentation()
+                .AddNpgsql()
+                .AddOtlpExporter(exporter => exporter.Endpoint = endpoint))
+            .WithMetrics(metrics => metrics
+                .SetExemplarFilter(ExemplarFilterType.TraceBased)
+                .AddMeter(ContractIqTelemetry.MeterName)
+                .AddNpgsqlInstrumentation(_ => { })
+                .AddHttpClientInstrumentation()
+                .AddRuntimeInstrumentation()
+                .AddOtlpExporter(exporter => exporter.Endpoint = endpoint));
+
+        builder.Logging.AddOpenTelemetry(logging =>
+        {
+            logging.IncludeFormattedMessage = true;
+            logging.IncludeScopes = true;
+            logging.SetResourceBuilder(resource);
+            logging.AddOtlpExporter(exporter => exporter.Endpoint = endpoint);
+        });
+
+        return builder;
+    }
+}

--- a/tools/ContractIQ.DocumentIndexer/Program.cs
+++ b/tools/ContractIQ.DocumentIndexer/Program.cs
@@ -9,6 +9,7 @@ var builder = Host.CreateApplicationBuilder(new HostApplicationBuilderSettings
     Args = args,
     ContentRootPath = AppContext.BaseDirectory,
 });
+builder.AddDocumentIndexerOpenTelemetry();
 
 builder.Services.AddSingleton(TimeProvider.System);
 builder.Services.AddSingleton<MarkdownKnowledgeChunker>();
@@ -16,14 +17,25 @@ builder.Services.AddScoped<IndexKnowledgeDocumentsHandler>();
 builder.Services.AddInfrastructure(builder.Configuration);
 
 using IHost host = builder.Build();
-await host.Services.InitializeDatabaseAsync();
+await host.StartAsync();
 
-await using AsyncServiceScope scope = host.Services.CreateAsyncScope();
-IndexKnowledgeDocumentsResult result = await scope.ServiceProvider
-    .GetRequiredService<IndexKnowledgeDocumentsHandler>()
-    .HandleAsync();
+try
+{
+    await host.Services.InitializeDatabaseAsync();
 
-Console.WriteLine(
-    $"Knowledge index ready. Indexed documents: {result.IndexedDocuments}; " +
-    $"skipped unchanged documents: {result.SkippedDocuments}; " +
-    $"new chunks: {result.IndexedChunks}.");
+    await using AsyncServiceScope scope = host.Services.CreateAsyncScope();
+    IndexKnowledgeDocumentsResult result = await scope.ServiceProvider
+        .GetRequiredService<IndexKnowledgeDocumentsHandler>()
+        .HandleAsync();
+
+    Console.WriteLine(
+        $"Knowledge index ready. Indexed documents: {result.IndexedDocuments}; " +
+        $"skipped unchanged documents: {result.SkippedDocuments}; " +
+        $"new chunks: {result.IndexedChunks}.");
+}
+finally
+{
+    // Starting and stopping the host activates and flushes the optional
+    // OpenTelemetry exporters before this short-lived process exits.
+    await host.StopAsync();
+}

--- a/tools/ContractIQ.DocumentIndexer/appsettings.json
+++ b/tools/ContractIQ.DocumentIndexer/appsettings.json
@@ -20,5 +20,10 @@
   "AzureSearch": {
     "Endpoint": "",
     "IndexName": "contractiq-knowledge-v1"
+  },
+  "OpenTelemetry": {
+    "Enabled": false,
+    "ServiceName": "ContractIQ.DocumentIndexer",
+    "OtlpEndpoint": "http://localhost:4317"
   }
 }

--- a/tools/ContractIQ.DocumentIndexer/packages.lock.json
+++ b/tools/ContractIQ.DocumentIndexer/packages.lock.json
@@ -32,6 +32,55 @@
           "Microsoft.Extensions.Options": "10.0.11"
         }
       },
+      "Npgsql.OpenTelemetry": {
+        "type": "Direct",
+        "requested": "[10.0.3, )",
+        "resolved": "10.0.3",
+        "contentHash": "ShsdG/FHxJ2VuWM6tebJL/mCWkcxymmvtENN59c85EsJdT4TStWwwtgZoBu/9UvC0qi1jpFZ6bOfl9ijiWD+vA==",
+        "dependencies": {
+          "Npgsql": "10.0.3",
+          "OpenTelemetry.API": "1.15.3"
+        }
+      },
+      "OpenTelemetry.Exporter.OpenTelemetryProtocol": {
+        "type": "Direct",
+        "requested": "[1.18.0, )",
+        "resolved": "1.18.0",
+        "contentHash": "Et3WAviooKGObZjUZN8d6eTsdJs1YM3ZoN+KlWSAHksTmHG1nyGi9XGo2wb0fkFMWK0g80FOPdR1njg52Dm+aw==",
+        "dependencies": {
+          "OpenTelemetry": "1.18.0"
+        }
+      },
+      "OpenTelemetry.Extensions.Hosting": {
+        "type": "Direct",
+        "requested": "[1.18.0, )",
+        "resolved": "1.18.0",
+        "contentHash": "u+JMA82H65MKwMvd2qUpL8C2qE4Jux2nvX9hmy036UK/Apv2YyIRYCttF/vlX6nMPcAKI8BXkscmL4QG3C69fw==",
+        "dependencies": {
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
+          "OpenTelemetry": "1.18.0"
+        }
+      },
+      "OpenTelemetry.Instrumentation.Http": {
+        "type": "Direct",
+        "requested": "[1.18.0, )",
+        "resolved": "1.18.0",
+        "contentHash": "/X57peOOa4a+9V4DSVXbuIWdsAxmU5gsxw8lu+gJU0zuewsYhC9f6qdm8GEW0VvqG9e+gxn0HdVR5G3YHcWDTw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0",
+          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.18.0, 2.0.0)"
+        }
+      },
+      "OpenTelemetry.Instrumentation.Runtime": {
+        "type": "Direct",
+        "requested": "[1.18.0, )",
+        "resolved": "1.18.0",
+        "contentHash": "McuXGjBJDL/Cown2PxfUQysK98MZG7ZDjO/IKUtaAx8t1m0PB0d+QtJC79RFTVipMhRIwjJiULNOp0OGfZbvwg==",
+        "dependencies": {
+          "OpenTelemetry.Api": "[1.18.0, 2.0.0)"
+        }
+      },
       "Azure.Core": {
         "type": "Transitive",
         "resolved": "1.54.0",
@@ -375,6 +424,31 @@
         "contentHash": "rKyVV0sJPo7pn0Ya5dgRs5ggGbjvnKcYSvYV2jITKgFIfeo2XHjgyi6UqNT/OnF0YBqjsNpPdgM6QjzYczWplg==",
         "dependencies": {
           "System.ClientModel": "1.14.0"
+        }
+      },
+      "OpenTelemetry": {
+        "type": "Transitive",
+        "resolved": "1.18.0",
+        "contentHash": "13AKxycK+olOLe061MjliPTNBR/DUkjyRr0b9zwUhKyMjFS8lXS7G31R85rkbM55up2YFmdykWdAw2giBDJpiQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.0",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.0",
+          "OpenTelemetry.Api.ProviderBuilderExtensions": "1.18.0"
+        }
+      },
+      "OpenTelemetry.Api": {
+        "type": "Transitive",
+        "resolved": "1.18.0",
+        "contentHash": "Dhzm5oughIY9EWckt2J1yXcEbXpki5WCL2q7prJoYxzH6C7jdkfGtPMTkUVZZ4AhjJKzQnlC+kLSIlmIVwC4Vw=="
+      },
+      "OpenTelemetry.Api.ProviderBuilderExtensions": {
+        "type": "Transitive",
+        "resolved": "1.18.0",
+        "contentHash": "io6A6PJFp3vIObRGf6oPjdHsdglkinXt/0SpTDJHrVnsLxUtOzwh/QwTsnhBJ43wJ6QcGMkyNzsSSY8XEB1Q5Q==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "OpenTelemetry.Api": "1.18.0"
         }
       },
       "Pgvector": {


### PR DESCRIPTION
## Summary

- add correlated OpenTelemetry spans and metrics for knowledge indexing;
- activate and flush OTLP export from the short-lived document indexer;
- prove indexing, retrieval, Foundry model calls, read tools, and confirmed CQRS execution in local Aspire;
- add privacy and idempotency correlation tests;
- record the bounded Azure calls, temporary-index cleanup, current resource state, and exact teardown procedure.

## Live evidence

- indexing trace: `cb0b47f9f3871283e98b69e0d900712f` (57 spans, five fictional documents, 22 chunks);
- assistant trace: `61e6e509e764ceec1b42e43753247477` (Foundry embedding/chat, Azure hybrid retrieval, two scoped tools, eight citations);
- confirmation trace: `be497206ffbea6234130fdbb46fd224c` (write tool -> CQRS command -> PostgreSQL, outcome `replayed`);
- temporary Search index `contractiq-telemetry-v1` deleted and absence confirmed;
- API and indexer stopped after validation; the local Aspire dashboard remains available for review.

The first indexing diagnostic completed before the console-host lifecycle fix but did not export traces. The corrected run repeated the same bounded input. The evidence document records both runs: ten embedding requests / 44 short fictional chunk inputs in total, plus one query embedding and one chat request. Provider retries were zero.

## Verification

- `dotnet format ContractIQ.slnx --verify-no-changes --no-restore`
- `dotnet test ContractIQ.slnx -c Release -m:1 --disable-build-servers --no-restore`
- 170 .NET tests passed: 15 AI evaluation, 36 application, 40 domain, 79 integration
- live Aspire attribute inspection found no prompts, answers, document content, business identifiers, idempotency keys, or credentials in application-owned span tags

Progresses #53.
